### PR TITLE
feat(realtime): add websocket event broker

### DIFF
--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -111,13 +111,23 @@ func hasPermission(action actions.ModuleAction, role string) bool {
 	switch a := action.(type) {
 	case actions.ListModuleAction:
 		permissions = a.Permission
+	case *actions.ListModuleAction:
+		permissions = a.Permission
 	case actions.AddModuleAction:
+		permissions = a.Permission
+	case *actions.AddModuleAction:
 		permissions = a.Permission
 	case actions.ViewModuleAction:
 		permissions = a.Permission
+	case *actions.ViewModuleAction:
+		permissions = a.Permission
 	case actions.UpdateModuleAction:
 		permissions = a.Permission
+	case *actions.UpdateModuleAction:
+		permissions = a.Permission
 	case actions.DeleteModuleAction:
+		permissions = a.Permission
+	case *actions.DeleteModuleAction:
 		permissions = a.Permission
 	default:
 		return false
@@ -270,72 +280,84 @@ func (generator *Generator) buildRoutes(
 		for _, action := range actionList {
 			switch a := action.(type) {
 			case actions.ListModuleAction:
-				routePath := module.Path + "/" + module.Name
-
-				viewAdapter := "list_table"
-				if adapter, exists := generator.ViewAdapters["list"]; exists {
-					viewAdapter = adapter
-				}
-
-				route := RouteConfig{
-					Title:     a.Label,
-					MenuTitle: a.Label,
-					Query: &RouteQuery{
-						Url:    "/api" + routePath,
-						Method: "GET",
-					},
-					Data: map[string]interface{}{
-						"view_adapter": viewAdapter,
-					},
-				}
-
-				route.Data["actions"] = generator.buildRouteActions(module, role)
-				route.Children = generator.buildRouteChildren(module, role)
-
-				routes[routePath] = route
-
+				routes[module.Path+"/"+module.Name] = generator.buildListRoute(module, a, role)
+			case *actions.ListModuleAction:
+				routes[module.Path+"/"+module.Name] = generator.buildListRoute(module, *a, role)
 			case actions.ViewModuleAction:
-				routePath := module.Path + "/" + module.Name + "/:id"
-
-				viewAdapter := "view"
-				if adapter, exists := generator.ViewAdapters["view"]; exists {
-					viewAdapter = adapter
-				}
-
-				routes[routePath] = RouteConfig{
-					Title: a.Label,
-					Query: &RouteQuery{
-						Url:    "/api" + module.Path + "/" + module.Name + "/view/:bykey/:value",
-						Method: "GET",
-					},
-					Data: map[string]interface{}{
-						"view_adapter": viewAdapter,
-					},
-				}
-
+				routes[module.Path+"/"+module.Name+"/:id"] = generator.buildViewRoute(module, a)
+			case *actions.ViewModuleAction:
+				routes[module.Path+"/"+module.Name+"/:id"] = generator.buildViewRoute(module, *a)
 			case actions.AddModuleAction:
-				routePath := module.Path + "/" + module.Name + "/add"
-
-				viewAdapter := "add"
-				if adapter, exists := generator.ViewAdapters["add"]; exists {
-					viewAdapter = adapter
-				}
-
-				routes[routePath] = RouteConfig{
-					Title: a.Label,
-					Query: &RouteQuery{
-						Url:    "/api" + module.Path + "/" + module.Name,
-						Method: "PUT",
-					},
-					Data: map[string]interface{}{
-						"view_adapter": viewAdapter,
-					},
-				}
+				routes[module.Path+"/"+module.Name+"/add"] = generator.buildAddRoute(module, a)
+			case *actions.AddModuleAction:
+				routes[module.Path+"/"+module.Name+"/add"] = generator.buildAddRoute(module, *a)
 			}
 		}
 	}
 
 	return routes
+}
+
+func (generator *Generator) buildListRoute(module *BaseModule, action actions.ListModuleAction, role string) RouteConfig {
+	routePath := module.Path + "/" + module.Name
+
+	viewAdapter := "list_table"
+	if adapter, exists := generator.ViewAdapters["list"]; exists {
+		viewAdapter = adapter
+	}
+
+	route := RouteConfig{
+		Title:     action.Label,
+		MenuTitle: action.Label,
+		Query: &RouteQuery{
+			Url:    "/api" + routePath,
+			Method: "GET",
+		},
+		Data: map[string]interface{}{
+			"view_adapter": viewAdapter,
+		},
+	}
+
+	route.Data["actions"] = generator.buildRouteActions(module, role)
+	route.Children = generator.buildRouteChildren(module, role)
+
+	return route
+}
+
+func (generator *Generator) buildViewRoute(module *BaseModule, action actions.ViewModuleAction) RouteConfig {
+	viewAdapter := "view"
+	if adapter, exists := generator.ViewAdapters["view"]; exists {
+		viewAdapter = adapter
+	}
+
+	return RouteConfig{
+		Title: action.Label,
+		Query: &RouteQuery{
+			Url:    "/api" + module.Path + "/" + module.Name + "/view/:bykey/:value",
+			Method: "GET",
+		},
+		Data: map[string]interface{}{
+			"view_adapter": viewAdapter,
+		},
+	}
+}
+
+func (generator *Generator) buildAddRoute(module *BaseModule, action actions.AddModuleAction) RouteConfig {
+	viewAdapter := "add"
+	if adapter, exists := generator.ViewAdapters["add"]; exists {
+		viewAdapter = adapter
+	}
+
+	return RouteConfig{
+		Title: action.Label,
+		Query: &RouteQuery{
+			Url:    "/api" + module.Path + "/" + module.Name,
+			Method: "PUT",
+		},
+		Data: map[string]interface{}{
+			"view_adapter": viewAdapter,
+		},
+	}
 }
 
 // buildRouteActions формирует actions для маршрута
@@ -380,69 +402,99 @@ func (generator *Generator) buildRouteChildren(module *BaseModule, role string) 
 	for _, action := range module.Actions {
 		switch a := action.(type) {
 		case actions.ViewModuleAction:
-			if !hasPermission(a, role) {
-				continue
+			if child, ok := generator.buildViewChild(module, a, role); ok {
+				children[":id"] = child
 			}
-
-			viewAdapter := "view"
-			if adapter, exists := generator.ViewAdapters["view"]; exists {
-				viewAdapter = adapter
+		case *actions.ViewModuleAction:
+			if child, ok := generator.buildViewChild(module, *a, role); ok {
+				children[":id"] = child
 			}
-
-			children[":id"] = RouteConfig{
-				Title: a.Label,
-				Query: &RouteQuery{
-					Url:    "/api" + module.Path + "/" + module.Name + "/view/:bykey/:value",
-					Method: "GET",
-				},
-				Data: map[string]interface{}{
-					"view_adapter": viewAdapter,
-				},
-			}
-
 		case actions.UpdateModuleAction:
-			if !hasPermission(a, role) {
-				continue
+			if child, ok := generator.buildUpdateChild(module, a, role); ok {
+				children[":id/edit"] = child
 			}
-
-			editAdapter := "edit"
-			if adapter, exists := generator.ViewAdapters["edit"]; exists {
-				editAdapter = adapter
+		case *actions.UpdateModuleAction:
+			if child, ok := generator.buildUpdateChild(module, *a, role); ok {
+				children[":id/edit"] = child
 			}
-
-			children[":id/edit"] = RouteConfig{
-				Title: a.Label,
-				Query: &RouteQuery{
-					Url:    "/api" + module.Path + "/" + module.Name + "/:bykey/:value",
-					Method: "POST",
-				},
-				Data: map[string]interface{}{
-					"view_adapter": editAdapter,
-				},
-			}
-
 		case actions.AddModuleAction:
-			if !hasPermission(a, role) {
-				continue
+			if child, ok := generator.buildAddChild(module, a, role); ok {
+				children["add"] = child
 			}
-
-			addAdapter := "add"
-			if adapter, exists := generator.ViewAdapters["add"]; exists {
-				addAdapter = adapter
-			}
-
-			children["add"] = RouteConfig{
-				Title: a.Label,
-				Query: &RouteQuery{
-					Url:    "/api" + module.Path + "/" + module.Name,
-					Method: "PUT",
-				},
-				Data: map[string]interface{}{
-					"view_adapter": addAdapter,
-				},
+		case *actions.AddModuleAction:
+			if child, ok := generator.buildAddChild(module, *a, role); ok {
+				children["add"] = child
 			}
 		}
 	}
 
 	return children
+}
+
+func (generator *Generator) buildViewChild(module *BaseModule, a actions.ViewModuleAction, role string) (RouteConfig, bool) {
+	if !hasPermission(a, role) {
+		return RouteConfig{}, false
+	}
+
+	viewAdapter := "view"
+	if adapter, exists := generator.ViewAdapters["view"]; exists {
+		viewAdapter = adapter
+	}
+
+	return RouteConfig{
+		Title: a.Label,
+		Query: &RouteQuery{
+			Url:    "/api" + module.Path + "/" + module.Name + "/view/:bykey/:value",
+			Method: "GET",
+		},
+		Data: map[string]interface{}{
+			"view_adapter": viewAdapter,
+		},
+	}, true
+}
+
+func (generator *Generator) buildUpdateChild(module *BaseModule, a actions.UpdateModuleAction, role string) (RouteConfig, bool) {
+	if !hasPermission(a, role) {
+		return RouteConfig{}, false
+	}
+
+	editAdapter := "edit"
+	if adapter, exists := generator.ViewAdapters["edit"]; exists {
+		editAdapter = adapter
+	}
+
+	return RouteConfig{
+			Title: a.Label,
+			Query: &RouteQuery{
+				Url:    "/api" + module.Path + "/" + module.Name + "/:bykey/:value",
+				Method: "POST",
+			},
+			Data: map[string]interface{}{
+				"view_adapter": editAdapter,
+			},
+		},
+		true
+}
+
+func (generator *Generator) buildAddChild(module *BaseModule, a actions.AddModuleAction, role string) (RouteConfig, bool) {
+	if !hasPermission(a, role) {
+		return RouteConfig{}, false
+	}
+
+	addAdapter := "add"
+	if adapter, exists := generator.ViewAdapters["add"]; exists {
+		addAdapter = adapter
+	}
+
+	return RouteConfig{
+			Title: a.Label,
+			Query: &RouteQuery{
+				Url:    "/api" + module.Path + "/" + module.Name,
+				Method: "PUT",
+			},
+			Data: map[string]interface{}{
+				"view_adapter": addAdapter,
+			},
+		},
+		true
 }

--- a/db/postgres_db.go
+++ b/db/postgres_db.go
@@ -6,8 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/darkrain/request-generator/actions"
@@ -169,7 +170,6 @@ type fieldMeta struct {
 	translatable bool
 	name         string
 }
-
 
 // arrayElementType determines whether an array literal contains integers or text.
 // "{1,2,3}" → "integer", "{en,ru,fr}" → "text"
@@ -840,9 +840,11 @@ func (db *DB) Update(log *log.Entry, table pg.Table, primaryKey pg.Column, modul
 
 	// Only run UPDATE on entity table if there are non-translatable fields to update
 	if len(setClauses) > 0 {
-		setClauses = append(setClauses, fmt.Sprintf(`"update_date" = $%d`, paramIdx))
-		values = append(values, time.Now())
-		paramIdx++
+		if hasModuleField(moduleFields, "update_date") {
+			setClauses = append(setClauses, fmt.Sprintf(`"update_date" = $%d`, paramIdx))
+			values = append(values, time.Now())
+			paramIdx++
+		}
 
 		// Get WHERE clause SQL from a dummy select
 		whereStmt := pg.SELECT(pg.Raw("1")).FROM(table).WHERE(where)
@@ -855,14 +857,9 @@ func (db *DB) Update(log *log.Entry, table pg.Table, primaryKey pg.Column, modul
 		}
 		whereClause := strings.TrimRight(whereSql[whereIdx:], ";\n\r\t ")
 
-		// Re-number placeholders in WHERE clause
-		for i, arg := range whereArgs {
-			oldPlaceholder := fmt.Sprintf("$%d", i+1)
-			newPlaceholder := fmt.Sprintf("$%d", paramIdx)
-			whereClause = strings.Replace(whereClause, oldPlaceholder, newPlaceholder, 1)
-			values = append(values, arg)
-			paramIdx++
-		}
+		whereClause = renumberPlaceholders(whereClause, paramIdx)
+		values = append(values, whereArgs...)
+		paramIdx += len(whereArgs)
 
 		tableName := table.TableName()
 		schemaName := table.SchemaName()
@@ -907,6 +904,27 @@ func (db *DB) Update(log *log.Entry, table pg.Table, primaryKey pg.Column, modul
 	}
 
 	return db.View(log, table, primaryKey, moduleFields, where, nil, tc)
+}
+
+func hasModuleField(moduleFields []fields.ModuleField, columnName string) bool {
+	for _, field := range moduleFields {
+		if field.ColumnName() == columnName {
+			return true
+		}
+	}
+	return false
+}
+
+var placeholderPattern = regexp.MustCompile(`\$(\d+)`)
+
+func renumberPlaceholders(query string, start int) string {
+	return placeholderPattern.ReplaceAllStringFunc(query, func(match string) string {
+		index, err := strconv.Atoi(strings.TrimPrefix(match, "$"))
+		if err != nil || index <= 0 {
+			return match
+		}
+		return fmt.Sprintf("$%d", start+index-1)
+	})
 }
 
 func (db *DB) Delete(log *log.Entry, table pg.Table, where pg.BoolExpression, tc *TranslationContext) error {

--- a/generator.go
+++ b/generator.go
@@ -41,6 +41,8 @@ type Generator struct {
 	GroupTitles          map[string]string
 	ViewAdapters         map[string]string
 	IconMap              map[string]string
+	Realtime             RealtimeConfig
+	realtimeHub          *realtimeHub
 }
 
 func NewGenerator(
@@ -109,6 +111,7 @@ func (generator *Generator) Run() {
 
 	featuresGroup := generator.group.Group("/api")
 	featuresGroup.GET("/features", generator.FeaturesMiddleware())
+	generator.initRealtime()
 
 	for _, module := range generator.Modules {
 		featuresModule := Features{
@@ -466,7 +469,7 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 						Convert:  realField.Convert,
 						Group:    realField.Group,
 						Order:    realField.Order,
-						Extra:   filterExtra,
+						Extra:    filterExtra,
 					}
 					filter[realField.ColumnName()] = filterField
 				}
@@ -524,13 +527,13 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			Page    int64                               `json:"page"`
 			Extra   interface{}                         `json:"extra"`
 			Rows    []interface{}                       `json:"rows"`
-			Heads   map[string]interface{}               `json:"heads"`
+			Heads   map[string]interface{}              `json:"heads"`
 			Filters map[string]fields.ModuleFilterField `json:"filters,omitempty"`
 			Sort    []actions.SortResponseItem          `json:"sort,omitempty"`
 		}{
-			Count:   count,
-			Size:    size,
-			Page:    page,
+			Count: count,
+			Size:  size,
+			Page:  page,
 			Extra: func() interface{} {
 				if action.ExtraFunc != nil {
 					return action.ExtraFunc(c)
@@ -540,7 +543,7 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			Rows:    results,
 			Heads:   heads,
 			Filters: filter,
-			Sort:      sortOptions,
+			Sort:    sortOptions,
 		}
 
 		if isCSV == 0 {
@@ -680,6 +683,7 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 		response.Response(l, c, output)
 
 		action.AfterRequest(c)
+		generator.publishRealtime(c, module, actions.ModuleActionNameAdd, output)
 	}
 }
 
@@ -1064,6 +1068,7 @@ func (generator *Generator) actionUpdate(module *BaseModule, action actions.Upda
 				if viewErr == nil {
 					response.Response(l, c, viewResult)
 					action.AfterRequest(c)
+					generator.publishRealtime(c, module, actions.ModuleActionNameUpdate, viewResult)
 					return
 				}
 			}
@@ -1079,6 +1084,7 @@ func (generator *Generator) actionUpdate(module *BaseModule, action actions.Upda
 		response.Response(l, c, fallbackResult)
 
 		action.AfterRequest(c)
+		generator.publishRealtime(c, module, actions.ModuleActionNameUpdate, fallbackResult)
 	}
 }
 
@@ -1162,5 +1168,6 @@ func (generator *Generator) actionDelete(module *BaseModule, action actions.Dele
 		response.Response(l, c, output)
 
 		action.AfterRequest(c)
+		generator.publishRealtime(c, module, actions.ModuleActionNameDelete, output)
 	}
 }

--- a/generator.go
+++ b/generator.go
@@ -624,6 +624,9 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 			}
 			return
 		}
+		if c.Writer.Written() {
+			return
+		}
 
 		var input map[string]interface{}
 		err = utils.ParseJson(c.Request, &input)

--- a/generator.go
+++ b/generator.go
@@ -1046,7 +1046,8 @@ func (generator *Generator) actionUpdate(module *BaseModule, action actions.Upda
 
 		_, err = generator.db(module).Update(l, module.Table, module.PrimaryKey, realFields, mapInput, where, tc)
 		if err != nil {
-			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorUpdate, nil)
+			l.Errorln("UPDATE ERR: ", err)
+			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorUpdate, []string{err.Error()})
 			return
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
 	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=

--- a/realtime.go
+++ b/realtime.go
@@ -321,7 +321,22 @@ func (c *realtimeConnection) canSubscribe(topic string) bool {
 }
 
 func SetRealtimePublish(c *gin.Context, event RealtimePublish) {
-	c.Set(realtimeContextKey, event)
+	if len(event.Topics) == 0 {
+		return
+	}
+	raw, ok := c.Get(realtimeContextKey)
+	if !ok {
+		c.Set(realtimeContextKey, []RealtimePublish{event})
+		return
+	}
+	switch existing := raw.(type) {
+	case []RealtimePublish:
+		c.Set(realtimeContextKey, append(existing, event))
+	case RealtimePublish:
+		c.Set(realtimeContextKey, []RealtimePublish{existing, event})
+	default:
+		c.Set(realtimeContextKey, []RealtimePublish{event})
+	}
 }
 
 func (generator *Generator) publishRealtime(c *gin.Context, module *BaseModule, action actions.ModuleActionName, output interface{}) {
@@ -332,8 +347,22 @@ func (generator *Generator) publishRealtime(c *gin.Context, module *BaseModule, 
 	if !ok {
 		return
 	}
-	pub, ok := raw.(RealtimePublish)
-	if !ok || len(pub.Topics) == 0 {
+	pubs := []RealtimePublish{}
+	switch value := raw.(type) {
+	case RealtimePublish:
+		pubs = append(pubs, value)
+	case []RealtimePublish:
+		pubs = value
+	default:
+		return
+	}
+	for _, pub := range pubs {
+		generator.publishRealtimeEvent(c, module, action, output, pub)
+	}
+}
+
+func (generator *Generator) publishRealtimeEvent(c *gin.Context, module *BaseModule, action actions.ModuleActionName, output interface{}, pub RealtimePublish) {
+	if len(pub.Topics) == 0 {
 		return
 	}
 	event := RealtimeEvent{

--- a/realtime.go
+++ b/realtime.go
@@ -42,6 +42,8 @@ type RealtimeEvent struct {
 }
 
 type RealtimePublish struct {
+	Module   string
+	Action   string
 	Topics   []string
 	RecordID interface{}
 	Payload  map[string]interface{}
@@ -342,6 +344,12 @@ func (generator *Generator) publishRealtime(c *gin.Context, module *BaseModule, 
 		Topics:    pub.Topics,
 		CreatedAt: time.Now().UTC(),
 		Payload:   pub.Payload,
+	}
+	if pub.Module != "" {
+		event.Module = pub.Module
+	}
+	if pub.Action != "" {
+		event.Action = pub.Action
 	}
 	if event.Payload == nil {
 		event.Payload = map[string]interface{}{}

--- a/realtime.go
+++ b/realtime.go
@@ -1,0 +1,380 @@
+package module
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/darkrain/request-generator/actions"
+	"github.com/darkrain/request-generator/icontext"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	realtimeContextKey = "_rg_realtime_event"
+)
+
+type RealtimeConfig struct {
+	Enabled bool
+	Broker  RealtimeBroker
+	Path    string
+}
+
+type RealtimeBroker interface {
+	Publish(ctx context.Context, event RealtimeEvent) (RealtimeEvent, error)
+	Replay(ctx context.Context, afterID string, limit int) ([]RealtimeEvent, bool, error)
+}
+
+type RealtimeEvent struct {
+	EventID   string                 `json:"event_id"`
+	Type      string                 `json:"type"`
+	Module    string                 `json:"module"`
+	Action    string                 `json:"action"`
+	RecordID  interface{}            `json:"record_id,omitempty"`
+	Topics    []string               `json:"topics,omitempty"`
+	CreatedAt time.Time              `json:"created_at"`
+	Payload   map[string]interface{} `json:"payload,omitempty"`
+}
+
+type RealtimePublish struct {
+	Topics   []string
+	RecordID interface{}
+	Payload  map[string]interface{}
+}
+
+type MemoryBrokerOptions struct {
+	MaxEvents int
+}
+
+type MemoryBroker struct {
+	mu     sync.RWMutex
+	seq    int64
+	events []RealtimeEvent
+	max    int
+}
+
+func NewMemoryBroker(options MemoryBrokerOptions) *MemoryBroker {
+	max := options.MaxEvents
+	if max <= 0 {
+		max = 1000
+	}
+	return &MemoryBroker{max: max}
+}
+
+func (b *MemoryBroker) Publish(ctx context.Context, event RealtimeEvent) (RealtimeEvent, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.seq++
+	event.EventID = strconv.FormatInt(b.seq, 10)
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now().UTC()
+	}
+	b.events = append(b.events, event)
+	if len(b.events) > b.max {
+		b.events = append([]RealtimeEvent(nil), b.events[len(b.events)-b.max:]...)
+	}
+	return event, nil
+}
+
+func (b *MemoryBroker) Replay(ctx context.Context, afterID string, limit int) ([]RealtimeEvent, bool, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if afterID == "" {
+		return nil, false, nil
+	}
+	after, err := strconv.ParseInt(afterID, 10, 64)
+	if err != nil {
+		return nil, true, nil
+	}
+	if len(b.events) == 0 {
+		return nil, true, nil
+	}
+	first, _ := strconv.ParseInt(b.events[0].EventID, 10, 64)
+	if after < first-1 {
+		return nil, true, nil
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	out := make([]RealtimeEvent, 0)
+	for _, event := range b.events {
+		id, _ := strconv.ParseInt(event.EventID, 10, 64)
+		if id > after {
+			out = append(out, event)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, false, nil
+}
+
+type realtimeHub struct {
+	mu          sync.RWMutex
+	connections map[*realtimeConnection]struct{}
+}
+
+type realtimeConnection struct {
+	hub    *realtimeHub
+	conn   *websocket.Conn
+	write  sync.Mutex
+	send   chan RealtimeEvent
+	topics map[string]struct{}
+	userID int64
+	role   string
+}
+
+func newRealtimeHub() *realtimeHub {
+	return &realtimeHub{connections: make(map[*realtimeConnection]struct{})}
+}
+
+func (h *realtimeHub) add(c *realtimeConnection) {
+	h.mu.Lock()
+	h.connections[c] = struct{}{}
+	h.mu.Unlock()
+}
+
+func (h *realtimeHub) remove(c *realtimeConnection) {
+	h.mu.Lock()
+	delete(h.connections, c)
+	h.mu.Unlock()
+	close(c.send)
+}
+
+func (h *realtimeHub) publish(event RealtimeEvent) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for c := range h.connections {
+		if !c.matches(event.Topics) {
+			continue
+		}
+		select {
+		case c.send <- event:
+		default:
+		}
+	}
+}
+
+func (c *realtimeConnection) matches(topics []string) bool {
+	if len(c.topics) == 0 {
+		return false
+	}
+	for _, topic := range topics {
+		if _, ok := c.topics[topic]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (generator *Generator) initRealtime() {
+	if !generator.Realtime.Enabled {
+		return
+	}
+	if generator.Realtime.Broker == nil {
+		panic("request-generator realtime enabled without broker")
+	}
+	if generator.realtimeHub == nil {
+		generator.realtimeHub = newRealtimeHub()
+	}
+	path := generator.Realtime.Path
+	if path == "" {
+		path = "/api/ws"
+	}
+	group := generator.group.Group(path)
+	dummyAction := actions.ListModuleAction{Auth: true, Permission: []actions.Role{}}
+	if generator.AuthMiddleware != nil {
+		group.Use(func(c *gin.Context) {
+			if token := c.Query("token"); token != "" && c.GetHeader("Authorization") == "" {
+				c.Request.Header.Set("Authorization", "Bearer "+token)
+			}
+			generator.AuthMiddleware(dummyAction)(c)
+		})
+	}
+	group.GET("", generator.handleRealtimeWebSocket())
+}
+
+func (generator *Generator) handleRealtimeWebSocket() gin.HandlerFunc {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+	return func(c *gin.Context) {
+		user, ok := icontext.GetUser(c.Request.Context())
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"message": "unauthorized"})
+			return
+		}
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			return
+		}
+		rc := &realtimeConnection{
+			hub:    generator.realtimeHub,
+			conn:   conn,
+			send:   make(chan RealtimeEvent, 64),
+			topics: map[string]struct{}{fmt.Sprintf("user:%d", user.ID): {}},
+			userID: user.ID,
+			role:   user.Role,
+		}
+		generator.realtimeHub.add(rc)
+		defer func() {
+			generator.realtimeHub.remove(rc)
+			conn.Close()
+		}()
+
+		go rc.writeLoop()
+		rc.readLoop(generator)
+	}
+}
+
+type realtimeClientMessage struct {
+	Type        string   `json:"type"`
+	RequestID   string   `json:"request_id,omitempty"`
+	LastEventID string   `json:"last_event_id,omitempty"`
+	Topics      []string `json:"topics,omitempty"`
+}
+
+func (c *realtimeConnection) readLoop(generator *Generator) {
+	for {
+		var msg realtimeClientMessage
+		if err := c.conn.ReadJSON(&msg); err != nil {
+			return
+		}
+		switch msg.Type {
+		case "hello":
+			c.handleHello(generator, msg)
+		case "subscribe":
+			c.handleSubscribe(msg)
+		case "unsubscribe":
+			c.handleUnsubscribe(msg)
+		case "ping":
+			_ = c.writeJSON(gin.H{"type": "pong", "request_id": msg.RequestID})
+		}
+	}
+}
+
+func (c *realtimeConnection) writeLoop() {
+	for event := range c.send {
+		if err := c.writeJSON(event); err != nil {
+			return
+		}
+	}
+}
+
+func (c *realtimeConnection) writeJSON(v interface{}) error {
+	c.write.Lock()
+	defer c.write.Unlock()
+	return c.conn.WriteJSON(v)
+}
+
+func (c *realtimeConnection) handleHello(generator *Generator, msg realtimeClientMessage) {
+	replay := "ok"
+	if msg.LastEventID != "" {
+		events, resync, err := generator.Realtime.Broker.Replay(context.Background(), msg.LastEventID, 500)
+		if err != nil || resync {
+			replay = "resync_required"
+		} else {
+			for _, event := range events {
+				if c.matches(event.Topics) {
+					c.send <- event
+				}
+			}
+		}
+	}
+	_ = c.writeJSON(gin.H{"type": "ready", "request_id": msg.RequestID, "replay": replay})
+}
+
+func (c *realtimeConnection) handleSubscribe(msg realtimeClientMessage) {
+	accepted := []string{}
+	for _, topic := range msg.Topics {
+		if c.canSubscribe(topic) {
+			c.topics[topic] = struct{}{}
+			accepted = append(accepted, topic)
+		}
+	}
+	_ = c.writeJSON(gin.H{"type": "subscribed", "request_id": msg.RequestID, "topics": accepted})
+}
+
+func (c *realtimeConnection) handleUnsubscribe(msg realtimeClientMessage) {
+	for _, topic := range msg.Topics {
+		if topic == fmt.Sprintf("user:%d", c.userID) {
+			continue
+		}
+		delete(c.topics, topic)
+	}
+	_ = c.writeJSON(gin.H{"type": "unsubscribed", "request_id": msg.RequestID})
+}
+
+func (c *realtimeConnection) canSubscribe(topic string) bool {
+	own := fmt.Sprintf("user:%d", c.userID)
+	if topic == own {
+		return true
+	}
+	return false
+}
+
+func SetRealtimePublish(c *gin.Context, event RealtimePublish) {
+	c.Set(realtimeContextKey, event)
+}
+
+func (generator *Generator) publishRealtime(c *gin.Context, module *BaseModule, action actions.ModuleActionName, output interface{}) {
+	if !generator.Realtime.Enabled || generator.Realtime.Broker == nil || generator.realtimeHub == nil {
+		return
+	}
+	raw, ok := c.Get(realtimeContextKey)
+	if !ok {
+		return
+	}
+	pub, ok := raw.(RealtimePublish)
+	if !ok || len(pub.Topics) == 0 {
+		return
+	}
+	event := RealtimeEvent{
+		Type:      "event",
+		Module:    module.Name,
+		Action:    string(action),
+		RecordID:  pub.RecordID,
+		Topics:    pub.Topics,
+		CreatedAt: time.Now().UTC(),
+		Payload:   pub.Payload,
+	}
+	if event.Payload == nil {
+		event.Payload = map[string]interface{}{}
+	}
+	if pub.RecordID == nil {
+		if mapped := outputRecordID(output); mapped != nil {
+			event.RecordID = mapped
+		}
+	}
+	published, err := generator.Realtime.Broker.Publish(c.Request.Context(), event)
+	if err != nil {
+		return
+	}
+	generator.realtimeHub.publish(published)
+}
+
+func outputRecordID(output interface{}) interface{} {
+	if output == nil {
+		return nil
+	}
+	body, err := json.Marshal(output)
+	if err != nil {
+		return nil
+	}
+	var mapped map[string]interface{}
+	if err := json.Unmarshal(body, &mapped); err != nil {
+		return nil
+	}
+	if v, ok := mapped["value"]; ok {
+		return v
+	}
+	if v, ok := mapped["id"]; ok {
+		return v
+	}
+	return nil
+}

--- a/realtime_test.go
+++ b/realtime_test.go
@@ -1,0 +1,52 @@
+package module
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMemoryBrokerReplay(t *testing.T) {
+	broker := NewMemoryBroker(MemoryBrokerOptions{MaxEvents: 10})
+
+	first, err := broker.Publish(context.Background(), RealtimeEvent{Module: "chat_messages", Action: "add"})
+	if err != nil {
+		t.Fatalf("publish first: %v", err)
+	}
+	second, err := broker.Publish(context.Background(), RealtimeEvent{Module: "chat_messages", Action: "add"})
+	if err != nil {
+		t.Fatalf("publish second: %v", err)
+	}
+
+	events, resync, err := broker.Replay(context.Background(), first.EventID, 10)
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if resync {
+		t.Fatal("replay should not require resync")
+	}
+	if len(events) != 1 || events[0].EventID != second.EventID {
+		t.Fatalf("unexpected replay events: %#v", events)
+	}
+}
+
+func TestMemoryBrokerReplayOverflowRequiresResync(t *testing.T) {
+	broker := NewMemoryBroker(MemoryBrokerOptions{MaxEvents: 2})
+
+	first, err := broker.Publish(context.Background(), RealtimeEvent{Module: "chat_messages", Action: "add"})
+	if err != nil {
+		t.Fatalf("publish first: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := broker.Publish(context.Background(), RealtimeEvent{Module: "chat_messages", Action: "add"}); err != nil {
+			t.Fatalf("publish overflow event %d: %v", i, err)
+		}
+	}
+
+	_, resync, err := broker.Replay(context.Background(), first.EventID, 10)
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if !resync {
+		t.Fatal("expected resync after ring buffer overflow")
+	}
+}

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -182,6 +182,7 @@ func TestConfigEndpoint_RoleFiltering(t *testing.T) {
 				Title:      "Restricted Module",
 				Group:      "Admin",
 				Order:      1,
+				Show:       true,
 			},
 		},
 		Actions: []actions.ModuleAction{

--- a/tests/postgres_db_test.go
+++ b/tests/postgres_db_test.go
@@ -232,7 +232,7 @@ func TestListEmpty(t *testing.T) {
 	cleanTable(t)
 
 	mf := testModuleFields()
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 	assert.Empty(t, results)
@@ -245,7 +245,7 @@ func TestListMultipleItems(t *testing.T) {
 	seedItem(t, "Charlie", "charlie@test.com", 35, "user")
 
 	mf := testModuleFields()
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), count)
 	assert.Len(t, results, 3)
@@ -259,11 +259,11 @@ func TestListPagination(t *testing.T) {
 
 	mf := testModuleFields()
 
-	results, _, err := testDB.List(testLog, tbl, tbl.ID, mf, 0, 2, nil, "", nil, nil, nil, nil, nil)
+	results, _, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 2, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Len(t, results, 2)
 
-	results, _, err = testDB.List(testLog, tbl, tbl.ID, mf, 1, 2, nil, "", nil, nil, nil, nil, nil)
+	results, _, err = testDB.List(testLog, tbl, tbl.ID, mf, mf, 1, 2, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 }
@@ -276,7 +276,7 @@ func TestListSearch(t *testing.T) {
 	mf := testModuleFields()
 	searchColumns := []postgres.Column{tbl.Email}
 
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, 0, 100, searchColumns, "alice", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, searchColumns, "alice", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.Len(t, results, 1)
@@ -291,7 +291,7 @@ func TestListFilter(t *testing.T) {
 	mf := testModuleFields()
 	filter := map[string]string{"role": "user"}
 
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, 0, 100, nil, "", filter, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", filter, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), count)
 	assert.Len(t, results, 2)
@@ -305,7 +305,7 @@ func TestListWhere(t *testing.T) {
 	mf := testModuleFields()
 	where := postgres.RawBool(`test_items."age" > #age`, postgres.RawArgs{"#age": 26})
 
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, 0, 100, nil, "", nil, where, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, where, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.Len(t, results, 1)
@@ -367,7 +367,7 @@ func TestDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	mf := testModuleFields()
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 	assert.Empty(t, results)
@@ -406,7 +406,7 @@ func TestListWithJoin(t *testing.T) {
 	}
 
 	mf := testModuleFields()
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, 0, 100, nil, "", nil, nil, []actions.ModuleActionJoin{join}, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, []actions.ModuleActionJoin{join}, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.Len(t, results, 1)
@@ -431,7 +431,7 @@ func TestAddRollbackOnError(t *testing.T) {
 	_, err = testDB.Add(testLog, tbl, tbl.ID, mf, input2, nil)
 	assert.Error(t, err)
 
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.Len(t, results, 1)


### PR DESCRIPTION
## Что изменено
- добавлен realtime core в request-generator
- добавлен websocket endpoint /api/ws с query token auth
- добавлен MemoryBroker для dev/local
- добавлен event protocol с event_id, last_event_id и resync_required
- generator публикует events после успешных add/update/delete, если модуль положил RealtimePublish в context
- добавлены unit tests для MemoryBroker replay/overflow

## Проверка
- go test . ./actions ./db ./fields ./icontext ./locale ./response ./utils

## Примечание
Production RedisBroker пока не реализован в этом PR. Интерфейс broker заложен так, чтобы добавить Redis Streams следующим PR без изменения webapp protocol.