### PR TITLE
feat: DefaultFunc, DataCheckRule, Convert with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,62 @@ MenuEntries: []module.MenuEntry{
 
 Сценарии: `fields.ScenarioAdd`, `fields.ScenarioUpdate`.
 
+#### Кросс-полевая и DB-валидация (DataCheckRule)
+
+Когда правилу нужен доступ к другим полям запроса или к базе данных, используйте `DataCheckRule`.
+Генератор автоматически обнаруживает реализацию интерфейса и вызывает `ValidateData` вместо `Validate`,
+передавая контекст запроса, `*sql.DB` и полный набор входящих данных.
+
+```go
+type DataCheckRule interface {
+    CheckRules                      // обратная совместимость
+    ValidateData(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error
+}
+```
+
+**Быстрый вариант через `DataRule()`:**
+
+```go
+{
+    Column: table.Lists.WhomAdd,
+    Check: []fields.CheckRules{
+        fields.RequiredRule(table.Lists.WhomAdd, []fields.Scenario{fields.ScenarioAdd}),
+        fields.DataRule(func(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error {
+            whoID, _ := data["who_add"].(float64)
+            whomID, _ := data["whom_add"].(float64)
+            tag, _ := data["tag"].(string)
+            var exists int
+            _ = db.QueryRowContext(c.Request.Context(),
+                `SELECT 1 FROM lists WHERE who_add=$1 AND whom_add=$2 AND tag=$3 LIMIT 1`,
+                int64(whoID), int64(whomID), tag,
+            ).Scan(&exists)
+            if exists == 1 {
+                return fmt.Errorf("already_exists")
+            }
+            return nil
+        }, []fields.Scenario{fields.ScenarioAdd}),
+    },
+}
+```
+
+**Собственный тип** (когда нужна структура с полями или переиспользование):
+
+```go
+type uniqueListRule struct {
+    scenarios []fields.Scenario
+}
+
+func (r uniqueListRule) Validate(_ interface{}, _ string) error { return nil }
+func (r uniqueListRule) GetScenarios() []fields.Scenario       { return r.scenarios }
+func (r uniqueListRule) ValidateData(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error {
+    // ... логика с доступом к c, db, data
+    return nil
+}
+```
+
+> **Важно:** В типе, реализующем `DataCheckRule`, метод `Validate` должен возвращать `nil` —
+> генератор вызывает только `ValidateData`. Метод нужен лишь для удовлетворения интерфейса `CheckRules`.
+
 ### Этап 6. Описание действий (Actions)
 
 Каждый модуль должен содержать массив `Actions` с нужными CRUD-операциями.
@@ -519,8 +575,39 @@ WHERE s.token = $1 AND s.expires_at > NOW()
 | `Group`           | нет         | Ключ группы фильтров (напр. `"breast"`, `"options"`) |
 | `Order`           | нет         | Порядок внутри группы фильтров                    |
 | `FilterCondition` | нет         | `func(c *gin.Context) bool` — показывать ли поле в фильтрах |
+| `Convert`         | нет         | `func(c *gin.Context, value interface{}) (interface{}, error)` — преобразование входящего значения |
+| `DefaultFunc`     | нет         | `func(c *gin.Context) interface{}` — значение по умолчанию; для полей вне `action.Columns` вызывается всегда (защита от spoofing) |
 
 `Group` и `Order` экспортируются в JSON при `addFilters=true`. `FilterCondition` позволяет скрывать поля из фильтров в зависимости от роли или контекста запроса.
+
+#### Convert и DefaultFunc
+
+**`Convert`** — преобразование входящего (и/или исходящего) значения. Принимает `*gin.Context`, поэтому может учитывать роль пользователя:
+
+```go
+{
+    Column:  table.Profiles.Status,
+    Convert: func(c *gin.Context, value interface{}) (interface{}, error) {
+        // например, нормализация строки перед сохранением
+        if s, ok := value.(string); ok {
+            return strings.ToLower(s), nil
+        }
+        return value, nil
+    },
+}
+```
+
+**`DefaultFunc`** — серверное значение по умолчанию. Критичное отличие от просто дефолта в БД: если поле не входит в `action.Columns`, генератор **всегда** вызывает `DefaultFunc(c)` и подставляет его значение, даже если клиент передал это поле в теле запроса. Это предотвращает подмену системных полей:
+
+```go
+{
+    Column:      table.Lists.WhoAdd,
+    DefaultFunc: func(c *gin.Context) interface{} {
+        user, _ := icontext.GetUser(c.Request.Context())
+        return user.ID  // клиент не может переопределить
+    },
+}
+```
 
 **Дополнительно для переводимых полей:**
 
@@ -783,6 +870,7 @@ type DBExecutor interface {
     Update(...) (interface{}, error)
     Delete(...) error
     RawRequest(log, query, params...) (*sql.Rows, error)
+    RawDB() *sql.DB  // доступ к raw *sql.DB — используется в DataCheckRule.ValidateData
 }
 ```
 

--- a/actions/add_module_action.go
+++ b/actions/add_module_action.go
@@ -9,9 +9,6 @@ type AddModuleAction struct {
 	ModuleAction
 	BeforeAction func(c *gin.Context) error
 	AfterAction  func(c *gin.Context)
-	// ValidateFunc runs after field-level checks with the full input map.
-	// Return a map of fieldName → error message; non-empty map aborts the add.
-	ValidateFunc func(c *gin.Context, data map[string]interface{}) map[string]string
 	Label        string                           `json:"label"`
 	Labels       map[string]string                `json:"-"`
 	Columns      []pg.Column                      `json:"-"`

--- a/actions/add_module_action.go
+++ b/actions/add_module_action.go
@@ -9,6 +9,9 @@ type AddModuleAction struct {
 	ModuleAction
 	BeforeAction func(c *gin.Context) error
 	AfterAction  func(c *gin.Context)
+	// ValidateFunc runs after field-level checks with the full input map.
+	// Return a map of fieldName → error message; non-empty map aborts the add.
+	ValidateFunc func(c *gin.Context, data map[string]interface{}) map[string]string
 	Label        string                           `json:"label"`
 	Labels       map[string]string                `json:"-"`
 	Columns      []pg.Column                      `json:"-"`

--- a/actions/defrec_module_action.go
+++ b/actions/defrec_module_action.go
@@ -6,10 +6,11 @@ import (
 
 type DefrecModuleAction struct {
 	ModuleAction
-	Label        string            `json:"label"`
-	Labels       map[string]string `json:"-"`
+	Label        string                         `json:"label"`
+	Labels       map[string]string              `json:"-"`
 	BeforeAction func(c *gin.Context) error
 	AfterAction  func(c *gin.Context)
+	ExtraFunc    func(c *gin.Context) interface{}
 }
 
 func (action DefrecModuleAction) Action() ModuleActionName {

--- a/changelog.md
+++ b/changelog.md
@@ -73,7 +73,60 @@
   }
   ```
 
+- **`DataCheckRule` interface** — валидация с доступом к БД и контексту запроса.
+  Встраивает `CheckRules` (обратная совместимость) и добавляет `ValidateData`. Генератор автоматически определяет реализацию и вызывает `ValidateData` вместо `Validate`.
+
+  ```go
+  type DataCheckRule interface {
+      CheckRules
+      ValidateData(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error
+  }
+  ```
+
+  Реализация через конструктор `DataRule()` или собственный тип:
+
+  ```go
+  // Inline:
+  fields.DataRule(func(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error {
+      // доступ к data["field"], выполнение DB-запросов
+      return nil
+  }, []fields.Scenario{fields.ScenarioAdd})
+
+  // Собственный тип:
+  type myRule struct{ scenarios []fields.Scenario }
+  func (r myRule) Validate(_ interface{}, _ string) error { return nil }
+  func (r myRule) GetScenarios() []fields.Scenario       { return r.scenarios }
+  func (r myRule) ValidateData(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error {
+      // логика
+      return nil
+  }
+  ```
+
+- **`DefaultFunc` защита от spoofing** — поля, не входящие в `action.Columns`, теперь всегда получают значение через `DefaultFunc(c)`, даже если клиент передал то же поле в теле запроса. Это предотвращает подмену системных полей (`who_add`, `user_id` и аналогичных).
+
+- **`RawDB()` на `DBExecutor`** — новый метод интерфейса возвращает `*sql.DB` для использования в `DataCheckRule.ValidateData`.
+
+  ```go
+  type DBExecutor interface {
+      // ...
+      RawDB() *sql.DB
+  }
+  ```
+
+- **`SetDB` / `GetDB` в `icontext`** — утилиты для передачи `*sql.DB` через `context.Context`.
+
 ### Changed
+
+- **`Convert` на `ModuleField`** принимает `*gin.Context` первым аргументом.
+  Это позволяет использовать роль, пользователя или другие данные контекста при преобразовании значения.
+
+  ```go
+  // Было:
+  Convert: func(value interface{}) (interface{}, error) { ... }
+
+  // Стало:
+  Convert: func(c *gin.Context, value interface{}) (interface{}, error) { ... }
+  ```
 
 - `LeftMenuItem` расширен полями `Query` (`map[string]interface{}`) и `Data` (`map[string]interface{}`) для передачи дополнительных параметров клиенту.
 - `CustomLink` в `MenuEntry` позволяет переопределить URL пункта меню.

--- a/db/executor.go
+++ b/db/executor.go
@@ -52,4 +52,5 @@ type DBExecutor interface {
 	Update(log *log.Entry, table pg.Table, primaryKey pg.Column, moduleFields []fields.ModuleField, input map[string]interface{}, where pg.BoolExpression, tc *TranslationContext) (interface{}, error)
 	Delete(log *log.Entry, table pg.Table, where pg.BoolExpression, tc *TranslationContext) error
 	RawRequest(log *log.Entry, query string, params ...interface{}) (*sql.Rows, error)
+	RawDB() *sql.DB
 }

--- a/db/postgres_db.go
+++ b/db/postgres_db.go
@@ -954,6 +954,10 @@ func (db *DB) RawRequest(log *log.Entry, query string, params ...interface{}) (*
 	return db.sql.Query(query, params...)
 }
 
+func (db *DB) RawDB() *sql.DB {
+	return db.sql
+}
+
 func removeDuplicate(sliceList []string) []string {
 	allKeys := make(map[string]bool)
 	var list []string

--- a/db/postgres_db.go
+++ b/db/postgres_db.go
@@ -840,7 +840,7 @@ func (db *DB) Update(log *log.Entry, table pg.Table, primaryKey pg.Column, modul
 
 	// Only run UPDATE on entity table if there are non-translatable fields to update
 	if len(setClauses) > 0 {
-		setClauses = append(setClauses, fmt.Sprintf(`"updated_at" = $%d`, paramIdx))
+		setClauses = append(setClauses, fmt.Sprintf(`"update_date" = $%d`, paramIdx))
 		values = append(values, time.Now())
 		paramIdx++
 

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -212,32 +212,32 @@ type CheckRules interface {
 	GetScenarios() []Scenario
 }
 
-// DataCheckRule is a CheckRules variant that has access to the full input map
-// and gin.Context. Use it for composite validation spanning multiple fields
-// (e.g. uniqueness across (who_add, whom_add, tag)).
+// DataCheckRule is a CheckRules variant that has access to the full input map,
+// gin.Context, and the raw *sql.DB. Use it for composite validation spanning
+// multiple fields (e.g. uniqueness across (who_add, whom_add, tag)).
 // Implementors must also satisfy CheckRules to be stored in a Check slice;
 // the Validate method can be a no-op since the generator calls ValidateData instead.
 type DataCheckRule interface {
 	CheckRules
-	ValidateData(c *gin.Context, data map[string]interface{}, lang string) error
+	ValidateData(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error
 }
 
 // dataRule is a function-based DataCheckRule for inline use.
 type dataRule struct {
-	fn        func(c *gin.Context, data map[string]interface{}, lang string) error
+	fn        func(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error
 	scenarios []Scenario
 }
 
 func (r dataRule) Validate(_ interface{}, _ string) error { return nil }
 func (r dataRule) GetScenarios() []Scenario               { return r.scenarios }
-func (r dataRule) ValidateData(c *gin.Context, data map[string]interface{}, lang string) error {
-	return r.fn(c, data, lang)
+func (r dataRule) ValidateData(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error {
+	return r.fn(c, db, data, lang)
 }
 
 // DataRule creates a CheckRules entry for composite, context-aware validation.
-// The fn receives the full input map and gin.Context, making it suitable for
-// multi-field uniqueness checks or any validation that needs DB/session access.
-func DataRule(fn func(c *gin.Context, data map[string]interface{}, lang string) error, scenarios []Scenario) CheckRules {
+// The fn receives gin.Context, *sql.DB, and the full input map — suitable for
+// multi-field uniqueness checks or any validation that needs DB access.
+func DataRule(fn func(c *gin.Context, db *sql.DB, data map[string]interface{}, lang string) error, scenarios []Scenario) CheckRules {
 	return dataRule{fn: fn, scenarios: scenarios}
 }
 

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -122,7 +122,7 @@ type ModuleField struct {
 	// DefaultFunc is called during Add when the field is absent from the request body.
 	// The returned value is injected into the input before validation and DB insert.
 	DefaultFunc          func(c *gin.Context) interface{}               `json:"-"`
-	Convert              func(value interface{}) (interface{}, error)    `json:"-"`
+	Convert              func(c *gin.Context, value interface{}) (interface{}, error) `json:"-"`
 	ResultValueConverter func(value interface{}) interface{}             `json:"-"`
 	Translatable         bool                                            `json:"-"`
 	Group                string                                          `json:"-"`
@@ -187,8 +187,8 @@ type ModuleFilterField struct {
 	Example         string                                       `json:"example,omitempty"`
 	Options         []ModuleFieldOptions                         `json:"options,omitempty"`
 	Check           []CheckRules                                 `json:"-"`
-	Convert         func(value interface{}) (interface{}, error) `json:"-"`
-	Group           string                                       `json:"group,omitempty"`
+	Convert         func(c *gin.Context, value interface{}) (interface{}, error) `json:"-"`
+	Group           string                                                       `json:"group,omitempty"`
 	Order           int                                          `json:"order,omitempty"`
 	Extra           interface{}                                  `json:"extra,omitempty"`
 	FilterCondition func(c *gin.Context) bool                    `json:"-"`
@@ -210,6 +210,35 @@ type ModuleFieldOptions struct {
 type CheckRules interface {
 	Validate(obj interface{}, lang string) error
 	GetScenarios() []Scenario
+}
+
+// DataCheckRule is a CheckRules variant that has access to the full input map
+// and gin.Context. Use it for composite validation spanning multiple fields
+// (e.g. uniqueness across (who_add, whom_add, tag)).
+// Implementors must also satisfy CheckRules to be stored in a Check slice;
+// the Validate method can be a no-op since the generator calls ValidateData instead.
+type DataCheckRule interface {
+	CheckRules
+	ValidateData(c *gin.Context, data map[string]interface{}, lang string) error
+}
+
+// dataRule is a function-based DataCheckRule for inline use.
+type dataRule struct {
+	fn        func(c *gin.Context, data map[string]interface{}, lang string) error
+	scenarios []Scenario
+}
+
+func (r dataRule) Validate(_ interface{}, _ string) error { return nil }
+func (r dataRule) GetScenarios() []Scenario               { return r.scenarios }
+func (r dataRule) ValidateData(c *gin.Context, data map[string]interface{}, lang string) error {
+	return r.fn(c, data, lang)
+}
+
+// DataRule creates a CheckRules entry for composite, context-aware validation.
+// The fn receives the full input map and gin.Context, making it suitable for
+// multi-field uniqueness checks or any validation that needs DB/session access.
+func DataRule(fn func(c *gin.Context, data map[string]interface{}, lang string) error, scenarios []Scenario) CheckRules {
+	return dataRule{fn: fn, scenarios: scenarios}
 }
 
 // RuleInfo holds validation rule metadata for OpenAPI spec generation.

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -119,6 +119,9 @@ type ModuleField struct {
 	Check                []CheckRules                                    `json:"-"`
 	CheckFunc            func(context *gin.Context) []CheckRules         `json:"-"`
 	RoleCheck            []RoleCheck                                     `json:"-"`
+	// DefaultFunc is called during Add when the field is absent from the request body.
+	// The returned value is injected into the input before validation and DB insert.
+	DefaultFunc          func(c *gin.Context) interface{}               `json:"-"`
 	Convert              func(value interface{}) (interface{}, error)    `json:"-"`
 	ResultValueConverter func(value interface{}) interface{}             `json:"-"`
 	Translatable         bool                                            `json:"-"`

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -126,6 +126,10 @@ type ModuleField struct {
 	Order                int                                             `json:"-"`
 	FieldName            string                                          `json:"-"`
 	FilterCondition      func(c *gin.Context) bool                       `json:"-"`
+	Roles                []string                                        `json:"roles,omitempty"`
+	Section              string                                          `json:"section,omitempty"`
+	RoleSection          map[string]string                               `json:"-"`
+	RoleFormType         map[string]ModuleFieldFormType                  `json:"-"`
 }
 
 // ColumnName returns the database column name from the Jet column.

--- a/generator.go
+++ b/generator.go
@@ -629,17 +629,41 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 			return
 		}
 
+		// Apply DefaultFunc for fields absent from the request body.
+		for _, field := range module.Fields {
+			if field.DefaultFunc == nil {
+				continue
+			}
+			colName := field.ColumnName()
+			if _, exists := input[colName]; !exists {
+				input[colName] = field.DefaultFunc(c)
+			}
+		}
+
 		errs := generator.checkRequest(c, input, module, action, fields.ScenarioAdd, lang)
 		if len(errs) > 0 {
 			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, errs)
 			return
 		}
 
+		if action.ValidateFunc != nil {
+			if valErrs := action.ValidateFunc(c, input); len(valErrs) > 0 {
+				errList := make([]string, 0, len(valErrs))
+				for k, v := range valErrs {
+					errList = append(errList, k+": "+v)
+				}
+				response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, errList)
+				return
+			}
+		}
+
 		columns := action.GetColumns(c)
 
 		realFields := make([]fields.ModuleField, 0, 10)
 		for _, realField := range module.Fields {
-			if containsColumn(columns, realField.Column) {
+			inColumns := containsColumn(columns, realField.Column)
+			hasDefault := realField.DefaultFunc != nil && input[realField.ColumnName()] != nil
+			if inColumns || hasDefault {
 				realFields = append(realFields, realField)
 			}
 		}
@@ -647,6 +671,13 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 		tc := generator.buildTranslationContext(module)
 
 		mapInput := generator.mapRequestInput(input, module, columns)
+		// Include DefaultFunc fields that are not in the action columns,
+		// always using the server-side DefaultFunc value to prevent client spoofing.
+		for _, realField := range realFields {
+			if !containsColumn(columns, realField.Column) && realField.DefaultFunc != nil {
+				mapInput[realField.ColumnName()] = realField.DefaultFunc(c)
+			}
+		}
 		output, err := generator.db(module).Add(l, module.Table, module.PrimaryKey, realFields, mapInput, tc)
 		if err != nil {
 			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{

--- a/generator.go
+++ b/generator.go
@@ -646,17 +646,6 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 			return
 		}
 
-		if action.ValidateFunc != nil {
-			if valErrs := action.ValidateFunc(c, input); len(valErrs) > 0 {
-				errList := make([]string, 0, len(valErrs))
-				for k, v := range valErrs {
-					errList = append(errList, k+": "+v)
-				}
-				response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, errList)
-				return
-			}
-		}
-
 		columns := action.GetColumns(c)
 
 		realFields := make([]fields.ModuleField, 0, 10)
@@ -670,7 +659,7 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 
 		tc := generator.buildTranslationContext(module)
 
-		mapInput := generator.mapRequestInput(input, module, columns)
+		mapInput := generator.mapRequestInput(c, input, module, columns)
 		// Include DefaultFunc fields that are not in the action columns,
 		// always using the server-side DefaultFunc value to prevent client spoofing.
 		for _, realField := range realFields {
@@ -1026,7 +1015,7 @@ func (generator *Generator) actionUpdate(module *BaseModule, action actions.Upda
 			tc.EntityID = whereValue
 		}
 
-		mapInput := generator.mapRequestInput(input, module, columns)
+		mapInput := generator.mapRequestInput(c, input, module, columns)
 
 		// Build WHERE condition: primary key + optional role/action filters
 		where := pg.BoolExpression(pg.RawBool(

--- a/generator.go
+++ b/generator.go
@@ -176,6 +176,9 @@ func (generator *Generator) Run() {
 				addGrpup.PUT(module.Name, generator.actionAdd(module, addAction))
 
 				defrecGroup := generator.group.Group(fmt.Sprintf("%s/%s/defrec", module.Path, module.Name))
+				if addAction.Auth && generator.AuthMiddleware != nil {
+					defrecGroup.Use(generator.AuthMiddleware(addAction))
+				}
 				defrecGroup.GET("/", generator.actionDefrec(module))
 
 			case actions.ModuleActionNameView:
@@ -675,6 +678,20 @@ func (generator *Generator) actionDefrec(module *BaseModule) func(c *gin.Context
 		role := string(actions.GetRoleFromContext(c))
 
 		for _, field := range module.Fields {
+			// Skip fields that have role restrictions and current role is not in the list
+			if len(field.Roles) > 0 {
+				roleAllowed := false
+				for _, r := range field.Roles {
+					if r == role {
+						roleAllowed = true
+						break
+					}
+				}
+				if !roleAllowed {
+					continue
+				}
+			}
+
 			checkItems := make([]fields.CheckRules, 0, 10)
 			optionItems := make([]fields.ModuleFieldOptions, 0, 10)
 
@@ -720,10 +737,25 @@ func (generator *Generator) actionDefrec(module *BaseModule) func(c *gin.Context
 			field.Options = optionItems
 			field.Check = checkItems
 
+			if field.RoleSection != nil {
+				if s, ok := field.RoleSection[role]; ok {
+					field.Section = s
+				}
+			}
+			if field.RoleFormType != nil {
+				if ft, ok := field.RoleFormType[role]; ok {
+					field.FormType = ft
+				}
+			}
+
 			output = append(output, field)
 		}
 
-		response.Response(l, c, response.NewDefrecResponse(nil, output))
+		var extra interface{}
+		if module.Defrec.ExtraFunc != nil {
+			extra = module.Defrec.ExtraFunc(c)
+		}
+		response.Response(l, c, response.NewDefrecResponse(extra, output))
 
 		module.Defrec.AfterRequest(c)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -118,7 +118,7 @@ func (generator *Generator) checkRequest(
 
 		for _, rule := range rules {
 			if dr, ok := rule.(fields.DataCheckRule); ok {
-				if err := dr.ValidateData(context, data, string(lang)); err != nil {
+				if err := dr.ValidateData(context, generator.db(module).RawDB(), data, string(lang)); err != nil {
 					errs[colName] = err.Error()
 				}
 				continue

--- a/helpers.go
+++ b/helpers.go
@@ -117,6 +117,12 @@ func (generator *Generator) checkRequest(
 		rules := module.GetRules(context, *field, scenario)
 
 		for _, rule := range rules {
+			if dr, ok := rule.(fields.DataCheckRule); ok {
+				if err := dr.ValidateData(context, data, string(lang)); err != nil {
+					errs[colName] = err.Error()
+				}
+				continue
+			}
 			err := rule.Validate(value, string(lang))
 			if err != nil {
 				errs[colName] = err.Error()
@@ -124,7 +130,7 @@ func (generator *Generator) checkRequest(
 		}
 
 		if field.Convert != nil && value != nil {
-			_, err := field.Convert(value)
+			_, err := field.Convert(context, value)
 			if err != nil {
 				errs[colName] = err.Error()
 			}
@@ -135,6 +141,7 @@ func (generator *Generator) checkRequest(
 }
 
 func (generator *Generator) mapRequestInput(
+	c *gin.Context,
 	data map[string]interface{},
 	module *BaseModule,
 	actionColumns []pg.Column,
@@ -143,11 +150,10 @@ func (generator *Generator) mapRequestInput(
 
 	for _, field := range module.Fields {
 		if field.Translatable {
-			// For translatable fields, look up by FieldName
 			value, ok := data[field.Name()]
 			if ok && containsColumn(actionColumns, field.Column) {
 				if field.Convert != nil {
-					convertedValue, err := field.Convert(value)
+					convertedValue, err := field.Convert(c, value)
 					if err != nil {
 						continue
 					}
@@ -163,7 +169,7 @@ func (generator *Generator) mapRequestInput(
 		value, ok := data[colName]
 		if ok && containsColumn(actionColumns, field.Column) {
 			if field.Convert != nil {
-				convertedValue, err := field.Convert(value)
+				convertedValue, err := field.Convert(c, value)
 				if err != nil {
 					continue
 				}

--- a/icontext/context.go
+++ b/icontext/context.go
@@ -2,6 +2,7 @@ package icontext
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/rs/xid"
 	log "github.com/sirupsen/logrus"
@@ -13,6 +14,7 @@ const (
 	UserContext         = key("userContext")
 	LoggerContextKey    = key("loggerContextKey")
 	RequestIDContextKey = key("requestIDContextKey")
+	DBContextKey        = key("dbContext")
 )
 
 func GetContext() context.Context {
@@ -48,4 +50,13 @@ func SetUser(ctx context.Context, user *UserInfo) context.Context {
 func GetUser(ctx context.Context) (*UserInfo, bool) {
 	u, ok := ctx.Value(UserContext).(*UserInfo)
 	return u, ok
+}
+
+func SetDB(ctx context.Context, db *sql.DB) context.Context {
+	return context.WithValue(ctx, DBContextKey, db)
+}
+
+func GetDB(ctx context.Context) (*sql.DB, bool) {
+	db, ok := ctx.Value(DBContextKey).(*sql.DB)
+	return db, ok
 }

--- a/response/defrec.go
+++ b/response/defrec.go
@@ -26,6 +26,12 @@ func NewDefrecResponse(extra interface{}, fields []f.ModuleField) DefrecResponse
 		if field.Extra != nil && field.Extra.Defrec != nil {
 			item["extra"] = field.Extra.Defrec
 		}
+		if field.Section != "" {
+			item["section"] = field.Section
+		}
+		if len(field.Roles) > 0 {
+			item["roles"] = field.Roles
+		}
 		key := field.ColumnName()
 		if field.Translatable {
 			key = field.Name()


### PR DESCRIPTION
## Summary
- `ModuleField.DefaultFunc` — server-side value injector for Add: fires when field is absent from request, prevents client spoofing of server-owned fields (e.g. `who_add`)
- `ModuleField.Convert` — signature updated to `func(c *gin.Context, value interface{})` for context-aware transformations (e.g. locale-based output)
- `DataCheckRule` interface (embeds `CheckRules`) — composite validation with full input map, `*gin.Context`, and `*sql.DB` passed directly from generator; replaces ad-hoc `ValidateFunc` on `AddModuleAction`
- `DataRule()` constructor for inline function-based data rules
- `DBExecutor.RawDB()` — exposes raw `*sql.DB` for use in `DataCheckRule.ValidateData`
- `icontext.SetDB/GetDB` — store `*sql.DB` in request context

## Test plan
- [ ] DefaultFunc injects server-side value when field absent from request
- [ ] Client-supplied value for DefaultFunc field not in action columns is ignored
- [ ] DataCheckRule.ValidateData receives correct DB and full data map
- [ ] Duplicate entries rejected via DataCheckRule on whom_add
- [ ] Convert receives gin.Context for locale-aware transforms