### PR TITLE
feat: add ExtraFunc support to ViewModuleAction

### DIFF
--- a/actions/view_module_action.go
+++ b/actions/view_module_action.go
@@ -13,12 +13,13 @@ type ViewModuleAction struct {
 	Labels       map[string]string                `json:"-"`
 	Columns      []pg.Column                      `json:"-"`
 	ColumnsFunc  func(c *gin.Context) []pg.Column `json:"-"`
-	Permission   []Role             `json:"permission"`
-	Auth         bool               `json:"auth"`
-	Join         []ModuleActionJoin `json:"join"`
-	By           []pg.Column        `json:"-"`
-	Extra        interface{}        `json:"extra"`
-	Fields       []RoleContext      `json:"-"`
+	Permission   []Role                           `json:"permission"`
+	Auth         bool                             `json:"auth"`
+	Join         []ModuleActionJoin               `json:"join"`
+	By           []pg.Column                      `json:"-"`
+	Extra        interface{}                      `json:"extra"`
+	ExtraFunc    func(c *gin.Context) interface{} `json:"-"`
+	Fields       []RoleContext                    `json:"-"`
 }
 
 func (action ViewModuleAction) Action() ModuleActionName {

--- a/generator.go
+++ b/generator.go
@@ -930,11 +930,18 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 			item[fieldKey] = fieldItem
 		}
 
+		var extra interface{}
+		if action.ExtraFunc != nil {
+			extra = action.ExtraFunc(c)
+		} else {
+			extra = action.Extra
+		}
+
 		output := struct {
 			Extra interface{}            `json:"extra"`
 			Item  map[string]interface{} `json:"item"`
 		}{
-			Extra: action.Extra,
+			Extra: extra,
 			Item:  item,
 		}
 


### PR DESCRIPTION
## Summary

- Add `ExtraFunc func(c *gin.Context) interface{}` field to `ViewModuleAction`, mirroring the existing behavior in `ListModuleAction`
- Update `generator.go` `actionView` to call `ExtraFunc(c)` when set, falling back to static `Extra` field

## Motivation

Required by `notification_preferences` module to return role-specific notification type catalog in the view response `extra.catalog`.

## Test plan
- [ ] Existing behavior unchanged when `ExtraFunc` is nil (falls back to `Extra`)
- [ ] `ExtraFunc` is called with gin context and result appears in `extra` response field
- [ ] `GET /api/notification_preferences/view/user_id/:id` returns `extra.catalog` with role-specific groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)