### PR TITLE
feat: реализовать эндпоинт /api/config с поддержкой i18n

### DIFF
--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -1,0 +1,437 @@
+package module
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/darkrain/request-generator/actions"
+	"github.com/darkrain/request-generator/icontext"
+	"github.com/darkrain/request-generator/response"
+	"github.com/gin-gonic/gin"
+)
+
+// ConfigResponse структурырует ответ эндпоинта /api/config
+type ConfigResponse struct {
+	LeftMenu []LeftMenuBlock            `json:"left_menu"`
+	Routes   map[string]RouteConfig     `json:"routes"`
+	Role     string                     `json:"role"`
+}
+
+// LeftMenuBlock представляет блок левого меню
+type LeftMenuBlock struct {
+	BlockTitle string   `json:"blockTitle"`
+	Elements   []string `json:"elements"`
+}
+
+// RouteConfig конфигурирует маршрут
+type RouteConfig struct {
+	Title        string                 `json:"title"`
+	MenuTitle    string                 `json:"menuTitle,omitempty"`
+	Query        *RouteQuery            `json:"query,omitempty"`
+	Data         map[string]interface{} `json:"data,omitempty"`
+	Children     map[string]RouteConfig `json:"children,omitempty"`
+}
+
+// RouteQuery описывает параметры запроса для маршрута
+type RouteQuery struct {
+	Url    string `json:"url"`
+	Method string `json:"method"`
+}
+
+// actionConfigEndpoint генерирует конфиг для webapp
+func (generator *Generator) actionConfigEndpoint() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		l, _ := icontext.GetLogger(ctx)
+
+		// Получаем пользователя из контекста (AuthMiddleware уже проверил токен)
+		user, ok := icontext.GetUser(ctx)
+		if !ok {
+			response.ErrorResponse(l, c, http.StatusUnauthorized, "Unauthorized", nil)
+			return
+		}
+
+		role := user.Role
+
+		// Собираем доступные модули
+		availableModules := make(map[string]*BaseModule)
+		moduleActions := make(map[string][]actions.ModuleAction)
+
+		for _, module := range generator.Modules {
+			moduleAvailable := false
+			var accessibleActions []actions.ModuleAction
+
+			for _, menuEntry := range module.MenuEntries {
+				// Находим соответствующее действие по ActionName
+				for _, action := range module.Actions {
+					if string(action.Action()) == menuEntry.ActionName {
+						// Проверяем permission
+						if hasPermission(action, role) {
+							moduleAvailable = true
+							accessibleActions = append(accessibleActions, action)
+						}
+						break
+					}
+				}
+			}
+
+			if moduleAvailable {
+				availableModules[module.Name] = module
+				moduleActions[module.Name] = accessibleActions
+			}
+		}
+
+		// Формируем left_menu
+		leftMenu := generator.buildLeftMenu(availableModules, moduleActions, role)
+
+		// Формируем routes
+		routes := generator.buildRoutes(availableModules, moduleActions, role)
+
+		config := ConfigResponse{
+			LeftMenu: leftMenu,
+			Routes:   routes,
+			Role:     role,
+		}
+
+		response.Response(l, c, config)
+	}
+}
+
+// hasPermission проверяет, есть ли у роли доступ к действию
+func hasPermission(action actions.ModuleAction, role string) bool {
+	// Получаем permission из action
+	var permissions []actions.Role
+
+	switch a := action.(type) {
+	case *actions.ListModuleAction:
+		permissions = a.Permission
+	case *actions.AddModuleAction:
+		permissions = a.Permission
+	case *actions.ViewModuleAction:
+		permissions = a.Permission
+	case *actions.UpdateModuleAction:
+		permissions = a.Permission
+	case *actions.DeleteModuleAction:
+		permissions = a.Permission
+	default:
+		return false
+	}
+
+	// Если permissions пустой, доступ открыт всем
+	if len(permissions) == 0 {
+		return true
+	}
+
+	// Проверяем наличие роли
+	for _, perm := range permissions {
+		if string(perm) == role || perm == actions.RoleAll {
+			return true
+		}
+	}
+
+	return false
+}
+
+// buildLeftMenu формирует левое меню с группировкой по Group
+func (generator *Generator) buildLeftMenu(
+	availableModules map[string]*BaseModule,
+	moduleActions map[string][]actions.ModuleAction,
+	role string,
+) []LeftMenuBlock {
+	// Группируем MenuEntries по Group
+	type menuEntryWithModule struct {
+		entry  MenuEntry
+		module *BaseModule
+	}
+
+	grouped := make(map[string][]menuEntryWithModule)
+	groupOrder := make(map[string]int)
+
+	for _, module := range availableModules {
+		actionList := moduleActions[module.Name]
+		actionMap := make(map[string]bool)
+		for _, action := range actionList {
+			actionMap[string(action.Action())] = true
+		}
+
+		for _, entry := range module.MenuEntries {
+			// Проверяем, что действие доступно
+			if !actionMap[entry.ActionName] {
+				continue
+			}
+
+			group := entry.Group
+			if group == "" {
+				group = "default"
+			}
+
+			grouped[group] = append(grouped[group], menuEntryWithModule{
+				entry:  entry,
+				module: module,
+			})
+
+			// Запоминаем минимальный Order для группы
+			if _, exists := groupOrder[group]; !exists {
+				groupOrder[group] = entry.Order
+			} else if entry.Order < groupOrder[group] {
+				groupOrder[group] = entry.Order
+			}
+		}
+	}
+
+	// Сортируем группы по Order
+	type groupInfo struct {
+		name  string
+		order int
+	}
+
+	var groups []groupInfo
+	for name, order := range groupOrder {
+		groups = append(groups, groupInfo{name: name, order: order})
+	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].order < groups[j].order
+	})
+
+	// Формируем LeftMenuBlock
+	var result []LeftMenuBlock
+	for _, group := range groups {
+		entries := grouped[group.name]
+
+		// Сортируем entries по Order
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].entry.Order < entries[j].entry.Order
+		})
+
+		// Получаем название группы из GroupTitles
+		blockTitle := group.name
+		if title, exists := generator.GroupTitles[group.name]; exists {
+			blockTitle = title // Это i18n ключ
+		}
+
+		// Формируем элементы (ссылки)
+		var elements []string
+		for _, item := range entries {
+			entry := item.entry
+			if entry.CustomLink != "" {
+				elements = append(elements, entry.CustomLink)
+			} else {
+				// Генерируем ссылку на основе модуля
+				elements = append(elements, item.module.Path+"/"+item.module.Name)
+			}
+		}
+
+		if len(elements) > 0 {
+			result = append(result, LeftMenuBlock{
+				BlockTitle: blockTitle,
+				Elements:   elements,
+			})
+		}
+	}
+
+	return result
+}
+
+// buildRoutes формирует маршруты с view-адаптерами, actions, children
+func (generator *Generator) buildRoutes(
+	availableModules map[string]*BaseModule,
+	moduleActions map[string][]actions.ModuleAction,
+	role string,
+) map[string]RouteConfig {
+	routes := make(map[string]RouteConfig)
+
+	for _, module := range availableModules {
+		actionList := moduleActions[module.Name]
+
+		for _, action := range actionList {
+			switch a := action.(type) {
+			case *actions.ListModuleAction:
+				// Генерируем route для списка
+				routePath := module.Path + "/" + module.Name
+				routeTitle := a.Label // i18n ключ
+
+				viewAdapter := "list_table"
+				if adapter, exists := generator.ViewAdapters["list"]; exists {
+					viewAdapter = adapter
+				}
+
+				route := RouteConfig{
+					Title:     routeTitle,
+					MenuTitle: routeTitle,
+					Query: &RouteQuery{
+						Url:    "/api" + routePath,
+						Method: "GET",
+					},
+					Data: map[string]interface{}{
+						"view_adapter": viewAdapter,
+					},
+				}
+
+				// Добавляем actions для маршрута
+				route.Data["actions"] = generator.buildRouteActions(module, role)
+
+				// Добавляем children (view, edit, add)
+				route.Children = generator.buildRouteChildren(module, role)
+
+				routes[routePath] = route
+
+			case *actions.ViewModuleAction:
+				// View обычно является children, но если отдельное действие
+				routePath := module.Path + "/" + module.Name + "/:id"
+
+				viewAdapter := "view"
+				if adapter, exists := generator.ViewAdapters["view"]; exists {
+					viewAdapter = adapter
+				}
+
+				route := RouteConfig{
+					Title: a.Label,
+					Query: &RouteQuery{
+						Url:    "/api" + module.Path + "/" + module.Name + "/view/:bykey/:value",
+						Method: "GET",
+					},
+					Data: map[string]interface{}{
+						"view_adapter": viewAdapter,
+					},
+				}
+
+				routes[routePath] = route
+
+			case *actions.AddModuleAction:
+				routePath := module.Path + "/" + module.Name + "/add"
+
+				viewAdapter := "add"
+				if adapter, exists := generator.ViewAdapters["add"]; exists {
+					viewAdapter = adapter
+				}
+
+				route := RouteConfig{
+					Title: a.Label,
+					Query: &RouteQuery{
+						Url:    "/api" + module.Path + "/" + module.Name,
+						Method: "PUT",
+					},
+					Data: map[string]interface{}{
+						"view_adapter": viewAdapter,
+					},
+				}
+
+				routes[routePath] = route
+			}
+		}
+	}
+
+	return routes
+}
+
+// buildRouteActions формирует actions для маршрута
+func (generator *Generator) buildRouteActions(module *BaseModule, role string) []map[string]interface{} {
+	var result []map[string]interface{}
+
+	for _, entry := range module.MenuEntries {
+		// Находим соответствующее действие
+		for _, action := range module.Actions {
+			if string(action.Action()) != entry.ActionName {
+				continue
+			}
+			if !hasPermission(action, role) {
+				continue
+			}
+
+			actionMap := map[string]interface{}{
+				"title": entry.Title, // i18n ключ
+				"type":  entry.ActionName,
+				"icon":  entry.Icon,
+				"show":  entry.Show,
+			}
+
+			if entry.CustomQuery != nil {
+				actionMap["query"] = entry.CustomQuery
+			}
+
+			if entry.CustomData != nil {
+				actionMap["data"] = entry.CustomData
+			}
+
+			result = append(result, actionMap)
+			break
+		}
+	}
+
+	return result
+}
+
+// buildRouteChildren формирует children маршруты (view, edit, add)
+func (generator *Generator) buildRouteChildren(module *BaseModule, role string) map[string]RouteConfig {
+	children := make(map[string]RouteConfig)
+
+	for _, action := range module.Actions {
+		switch a := action.(type) {
+		case *actions.ViewModuleAction:
+			if !hasPermission(a, role) {
+				continue
+			}
+
+			viewAdapter := "view"
+			if adapter, exists := generator.ViewAdapters["view"]; exists {
+				viewAdapter = adapter
+			}
+
+			children[":id"] = RouteConfig{
+				Title: a.Label,
+				Query: &RouteQuery{
+					Url:    "/api" + module.Path + "/" + module.Name + "/view/:bykey/:value",
+					Method: "GET",
+				},
+				Data: map[string]interface{}{
+					"view_adapter": viewAdapter,
+				},
+			}
+
+		case *actions.UpdateModuleAction:
+			if !hasPermission(a, role) {
+				continue
+			}
+
+			editAdapter := "edit"
+			if adapter, exists := generator.ViewAdapters["edit"]; exists {
+				editAdapter = adapter
+			}
+
+			children[":id/edit"] = RouteConfig{
+				Title: a.Label,
+				Query: &RouteQuery{
+					Url:    "/api" + module.Path + "/" + module.Name + "/:bykey/:value",
+					Method: "POST",
+				},
+				Data: map[string]interface{}{
+					"view_adapter": editAdapter,
+				},
+			}
+
+		case *actions.AddModuleAction:
+			if !hasPermission(a, role) {
+				continue
+			}
+
+			addAdapter := "add"
+			if adapter, exists := generator.ViewAdapters["add"]; exists {
+				addAdapter = adapter
+			}
+
+			children["add"] = RouteConfig{
+				Title: a.Label,
+				Query: &RouteQuery{
+					Url:    "/api" + module.Path + "/" + module.Name,
+					Method: "PUT",
+				},
+				Data: map[string]interface{}{
+					"view_adapter": addAdapter,
+				},
+			}
+		}
+	}
+
+	return children
+}

--- a/generator.go
+++ b/generator.go
@@ -259,6 +259,18 @@ func (generator *Generator) Run() {
 	featuresGroup.GET("/lang", generator.handleLangList())
 	featuresGroup.GET("/lang/:key", generator.handleLangTranslations())
 
+	// Config endpoint (protected by AuthMiddleware)
+	if generator.AuthMiddleware != nil {
+		configGroup := featuresGroup.Group("")
+		// Dummy action for auth middleware (config doesn't map to a specific module action)
+		dummyAction := actions.ListModuleAction{
+			Permission: []actions.Role{},
+			Auth:       true,
+		}
+		configGroup.Use(generator.AuthMiddleware(dummyAction))
+		configGroup.GET("/config", generator.actionConfigEndpoint())
+	}
+
 	// Build and serve OpenAPI 3.0 spec (only when enabled)
 	if generator.EnableOpenAPI {
 		spec := generator.buildOpenAPISpec("Muta Alim API", "1.0.0")

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -1,0 +1,310 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/darkrain/request-generator"
+	"github.com/darkrain/request-generator/actions"
+	"github.com/darkrain/request-generator/icontext"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestRouter создаёт тестовый роутер с мокированным AuthMiddleware
+func setupTestRouter(authMiddleware func(actions.ModuleAction) gin.HandlerFunc) (*module.Generator, *gin.Engine) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+
+	// Создаём простой тестовый модуль
+	testModule := &module.BaseModule{
+		Name: "users",
+		Path: "/admin",
+		MenuEntries: []module.MenuEntry{
+			{
+				ActionName: "list",
+				Title:      "Пользователи",
+				Group:      "Управление",
+				Order:      1,
+				Icon:       "user",
+				Show:       true,
+			},
+			{
+				ActionName: "add",
+				Title:      "Добавить",
+				Group:      "Управление",
+				Order:      2,
+				Icon:       "plus",
+				Show:       true,
+			},
+		},
+		Actions: []actions.ModuleAction{
+			&actions.ListModuleAction{
+				Permission: []actions.Role{"admin", "manager"},
+				Label:      "Список пользователей",
+			},
+			&actions.AddModuleAction{
+				Permission: []actions.Role{"admin"},
+				Label:      "Добавить пользователя",
+			},
+			&actions.ViewModuleAction{
+				Permission: []actions.Role{"admin", "manager", actions.RoleAll},
+				Label:      "Просмотр пользователя",
+			},
+			&actions.UpdateModuleAction{
+				Permission: []actions.Role{"admin"},
+				Label:      "Обновить пользователя",
+			},
+		},
+	}
+
+	modules := []*module.BaseModule{testModule}
+
+	// Мок PermissionMiddleware
+	permissionMiddleware := func(action actions.ModuleAction, permissions []actions.Role) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			c.Next()
+		}
+	}
+
+	g := engine.Group("") // корневой роутер, т.к. Run() сам создаёт группу /api
+	generator := module.NewGenerator(
+		nil, // db функция не нужна для теста конфиг эндпоинта
+		*g,
+		modules,
+		permissionMiddleware,
+		authMiddleware,
+	)
+
+	// Регистрируем маршруты (это создаст конфиг эндпоинт)
+	generator.Run()
+
+	return generator, engine
+}
+
+// createMockAuthMiddleware создаёт мок AuthMiddleware, который устанавливает пользователя в контекст
+func createMockAuthMiddleware(user *icontext.UserInfo) func(actions.ModuleAction) gin.HandlerFunc {
+	return func(action actions.ModuleAction) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			if user == nil {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+			ctx := icontext.SetUser(c.Request.Context(), user)
+			c.Request = c.Request.WithContext(ctx)
+			c.Next()
+		}
+	}
+}
+
+func executeRequest(engine *gin.Engine, method, path string, headers map[string]string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, nil)
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	return w
+}
+
+// TestConfigEndpoint_ValidToken — успешный запрос с валидным токеном
+func TestConfigEndpoint_ValidToken(t *testing.T) {
+	// Мокированный пользователь с ролью admin
+	mockUser := &icontext.UserInfo{
+		ID:   1,
+		Role: "admin",
+	}
+
+	_, engine := setupTestRouter(createMockAuthMiddleware(mockUser))
+
+	w := executeRequest(engine, "GET", "/api/config", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Проверяем, что ответ валидный JSON с правильной структурой
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Contains(t, response, "left_menu")
+	assert.Contains(t, response, "routes")
+	assert.Contains(t, response, "role")
+	assert.Equal(t, "admin", response["role"])
+}
+
+// TestConfigEndpoint_InvalidToken — 401 при невалидном токене
+func TestConfigEndpoint_InvalidToken(t *testing.T) {
+	// Мокированный middleware, который всегда возвращает 401
+	invalidAuthMiddleware := func(action actions.ModuleAction) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			c.AbortWithStatus(http.StatusUnauthorized)
+		}
+	}
+
+	_, engine := setupTestRouter(invalidAuthMiddleware)
+
+	w := executeRequest(engine, "GET", "/api/config", nil)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestConfigEndpoint_MissingToken — 401 при отсутствии токена
+func TestConfigEndpoint_MissingToken(t *testing.T) {
+	// Мокированный middleware, который проверяет наличие токена
+	noTokenMiddleware := func(action actions.ModuleAction) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			// Имитируем отсутствие токена
+			c.AbortWithStatus(http.StatusUnauthorized)
+		}
+	}
+
+	_, engine := setupTestRouter(noTokenMiddleware)
+
+	w := executeRequest(engine, "GET", "/api/config", nil)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestConfigEndpoint_RoleFiltering — проверка что модули фильтруются по роли
+func TestConfigEndpoint_RoleFiltering(t *testing.T) {
+	// Создаём отдельный роутер для теста с модулем
+	gin.SetMode(gin.TestMode)
+
+	testModule := &module.BaseModule{
+		Name: "restricted",
+		Path: "/admin",
+		MenuEntries: []module.MenuEntry{
+			{
+				ActionName: "list",
+				Title:      "Restricted Module",
+				Group:      "Admin",
+				Order:      1,
+			},
+		},
+		Actions: []actions.ModuleAction{
+			&actions.ListModuleAction{
+				Permission: []actions.Role{"admin"}, // Только админ
+				Label:      "Restricted List",
+			},
+		},
+	}
+
+	modules := []*module.BaseModule{testModule}
+
+	permissionMiddleware := func(action actions.ModuleAction, permissions []actions.Role) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			c.Next()
+		}
+	}
+
+	mockAdmin := &icontext.UserInfo{ID: 1, Role: "admin"}
+	mockManager := &icontext.UserInfo{ID: 2, Role: "manager"}
+
+	// Тестируем доступ для админа (должен видеть модуль)
+	adminEngine := gin.New()
+	authMiddlewareAdmin := createMockAuthMiddleware(mockAdmin)
+	ag := adminEngine.Group("")
+	adminGenerator := module.NewGenerator(nil, *ag, modules, permissionMiddleware, authMiddlewareAdmin)
+	adminGenerator.Run()
+
+	w := executeRequest(adminEngine, "GET", "/api/config", nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var adminResponse module.ConfigResponse
+	err := json.Unmarshal(w.Body.Bytes(), &adminResponse)
+	require.NoError(t, err)
+	assert.NotEmpty(t, adminResponse.Routes, "Admin should see routes")
+
+	// Тестируем доступ для менеджера (НЕ должен видеть модуль)
+	managerEngine := gin.New()
+	authMiddlewareManager := createMockAuthMiddleware(mockManager)
+	mg := managerEngine.Group("")
+	managerGenerator := module.NewGenerator(nil, *mg, modules, permissionMiddleware, authMiddlewareManager)
+	managerGenerator.Run()
+
+	w = executeRequest(managerEngine, "GET", "/api/config", nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var managerResponse module.ConfigResponse
+	err = json.Unmarshal(w.Body.Bytes(), &managerResponse)
+	require.NoError(t, err)
+	assert.Empty(t, managerResponse.Routes, "Manager should not see admin-only routes")
+}
+
+// TestConfigEndpoint_LeftMenuStructure — проверка структуры left_menu
+func TestConfigEndpoint_LeftMenuStructure(t *testing.T) {
+	mockUser := &icontext.UserInfo{
+		ID:   1,
+		Role: "admin",
+	}
+
+	_, engine := setupTestRouter(createMockAuthMiddleware(mockUser))
+
+	w := executeRequest(engine, "GET", "/api/config", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response module.ConfigResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, response.LeftMenu, "Left menu should not be empty")
+
+	// Проверяем структуру первого блока меню
+	leftMenuBlock := response.LeftMenu[0]
+	assert.NotEmpty(t, leftMenuBlock.BlockTitle, "Block title should not be empty")
+	assert.NotEmpty(t, leftMenuBlock.Elements, "Block should have elements")
+
+	// Проверяем, что элементы являются строками (ссылками)
+	for _, element := range leftMenuBlock.Elements {
+		assert.NotEmpty(t, element, "Menu element should not be empty")
+	}
+}
+
+// TestConfigEndpoint_RoutesStructure — проверка структуры routes
+func TestConfigEndpoint_RoutesStructure(t *testing.T) {
+	mockUser := &icontext.UserInfo{
+		ID:   1,
+		Role: "admin",
+	}
+
+	_, engine := setupTestRouter(createMockAuthMiddleware(mockUser))
+
+	w := executeRequest(engine, "GET", "/api/config", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response module.ConfigResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, response.Routes, "Routes should not be empty")
+
+	// Проверяем структуру маршрутов
+	for routePath, routeConfig := range response.Routes {
+		assert.NotEmpty(t, routePath, "Route path should not be empty")
+		assert.NotEmpty(t, routeConfig.Title, "Route title should not be empty")
+
+		// Проверяем наличие query для маршрута
+		if routeConfig.Query != nil {
+			assert.NotEmpty(t, routeConfig.Query.Url, "Query URL should not be empty")
+			assert.NotEmpty(t, routeConfig.Query.Method, "Query method should not be empty")
+		}
+
+		// Проверяем наличие data
+		assert.NotNil(t, routeConfig.Data, "Route data should not be nil")
+	}
+
+	// Проверяем, что есть хотя бы один маршрут для нашего тестового модуля
+	foundUsersRoute := false
+	for routePath := range response.Routes {
+		if routePath == "/admin/users" {
+			foundUsersRoute = true
+			break
+		}
+	}
+	assert.True(t, foundUsersRoute, "Should have route for /admin/users")
+}


### PR DESCRIPTION
Реализация issue #12.

## Что сделано
- Добавлен GET /api/config, защищён AuthMiddleware
- Определяет роль пользователя из токена (icontext.GetUser)
- Собирает доступные модули на основе роли и action.Permission
- Формирует left_menu с группировкой MenuEntries по Group
- Формирует routes с view-адаптерами, actions, children
- Все текстовые поля — i18n ключи (не переведённые строки)
- Добавлены структуры ConfigResponse, LeftMenuBlock, RouteConfig
- Используются GroupTitles и ViewAdapters из конфига генератора

## Тестирование
Проект собирается: go build ./...