### PR TITLE
Extend UniversalRenderer page metadata

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -704,8 +704,9 @@ Conditions отвечают только за отображение. Любое
         "renderer": "universal.display",
         "layout_slot": "center",
         "order": 10,
-        "block": {"type": "panel"},
-        "extra": {"components": []}
+        "block": {"type": "panel", "inset": "md"},
+        "stack": {"gap": "md"},
+        "components": []
       }
     ],
     "display_data": {},
@@ -717,7 +718,7 @@ Conditions отвечают только за отображение. Любое
 }
 ```
 
-`record_page.extra` имеет ту же роль, что и `list_page.extra`: typed extension текущего page object без возврата к `response.extra.record_page`.
+`record_page.sections[].components` и `record_page.sections[].stack` являются canonical metadata для display renderer. Не кладите layout/display metadata в `section.extra`: `extra` остается только legacy escape hatch для старых модулей и не должен использоваться новыми producer modules.
 
 ## View Groups
 

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -53,7 +53,7 @@ flowchart TD
 
 ## Где Лежит Metadata
 
-UniversalRenderer читает canonical metadata только из typed top-level response fields. `extra.*` остается legacy/deprecated escape hatch для старых модулей и application-specific compatibility.
+UniversalRenderer читает canonical metadata только из typed top-level response fields. `response.extra` остается legacy/deprecated escape hatch для старых модулей и application-specific compatibility, но не является частью UniversalRenderer metadata.
 
 Каждый response с typed page metadata должен содержать renderer identity:
 
@@ -428,13 +428,12 @@ Renderer discovery происходит через `/api/config`: frontend мо�
       "mode": "server"
     },
     "card_schema": {},
-    "context": {},
-    "extra": {}
+    "context": {}
   }
 }
 ```
 
-`list_page.extra` является typed extension bag текущего page object. Producer может класть туда renderer-specific параметры, которые уже стандартизованы на уровне приложения, но еще не подняты в core Go structs. Frontend нормализует `list_page.extra` внутрь того же `list_page`; это не legacy `response.extra.list_page`.
+`list_page.extra` не используется. Если producer-у не хватает поля для renderer metadata, поле нужно добавить в typed contract генератора и в документацию.
 
 ### Design Tokens
 
@@ -644,13 +643,12 @@ Conditions отвечают только за отображение. Любое
     "status": {"activeField": "status"},
     "actions": {},
     "text": {},
-    "context": {},
-    "extra": {}
+    "context": {}
   }
 }
 ```
 
-`resource_grid_page.actions`, `resource_grid_page.text`, `resource_grid_page.context` и `resource_grid_page.extra` предназначены для reusable resource management screens: route/action wiring, translation keys, runtime context and renderer-specific extensions.
+`resource_grid_page.actions`, `resource_grid_page.text` и `resource_grid_page.context` предназначены для reusable resource management screens: route/action wiring, translation keys and runtime context.
 
 ## Form Page
 
@@ -712,13 +710,12 @@ Conditions отвечают только за отображение. Любое
     "display_data": {},
     "theme": {},
     "actions": [],
-    "context": {},
-    "extra": {}
+    "context": {}
   }
 }
 ```
 
-`record_page.sections[].components` и `record_page.sections[].stack` являются canonical metadata для display renderer. Не кладите layout/display metadata в `section.extra`: `extra` остается только legacy escape hatch для старых модулей и не должен использоваться новыми producer modules.
+`record_page.sections[].components` и `record_page.sections[].stack` являются canonical metadata для display renderer. Не кладите layout/display metadata в `section.extra`: такого поля нет в UniversalRenderer contract.
 
 ## View Groups
 
@@ -754,9 +751,9 @@ Stable renderer names:
 | `universal.display` | Display section metadata: `components`, `display_data`, layout fields. |
 | `universal.filters` | `filters`, `levels`, `primary`, `secondary`, `more`, `nested`, `reset`. |
 | `universal.pagination` | `mode`, pagination response fields. |
-| `universal.preferences` | `preferences` config in section `extra`. |
+| `universal.preferences` | `preferences` config directly in section. |
 | `media.gallery` | Media fields/config in section metadata. |
-| `collection.manager` | `collection` config in section `extra`. |
+| `collection.manager` | `collection` config directly in section. |
 
 Unknown renderer names must degrade to a generic block or produce a visible unsupported-renderer state. Producer services should not introduce custom renderer names unless the target frontend registers them.
 
@@ -848,10 +845,10 @@ Examples of application-specific values:
 Legacy forms:
 
 - UniversalRenderer metadata внутри `response.extra.*`, например `extra.list_page`, `extra.form_page`, `extra.record_page`, `extra.resource_grid_page`;
-- application extension fields внутри top-level page `extra` допустимы и не считаются legacy, если они относятся к тому же page object;
+- application extension fields внутри top-level page `extra` не допускаются в UniversalRenderer contract;
 - `display` как string вместо object, например `"display": "badge"`;
 - `{"path": "...", "not": true}` вместо `{"not": {"path": "...", "truthy": true}}`;
 - `external: true` action without explicit `type`;
 - application-specific route fields such as `uniqueEndpoint` and `afterRoute` in `resource_grid_page`.
 
-`extra` остается deprecated escape hatch для старых модулей и application-specific данных. Новые producer modules должны описывать UniversalRenderer metadata через typed `BaseModule.Render renderer.Universal`, а request-generator должен отдавать canonical top-level `renderer` + page metadata fields.
+`response.extra` остается deprecated escape hatch для старых модулей и application-specific данных вне UniversalRenderer. Новые producer modules должны описывать UniversalRenderer metadata через typed `BaseModule.Render renderer.Universal`, а request-generator должен отдавать canonical top-level `renderer` + page metadata fields.

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -415,7 +415,9 @@ Renderer discovery происходит через `/api/config`: frontend мо�
     },
     "summary": {
       "title": "entities.summary",
-      "title_fallback": "All records"
+      "title_fallback": "All records",
+      "show_online": true,
+      "show_action": false
     },
     "grid": {
       "enabled": true,
@@ -426,10 +428,13 @@ Renderer discovery происходит через `/api/config`: frontend мо�
       "mode": "server"
     },
     "card_schema": {},
-    "context": {}
+    "context": {},
+    "extra": {}
   }
 }
 ```
+
+`list_page.extra` является typed extension bag текущего page object. Producer может класть туда renderer-specific параметры, которые уже стандартизованы на уровне приложения, но еще не подняты в core Go structs. Frontend нормализует `list_page.extra` внутрь того же `list_page`; это не legacy `response.extra.list_page`.
 
 ### Design Tokens
 
@@ -636,10 +641,16 @@ Conditions отвечают только за отображение. Любое
       "after_success": {"reload": "record"}
     },
     "card": {"type": "entity", "size": "md"},
-    "status": {"activeField": "status"}
+    "status": {"activeField": "status"},
+    "actions": {},
+    "text": {},
+    "context": {},
+    "extra": {}
   }
 }
 ```
+
+`resource_grid_page.actions`, `resource_grid_page.text`, `resource_grid_page.context` и `resource_grid_page.extra` предназначены для reusable resource management screens: route/action wiring, translation keys, runtime context and renderer-specific extensions.
 
 ## Form Page
 
@@ -678,6 +689,14 @@ Conditions отвечают только за отображение. Любое
 ```json
 {
   "record_page": {
+    "id": "profile",
+    "title": "Anna",
+    "subtitle": "@anna",
+    "show_header": false,
+    "badge": "Model",
+    "badge_tone": "glass-cyan",
+    "badge_teleport": "topbar",
+    "navigation": {"type": "none", "enabled": false},
     "layout": {"type": "three_column"},
     "sections": [
       {
@@ -691,10 +710,14 @@ Conditions отвечают только за отображение. Любое
     ],
     "display_data": {},
     "theme": {},
-    "actions": []
+    "actions": [],
+    "context": {},
+    "extra": {}
   }
 }
 ```
+
+`record_page.extra` имеет ту же роль, что и `list_page.extra`: typed extension текущего page object без возврата к `response.extra.record_page`.
 
 ## View Groups
 
@@ -824,6 +847,7 @@ Examples of application-specific values:
 Legacy forms:
 
 - UniversalRenderer metadata внутри `response.extra.*`, например `extra.list_page`, `extra.form_page`, `extra.record_page`, `extra.resource_grid_page`;
+- application extension fields внутри top-level page `extra` допустимы и не считаются legacy, если они относятся к тому же page object;
 - `display` как string вместо object, например `"display": "badge"`;
 - `{"path": "...", "not": true}` вместо `{"not": {"path": "...", "truthy": true}}`;
 - `external: true` action without explicit `type`;

--- a/generator.go
+++ b/generator.go
@@ -1008,7 +1008,7 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 		output := struct {
 			Renderer   *renderer.Identity     `json:"renderer,omitempty"`
 			RecordPage *renderer.RecordPage   `json:"record_page,omitempty"`
-			Extra      interface{}            `json:"extra"`
+			Extra      interface{}            `json:"extra,omitempty"`
 			Item       map[string]interface{} `json:"item"`
 		}{
 			Renderer:   render.RecordIdentity(),

--- a/generator.go
+++ b/generator.go
@@ -567,7 +567,7 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			Renderer         *renderer.Identity                  `json:"renderer,omitempty"`
 			ListPage         *renderer.ListPage                  `json:"list_page,omitempty"`
 			ResourceGridPage *renderer.ResourceGridPage          `json:"resource_grid_page,omitempty"`
-			Extra            interface{}                         `json:"extra"`
+			Extra            interface{}                         `json:"extra,omitempty"`
 			Rows             []interface{}                       `json:"rows"`
 			Heads            map[string]interface{}              `json:"heads"`
 			Filters          map[string]fields.ModuleFilterField `json:"filters,omitempty"`

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -23,6 +23,7 @@ func cloneListPage(v *ListPage) *ListPage {
 	cp.CardSchema = cloneCardSchema(v.CardSchema)
 	cp.Context = cloneMap(v.Context)
 	cp.Actions = cloneActions(v.Actions)
+	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 
@@ -43,12 +44,15 @@ func cloneRecordPage(v *RecordPage) *RecordPage {
 		return nil
 	}
 	cp := *v
+	cp.ShowHeader = clonePtr(v.ShowHeader)
+	cp.Navigation = cloneMap(v.Navigation)
 	cp.Layout = cloneLayout(v.Layout)
 	cp.Sections = cloneRecordSections(v.Sections)
 	cp.DisplayData = cloneMap(v.DisplayData)
 	cp.Theme = cloneMap(v.Theme)
 	cp.Actions = cloneActions(v.Actions)
 	cp.Context = cloneMap(v.Context)
+	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 
@@ -63,7 +67,10 @@ func cloneResourceGridPage(v *ResourceGridPage) *ResourceGridPage {
 	cp.Update = cloneAction(v.Update)
 	cp.Card = cloneCardSchema(v.Card)
 	cp.Status = cloneMap(v.Status)
+	cp.Actions = cloneMap(v.Actions)
+	cp.Text = cloneMap(v.Text)
 	cp.Context = cloneMap(v.Context)
+	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 
@@ -119,6 +126,9 @@ func cloneSummary(v *Summary) *Summary {
 		return nil
 	}
 	cp := *v
+	cp.ShowOnline = clonePtr(v.ShowOnline)
+	cp.ShowAction = clonePtr(v.ShowAction)
+	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -23,7 +23,6 @@ func cloneListPage(v *ListPage) *ListPage {
 	cp.CardSchema = cloneCardSchema(v.CardSchema)
 	cp.Context = cloneMap(v.Context)
 	cp.Actions = cloneActions(v.Actions)
-	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 
@@ -52,7 +51,6 @@ func cloneRecordPage(v *RecordPage) *RecordPage {
 	cp.Theme = cloneMap(v.Theme)
 	cp.Actions = cloneActions(v.Actions)
 	cp.Context = cloneMap(v.Context)
-	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 
@@ -70,7 +68,6 @@ func cloneResourceGridPage(v *ResourceGridPage) *ResourceGridPage {
 	cp.Actions = cloneMap(v.Actions)
 	cp.Text = cloneMap(v.Text)
 	cp.Context = cloneMap(v.Context)
-	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 
@@ -88,13 +85,33 @@ func cloneFilters(v *Filters) *Filters {
 		return nil
 	}
 	cp := *v
+	cp.SecondaryEnabled = clonePtr(v.SecondaryEnabled)
+	cp.Levels = cloneSlice(v.Levels)
 	cp.Primary = cloneSlice(v.Primary)
 	cp.Secondary = cloneSlice(v.Secondary)
 	cp.More = cloneSlice(v.More)
 	cp.Nested = cloneSlice(v.Nested)
+	cp.PillRows = cloneMapRows(v.PillRows)
+	cp.SecondaryPillRows = cloneMapRows(v.SecondaryPillRows)
 	cp.Reset = cloneFilterReset(v.Reset)
-	cp.Extra = cloneMap(v.Extra)
 	return &cp
+}
+
+func cloneMapRows(values [][]map[string]interface{}) [][]map[string]interface{} {
+	if values == nil {
+		return nil
+	}
+	out := make([][]map[string]interface{}, len(values))
+	for i, row := range values {
+		if row == nil {
+			continue
+		}
+		out[i] = make([]map[string]interface{}, len(row))
+		for j, item := range row {
+			out[i][j] = cloneMap(item)
+		}
+	}
+	return out
 }
 
 func cloneFilterReset(v *FilterReset) *FilterReset {
@@ -129,7 +146,6 @@ func cloneSummary(v *Summary) *Summary {
 	cp := *v
 	cp.ShowOnline = clonePtr(v.ShowOnline)
 	cp.ShowAction = clonePtr(v.ShowAction)
-	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 
@@ -143,10 +159,9 @@ func cloneCardSchema(v *CardSchema) *CardSchema {
 	cp.Subtitle = cloneTextBinding(v.Subtitle)
 	cp.Description = cloneTextBinding(v.Description)
 	cp.Status = cloneStatusBinding(v.Status)
-	cp.Badges = cloneSlice(v.Badges)
+	cp.Badges = cloneBadges(v.Badges)
 	cp.Stats = cloneStats(v.Stats)
 	cp.Actions = cloneActions(v.Actions)
-	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 
@@ -155,7 +170,7 @@ func cloneMedia(v *Media) *Media {
 		return nil
 	}
 	cp := *v
-	cp.Extra = cloneMap(v.Extra)
+	cp.GlowEnabled = clonePtr(v.GlowEnabled)
 	return &cp
 }
 
@@ -167,11 +182,28 @@ func cloneTextBinding(v *TextBinding) *TextBinding {
 	return &cp
 }
 
+func cloneBadges(values []Badge) []Badge {
+	if values == nil {
+		return nil
+	}
+	out := make([]Badge, len(values))
+	for i, v := range values {
+		out[i] = v
+		out[i].Marker = clonePtr(v.Marker)
+		out[i].ToneMap = cloneMap(v.ToneMap)
+		out[i].Then = cloneMap(v.Then)
+		out[i].Else = cloneMap(v.Else)
+	}
+	return out
+}
+
 func cloneStatusBinding(v *StatusBinding) *StatusBinding {
 	if v == nil {
 		return nil
 	}
 	cp := *v
+	cp.Marker = clonePtr(v.Marker)
+	cp.ToneMap = cloneMap(v.ToneMap)
 	return &cp
 }
 
@@ -196,7 +228,9 @@ func cloneFormSections(values []FormSection) []FormSection {
 		out[i] = v
 		out[i].Block = cloneBlock(v.Block)
 		out[i].Fields = cloneSlice(v.Fields)
-		out[i].Extra = cloneMap(v.Extra)
+		out[i].ListPage = cloneListPage(v.ListPage)
+		out[i].Collection = cloneMap(v.Collection)
+		out[i].Preferences = cloneMap(v.Preferences)
 	}
 	return out
 }
@@ -211,7 +245,6 @@ func cloneRecordSections(values []RecordSection) []RecordSection {
 		out[i].Block = cloneBlock(v.Block)
 		out[i].Stack = cloneStack(v.Stack)
 		out[i].Components = cloneDisplayComponents(v.Components)
-		out[i].Extra = cloneMap(v.Extra)
 	}
 	return out
 }
@@ -221,7 +254,6 @@ func cloneBlock(v *Block) *Block {
 		return nil
 	}
 	cp := *v
-	cp.Extra = cloneMap(v.Extra)
 	return &cp
 }
 
@@ -245,7 +277,6 @@ func cloneDisplayComponents(values []DisplayComponent) []DisplayComponent {
 	for i, v := range values {
 		out[i] = v
 		out[i].Block = cloneBlock(v.Block)
-		out[i].Extra = cloneMap(v.Extra)
 		if v.Visible != nil {
 			visible := *v.Visible
 			out[i].Visible = &visible
@@ -291,13 +322,12 @@ func cloneActionValue(v Action) Action {
 	v.VisibleIf = cloneCondition(v.VisibleIf)
 	v.HiddenIf = cloneCondition(v.HiddenIf)
 	v.DisabledIf = cloneCondition(v.DisabledIf)
-	v.Route = cloneRouteAction(v.Route)
+	v.Route = cloneRouteValue(v.Route)
 	v.API = cloneAPIAction(v.API)
 	v.Modal = cloneModalAction(v.Modal)
 	v.Confirm = cloneConfirm(v.Confirm)
 	v.AfterSuccess = cloneActionResult(v.AfterSuccess)
 	v.AfterError = cloneActionResult(v.AfterError)
-	v.Extra = cloneMap(v.Extra)
 	return v
 }
 
@@ -309,6 +339,27 @@ func cloneRouteAction(v *RouteAction) *RouteAction {
 	cp.Params = cloneMap(v.Params)
 	cp.Query = cloneMap(v.Query)
 	return &cp
+}
+
+func cloneRouteValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case string:
+		return typed
+	case *RouteAction:
+		return cloneRouteAction(typed)
+	case RouteAction:
+		cloned := cloneRouteAction(&typed)
+		if cloned == nil {
+			return nil
+		}
+		return *cloned
+	case map[string]interface{}:
+		return cloneMap(typed)
+	default:
+		return typed
+	}
 }
 
 func cloneAPIAction(v *APIAction) *APIAction {
@@ -360,8 +411,27 @@ func cloneCondition(v *Condition) *Condition {
 	cp.Falsy = clonePtr(v.Falsy)
 	cp.All = cloneConditions(v.All)
 	cp.Any = cloneConditions(v.Any)
-	cp.Not = cloneCondition(v.Not)
+	cp.Not = cloneConditionValue(v.Not)
 	return &cp
+}
+
+func cloneConditionValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case *Condition:
+		return cloneCondition(typed)
+	case Condition:
+		cloned := cloneCondition(&typed)
+		if cloned == nil {
+			return nil
+		}
+		return *cloned
+	case map[string]interface{}:
+		return cloneMap(typed)
+	default:
+		return typed
+	}
 }
 
 func cloneConditions(values []Condition) []Condition {

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -79,6 +79,7 @@ func cloneLayout(v *Layout) *Layout {
 		return nil
 	}
 	cp := *v
+	cp.Slots = cloneSlice(v.Slots)
 	return &cp
 }
 
@@ -208,6 +209,8 @@ func cloneRecordSections(values []RecordSection) []RecordSection {
 	for i, v := range values {
 		out[i] = v
 		out[i].Block = cloneBlock(v.Block)
+		out[i].Stack = cloneStack(v.Stack)
+		out[i].Components = cloneDisplayComponents(v.Components)
 		out[i].Extra = cloneMap(v.Extra)
 	}
 	return out
@@ -220,6 +223,49 @@ func cloneBlock(v *Block) *Block {
 	cp := *v
 	cp.Extra = cloneMap(v.Extra)
 	return &cp
+}
+
+func cloneStack(v *Stack) *Stack {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	if v.Wrap != nil {
+		wrap := *v.Wrap
+		cp.Wrap = &wrap
+	}
+	return &cp
+}
+
+func cloneDisplayComponents(values []DisplayComponent) []DisplayComponent {
+	if values == nil {
+		return nil
+	}
+	out := make([]DisplayComponent, len(values))
+	for i, v := range values {
+		out[i] = v
+		out[i].Block = cloneBlock(v.Block)
+		out[i].Extra = cloneMap(v.Extra)
+		if v.Visible != nil {
+			visible := *v.Visible
+			out[i].Visible = &visible
+		}
+		if v.Wrap != nil {
+			wrap := *v.Wrap
+			out[i].Wrap = &wrap
+		}
+		if v.VideoControls != nil {
+			videoControls := *v.VideoControls
+			out[i].VideoControls = &videoControls
+		}
+		if v.MatrixColumns != nil {
+			out[i].MatrixColumns = make([]map[string]interface{}, len(v.MatrixColumns))
+			for j, column := range v.MatrixColumns {
+				out[i].MatrixColumns[j] = cloneMap(column)
+			}
+		}
+	}
+	return out
 }
 
 func cloneActions(values []Action) []Action {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -75,6 +75,11 @@ func (r Universal) Validate() error {
 
 type Layout struct {
 	Type     LayoutType   `json:"type,omitempty"`
+	Mode     string       `json:"mode,omitempty"`
+	Slots    []string     `json:"slots,omitempty"`
+	Left     string       `json:"left,omitempty"`
+	Center   string       `json:"center,omitempty"`
+	Right    string       `json:"right,omitempty"`
 	Align    AlignToken   `json:"align,omitempty"`
 	MaxWidth MaxWidth     `json:"max_width,omitempty"`
 	Gap      SpacingToken `json:"gap,omitempty"`
@@ -216,13 +221,69 @@ type Block struct {
 	TitleDecor     string                 `json:"title_decor,omitempty"`
 	TitleBar       string                 `json:"title_bar,omitempty"`
 	TitleUnderline string                 `json:"title_underline,omitempty"`
-	Padding        string                 `json:"padding,omitempty"`
+	Inset          string                 `json:"inset,omitempty"`
 	MaxWidth       string                 `json:"max_width,omitempty"`
 	BodyClass      string                 `json:"body_class,omitempty"`
 	BorderStyle    string                 `json:"border_style,omitempty"`
 	HoverEnabled   *bool                  `json:"hover_enabled,omitempty"`
 	Effect         string                 `json:"effect,omitempty"`
 	Extra          map[string]interface{} `json:"extra,omitempty"`
+}
+
+type Stack struct {
+	Gap       string `json:"gap,omitempty"`
+	Direction string `json:"direction,omitempty"`
+	Wrap      *bool  `json:"wrap,omitempty"`
+	Justify   string `json:"justify,omitempty"`
+	Align     string `json:"align,omitempty"`
+	Inset     string `json:"inset,omitempty"`
+}
+
+type DisplayComponent struct {
+	ID                  string                   `json:"id,omitempty"`
+	Type                string                   `json:"type,omitempty"`
+	Data                string                   `json:"data,omitempty"`
+	Value               interface{}              `json:"value,omitempty"`
+	Default             interface{}              `json:"default,omitempty"`
+	Visible             *bool                    `json:"visible,omitempty"`
+	ModelValue          string                   `json:"model_value,omitempty"`
+	Overlays            string                   `json:"overlays,omitempty"`
+	OverlayData         string                   `json:"overlay_data,omitempty"`
+	UpdateAction        string                   `json:"update_action,omitempty"`
+	MainRatio           string                   `json:"main_ratio,omitempty"`
+	MainRadius          string                   `json:"main_radius,omitempty"`
+	MainRadiusToken     string                   `json:"main_radius_token,omitempty"`
+	ThumbRatio          string                   `json:"thumb_ratio,omitempty"`
+	ThumbsInset         string                   `json:"thumbs_inset,omitempty"`
+	ThumbsInsetToken    string                   `json:"thumbs_inset_token,omitempty"`
+	VideoControls       *bool                    `json:"video_controls,omitempty"`
+	Size                string                   `json:"size,omitempty"`
+	Wrap                *bool                    `json:"wrap,omitempty"`
+	Gap                 string                   `json:"gap,omitempty"`
+	Direction           string                   `json:"direction,omitempty"`
+	Justify             string                   `json:"justify,omitempty"`
+	Align               string                   `json:"align,omitempty"`
+	Inset               string                   `json:"inset,omitempty"`
+	Compact             bool                     `json:"compact,omitempty"`
+	Columns             int                      `json:"columns,omitempty"`
+	ReadonlyColumns     int                      `json:"readonly_columns,omitempty"`
+	DisplayType         string                   `json:"display_type,omitempty"`
+	SeparatorVariant    string                   `json:"separator_variant,omitempty"`
+	SeparatorAppearance string                   `json:"separator_appearance,omitempty"`
+	MatrixColumns       []map[string]interface{} `json:"matrix_columns,omitempty"`
+	ValueLabel          string                   `json:"value_label,omitempty"`
+	ValueFallback       string                   `json:"value_fallback,omitempty"`
+	MatrixLabel         string                   `json:"matrix_label,omitempty"`
+	MatrixLabelIcon     string                   `json:"matrix_label_icon,omitempty"`
+	Block               *Block                   `json:"block,omitempty"`
+	Title               string                   `json:"title,omitempty"`
+	TitleFallback       string                   `json:"title_fallback,omitempty"`
+	Subtitle            string                   `json:"subtitle,omitempty"`
+	SubtitleFallback    string                   `json:"subtitle_fallback,omitempty"`
+	TitleLevel          int                      `json:"title_level,omitempty"`
+	TitleTone           string                   `json:"title_tone,omitempty"`
+	BodyClass           string                   `json:"body_class,omitempty"`
+	Extra               map[string]interface{}   `json:"extra,omitempty"`
 }
 
 type RecordPage struct {
@@ -253,6 +314,8 @@ type RecordSection struct {
 	LayoutSlot    string                 `json:"layout_slot,omitempty"`
 	Order         int                    `json:"order,omitempty"`
 	Block         *Block                 `json:"block,omitempty"`
+	Stack         *Stack                 `json:"stack,omitempty"`
+	Components    []DisplayComponent     `json:"components,omitempty"`
 	Extra         map[string]interface{} `json:"extra,omitempty"`
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -211,9 +211,18 @@ type FormSection struct {
 }
 
 type Block struct {
-	Type    BlockType              `json:"type,omitempty"`
-	Variant BlockVariant           `json:"variant,omitempty"`
-	Extra   map[string]interface{} `json:"extra,omitempty"`
+	Type           BlockType              `json:"type,omitempty"`
+	Variant        BlockVariant           `json:"variant,omitempty"`
+	TitleDecor     string                 `json:"title_decor,omitempty"`
+	TitleBar       string                 `json:"title_bar,omitempty"`
+	TitleUnderline string                 `json:"title_underline,omitempty"`
+	Padding        string                 `json:"padding,omitempty"`
+	MaxWidth       string                 `json:"max_width,omitempty"`
+	BodyClass      string                 `json:"body_class,omitempty"`
+	BorderStyle    string                 `json:"border_style,omitempty"`
+	HoverEnabled   *bool                  `json:"hover_enabled,omitempty"`
+	Effect         string                 `json:"effect,omitempty"`
+	Extra          map[string]interface{} `json:"extra,omitempty"`
 }
 
 type RecordPage struct {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -86,15 +86,19 @@ type Layout struct {
 }
 
 type Filters struct {
-	Renderer         string                 `json:"renderer,omitempty"`
-	Enabled          bool                   `json:"enabled"`
-	PrimaryPlacement string                 `json:"primary_placement,omitempty"`
-	Primary          []string               `json:"primary,omitempty"`
-	Secondary        []string               `json:"secondary,omitempty"`
-	More             []string               `json:"more,omitempty"`
-	Nested           []string               `json:"nested,omitempty"`
-	Reset            *FilterReset           `json:"reset,omitempty"`
-	Extra            map[string]interface{} `json:"extra,omitempty"`
+	Renderer          string                     `json:"renderer,omitempty"`
+	Enabled           bool                       `json:"enabled"`
+	PrimaryPlacement  string                     `json:"primary_placement,omitempty"`
+	SecondaryEnabled  *bool                      `json:"secondary_enabled,omitempty"`
+	ResetPlacement    string                     `json:"reset_placement,omitempty"`
+	Levels            []string                   `json:"levels,omitempty"`
+	Primary           []string                   `json:"primary,omitempty"`
+	Secondary         []string                   `json:"secondary,omitempty"`
+	More              []string                   `json:"more,omitempty"`
+	Nested            []string                   `json:"nested,omitempty"`
+	PillRows          [][]map[string]interface{} `json:"pill_rows,omitempty"`
+	SecondaryPillRows [][]map[string]interface{} `json:"secondary_pill_rows,omitempty"`
+	Reset             *FilterReset               `json:"reset,omitempty"`
 }
 
 type FilterReset struct {
@@ -124,43 +128,47 @@ type ListPage struct {
 	CardSchema *CardSchema            `json:"card_schema,omitempty"`
 	Context    map[string]interface{} `json:"context,omitempty"`
 	Actions    []Action               `json:"actions,omitempty"`
-	Extra      map[string]interface{} `json:"extra,omitempty"`
 }
 
 type Summary struct {
-	Title         string                 `json:"title,omitempty"`
-	TitleFallback string                 `json:"title_fallback,omitempty"`
-	ShowOnline    *bool                  `json:"show_online,omitempty"`
-	ShowAction    *bool                  `json:"show_action,omitempty"`
-	Extra         map[string]interface{} `json:"extra,omitempty"`
+	Title         string `json:"title,omitempty"`
+	TitleFallback string `json:"title_fallback,omitempty"`
+	ShowOnline    *bool  `json:"show_online,omitempty"`
+	ShowAction    *bool  `json:"show_action,omitempty"`
 }
 
 type CardSchema struct {
-	Type           string                 `json:"type,omitempty"`
-	Variant        CardVariant            `json:"variant,omitempty"`
-	Size           SizeToken              `json:"size,omitempty"`
-	SurfaceVariant SurfaceVariant         `json:"surface_variant,omitempty"`
-	SurfaceEffect  SurfaceEffect          `json:"surface_effect,omitempty"`
-	BadgeSize      SizeToken              `json:"badge_size,omitempty"`
-	ActionSize     SizeToken              `json:"action_size,omitempty"`
-	PrimaryAction  string                 `json:"primary_action,omitempty"`
-	Media          *Media                 `json:"media,omitempty"`
-	Title          *TextBinding           `json:"title,omitempty"`
-	Subtitle       *TextBinding           `json:"subtitle,omitempty"`
-	Description    *TextBinding           `json:"description,omitempty"`
-	Status         *StatusBinding         `json:"status,omitempty"`
-	Badges         []Badge                `json:"badges,omitempty"`
-	Stats          []Stat                 `json:"stats,omitempty"`
-	Actions        []Action               `json:"actions,omitempty"`
-	Extra          map[string]interface{} `json:"extra,omitempty"`
+	Type             string         `json:"type,omitempty"`
+	Variant          CardVariant    `json:"variant,omitempty"`
+	Size             SizeToken      `json:"size,omitempty"`
+	SurfaceVariant   SurfaceVariant `json:"surface_variant,omitempty"`
+	SurfaceEffect    SurfaceEffect  `json:"surface_effect,omitempty"`
+	BadgeSize        SizeToken      `json:"badge_size,omitempty"`
+	ActionSize       SizeToken      `json:"action_size,omitempty"`
+	DeleteActionSize SizeToken      `json:"delete_action_size,omitempty"`
+	PrimaryAction    string         `json:"primary_action,omitempty"`
+	Media            *Media         `json:"media,omitempty"`
+	Title            *TextBinding   `json:"title,omitempty"`
+	Subtitle         *TextBinding   `json:"subtitle,omitempty"`
+	SubtitleTone     string         `json:"subtitle_tone,omitempty"`
+	Description      *TextBinding   `json:"description,omitempty"`
+	Status           *StatusBinding `json:"status,omitempty"`
+	Badges           []Badge        `json:"badges,omitempty"`
+	Stats            []Stat         `json:"stats,omitempty"`
+	Actions          []Action       `json:"actions,omitempty"`
 }
 
 type Media struct {
-	Field    string                 `json:"field,omitempty"`
-	Ratio    MediaRatio             `json:"ratio,omitempty"`
-	Size     MediaSize              `json:"size,omitempty"`
-	Fallback string                 `json:"fallback,omitempty"`
-	Extra    map[string]interface{} `json:"extra,omitempty"`
+	Field        string     `json:"field,omitempty"`
+	Renderer     string     `json:"renderer,omitempty"`
+	Ratio        MediaRatio `json:"ratio,omitempty"`
+	Size         MediaSize  `json:"size,omitempty"`
+	Variant      string     `json:"variant,omitempty"`
+	GlowField    string     `json:"glow_field,omitempty"`
+	GlowFallback string     `json:"glow_fallback,omitempty"`
+	GlowEnabled  *bool      `json:"glow_enabled,omitempty"`
+	StatusField  string     `json:"status_field,omitempty"`
+	Fallback     string     `json:"fallback,omitempty"`
 }
 
 type TextBinding struct {
@@ -169,25 +177,42 @@ type TextBinding struct {
 }
 
 type StatusBinding struct {
-	ID    string `json:"id,omitempty"`
-	Field string `json:"field,omitempty"`
-	Type  string `json:"type,omitempty"`
+	ID         string            `json:"id,omitempty"`
+	Field      string            `json:"field,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	Option     string            `json:"option,omitempty"`
+	Placement  string            `json:"placement,omitempty"`
+	Marker     *bool             `json:"marker,omitempty"`
+	OnlineTone string            `json:"online_tone,omitempty"`
+	ToneMap    map[string]string `json:"tone_map,omitempty"`
 }
 
 type Badge struct {
-	ID    string `json:"id,omitempty"`
-	Field string `json:"field,omitempty"`
-	Tone  string `json:"tone,omitempty"`
+	ID        string                 `json:"id,omitempty"`
+	Type      string                 `json:"type,omitempty"`
+	Field     string                 `json:"field,omitempty"`
+	IfField   string                 `json:"if_field,omitempty"`
+	Option    string                 `json:"option,omitempty"`
+	Placement string                 `json:"placement,omitempty"`
+	Label     string                 `json:"label,omitempty"`
+	LabelKey  string                 `json:"label_key,omitempty"`
+	Tone      string                 `json:"tone,omitempty"`
+	ToneMap   map[string]string      `json:"tone_map,omitempty"`
+	Marker    *bool                  `json:"marker,omitempty"`
+	Then      map[string]interface{} `json:"then,omitempty"`
+	Else      map[string]interface{} `json:"else,omitempty"`
 }
 
 type Stat struct {
-	ID    string       `json:"id,omitempty"`
-	Label string       `json:"label,omitempty"`
-	Field string       `json:"field,omitempty"`
-	Icon  string       `json:"icon,omitempty"`
-	Size  SizeToken    `json:"size,omitempty"`
-	Tone  string       `json:"tone,omitempty"`
-	Value *TextBinding `json:"value,omitempty"`
+	ID       string       `json:"id,omitempty"`
+	Type     string       `json:"type,omitempty"`
+	Label    string       `json:"label,omitempty"`
+	LabelKey string       `json:"label_key,omitempty"`
+	Field    string       `json:"field,omitempty"`
+	Icon     string       `json:"icon,omitempty"`
+	Size     SizeToken    `json:"size,omitempty"`
+	Tone     string       `json:"tone,omitempty"`
+	Value    *TextBinding `json:"value,omitempty"`
 }
 
 type FormPage struct {
@@ -202,32 +227,35 @@ type FormPage struct {
 }
 
 type FormSection struct {
-	ID         string                 `json:"id,omitempty"`
-	Title      string                 `json:"title,omitempty"`
-	PanelTitle string                 `json:"panel_title,omitempty"`
-	Subtitle   string                 `json:"subtitle,omitempty"`
-	Renderer   string                 `json:"renderer,omitempty"`
-	Group      string                 `json:"group,omitempty"`
-	GroupTitle string                 `json:"group_title,omitempty"`
-	Icon       string                 `json:"icon,omitempty"`
-	Block      *Block                 `json:"block,omitempty"`
-	Fields     []string               `json:"fields,omitempty"`
-	Extra      map[string]interface{} `json:"extra,omitempty"`
+	ID          string                 `json:"id,omitempty"`
+	Title       string                 `json:"title,omitempty"`
+	PanelTitle  string                 `json:"panel_title,omitempty"`
+	Subtitle    string                 `json:"subtitle,omitempty"`
+	Renderer    string                 `json:"renderer,omitempty"`
+	Group       string                 `json:"group,omitempty"`
+	GroupTitle  string                 `json:"group_title,omitempty"`
+	Icon        string                 `json:"icon,omitempty"`
+	Action      string                 `json:"action,omitempty"`
+	Mode        string                 `json:"mode,omitempty"`
+	Block       *Block                 `json:"block,omitempty"`
+	Fields      []string               `json:"fields,omitempty"`
+	ListPage    *ListPage              `json:"list_page,omitempty"`
+	Collection  map[string]interface{} `json:"collection,omitempty"`
+	Preferences map[string]interface{} `json:"preferences,omitempty"`
 }
 
 type Block struct {
-	Type           BlockType              `json:"type,omitempty"`
-	Variant        BlockVariant           `json:"variant,omitempty"`
-	TitleDecor     string                 `json:"title_decor,omitempty"`
-	TitleBar       string                 `json:"title_bar,omitempty"`
-	TitleUnderline string                 `json:"title_underline,omitempty"`
-	Inset          string                 `json:"inset,omitempty"`
-	MaxWidth       string                 `json:"max_width,omitempty"`
-	BodyClass      string                 `json:"body_class,omitempty"`
-	BorderStyle    string                 `json:"border_style,omitempty"`
-	HoverEnabled   *bool                  `json:"hover_enabled,omitempty"`
-	Effect         string                 `json:"effect,omitempty"`
-	Extra          map[string]interface{} `json:"extra,omitempty"`
+	Type           BlockType    `json:"type,omitempty"`
+	Variant        BlockVariant `json:"variant,omitempty"`
+	TitleDecor     string       `json:"title_decor,omitempty"`
+	TitleBar       string       `json:"title_bar,omitempty"`
+	TitleUnderline string       `json:"title_underline,omitempty"`
+	Inset          string       `json:"inset,omitempty"`
+	MaxWidth       string       `json:"max_width,omitempty"`
+	BodyClass      string       `json:"body_class,omitempty"`
+	BorderStyle    string       `json:"border_style,omitempty"`
+	HoverEnabled   *bool        `json:"hover_enabled,omitempty"`
+	Effect         string       `json:"effect,omitempty"`
 }
 
 type Stack struct {
@@ -283,7 +311,6 @@ type DisplayComponent struct {
 	TitleLevel          int                      `json:"title_level,omitempty"`
 	TitleTone           string                   `json:"title_tone,omitempty"`
 	BodyClass           string                   `json:"body_class,omitempty"`
-	Extra               map[string]interface{}   `json:"extra,omitempty"`
 }
 
 type RecordPage struct {
@@ -301,22 +328,20 @@ type RecordPage struct {
 	Theme         map[string]interface{} `json:"theme,omitempty"`
 	Actions       []Action               `json:"actions,omitempty"`
 	Context       map[string]interface{} `json:"context,omitempty"`
-	Extra         map[string]interface{} `json:"extra,omitempty"`
 }
 
 type RecordSection struct {
-	ID            string                 `json:"id,omitempty"`
-	Title         string                 `json:"title,omitempty"`
-	TitleFallback string                 `json:"title_fallback,omitempty"`
-	TitleLevel    int                    `json:"title_level,omitempty"`
-	TitleTone     string                 `json:"title_tone,omitempty"`
-	Renderer      string                 `json:"renderer,omitempty"`
-	LayoutSlot    string                 `json:"layout_slot,omitempty"`
-	Order         int                    `json:"order,omitempty"`
-	Block         *Block                 `json:"block,omitempty"`
-	Stack         *Stack                 `json:"stack,omitempty"`
-	Components    []DisplayComponent     `json:"components,omitempty"`
-	Extra         map[string]interface{} `json:"extra,omitempty"`
+	ID            string             `json:"id,omitempty"`
+	Title         string             `json:"title,omitempty"`
+	TitleFallback string             `json:"title_fallback,omitempty"`
+	TitleLevel    int                `json:"title_level,omitempty"`
+	TitleTone     string             `json:"title_tone,omitempty"`
+	Renderer      string             `json:"renderer,omitempty"`
+	LayoutSlot    string             `json:"layout_slot,omitempty"`
+	Order         int                `json:"order,omitempty"`
+	Block         *Block             `json:"block,omitempty"`
+	Stack         *Stack             `json:"stack,omitempty"`
+	Components    []DisplayComponent `json:"components,omitempty"`
 }
 
 type ResourceGridPage struct {
@@ -330,29 +355,32 @@ type ResourceGridPage struct {
 	Actions  map[string]interface{} `json:"actions,omitempty"`
 	Text     map[string]interface{} `json:"text,omitempty"`
 	Context  map[string]interface{} `json:"context,omitempty"`
-	Extra    map[string]interface{} `json:"extra,omitempty"`
 }
 
 type Action struct {
-	ID           string                 `json:"id,omitempty"`
-	Type         ActionType             `json:"type,omitempty"`
-	LabelKey     string                 `json:"label_key,omitempty"`
-	Icon         string                 `json:"icon,omitempty"`
-	Variant      ActionVariant          `json:"variant,omitempty"`
-	Appearance   ActionAppearance       `json:"appearance,omitempty"`
-	VisibleIf    *Condition             `json:"visible_if,omitempty"`
-	HiddenIf     *Condition             `json:"hidden_if,omitempty"`
-	DisabledIf   *Condition             `json:"disabled_if,omitempty"`
-	Route        *RouteAction           `json:"route,omitempty"`
-	API          *APIAction             `json:"api,omitempty"`
-	Modal        *ModalAction           `json:"modal,omitempty"`
-	Confirm      *Confirm               `json:"confirm,omitempty"`
-	AfterSuccess *ActionResult          `json:"after_success,omitempty"`
-	AfterError   *ActionResult          `json:"after_error,omitempty"`
-	AriaLabelKey string                 `json:"aria_label_key,omitempty"`
-	TitleKey     string                 `json:"title_key,omitempty"`
-	Test         string                 `json:"test,omitempty"`
-	Extra        map[string]interface{} `json:"extra,omitempty"`
+	ID               string           `json:"id,omitempty"`
+	Type             ActionType       `json:"type,omitempty"`
+	Label            string           `json:"label,omitempty"`
+	LabelKey         string           `json:"label_key,omitempty"`
+	Icon             string           `json:"icon,omitempty"`
+	Variant          ActionVariant    `json:"variant,omitempty"`
+	Appearance       ActionAppearance `json:"appearance,omitempty"`
+	ActiveAppearance ActionAppearance `json:"active_appearance,omitempty"`
+	Active           string           `json:"active,omitempty"`
+	External         *bool            `json:"external,omitempty"`
+	Block            *bool            `json:"block,omitempty"`
+	VisibleIf        *Condition       `json:"visible_if,omitempty"`
+	HiddenIf         *Condition       `json:"hidden_if,omitempty"`
+	DisabledIf       *Condition       `json:"disabled_if,omitempty"`
+	Route            interface{}      `json:"route,omitempty"`
+	API              *APIAction       `json:"api,omitempty"`
+	Modal            *ModalAction     `json:"modal,omitempty"`
+	Confirm          *Confirm         `json:"confirm,omitempty"`
+	AfterSuccess     *ActionResult    `json:"after_success,omitempty"`
+	AfterError       *ActionResult    `json:"after_error,omitempty"`
+	AriaLabelKey     string           `json:"aria_label_key,omitempty"`
+	TitleKey         string           `json:"title_key,omitempty"`
+	Test             string           `json:"test,omitempty"`
 }
 
 type RouteAction struct {
@@ -400,5 +428,5 @@ type Condition struct {
 	Falsy     *bool         `json:"falsy,omitempty"`
 	All       []Condition   `json:"all,omitempty"`
 	Any       []Condition   `json:"any,omitempty"`
-	Not       *Condition    `json:"not,omitempty"`
+	Not       interface{}   `json:"not,omitempty"`
 }

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -235,12 +235,16 @@ type RecordPage struct {
 }
 
 type RecordSection struct {
-	ID         string                 `json:"id,omitempty"`
-	Renderer   string                 `json:"renderer,omitempty"`
-	LayoutSlot string                 `json:"layout_slot,omitempty"`
-	Order      int                    `json:"order,omitempty"`
-	Block      *Block                 `json:"block,omitempty"`
-	Extra      map[string]interface{} `json:"extra,omitempty"`
+	ID            string                 `json:"id,omitempty"`
+	Title         string                 `json:"title,omitempty"`
+	TitleFallback string                 `json:"title_fallback,omitempty"`
+	TitleLevel    int                    `json:"title_level,omitempty"`
+	TitleTone     string                 `json:"title_tone,omitempty"`
+	Renderer      string                 `json:"renderer,omitempty"`
+	LayoutSlot    string                 `json:"layout_slot,omitempty"`
+	Order         int                    `json:"order,omitempty"`
+	Block         *Block                 `json:"block,omitempty"`
+	Extra         map[string]interface{} `json:"extra,omitempty"`
 }
 
 type ResourceGridPage struct {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -119,11 +119,15 @@ type ListPage struct {
 	CardSchema *CardSchema            `json:"card_schema,omitempty"`
 	Context    map[string]interface{} `json:"context,omitempty"`
 	Actions    []Action               `json:"actions,omitempty"`
+	Extra      map[string]interface{} `json:"extra,omitempty"`
 }
 
 type Summary struct {
-	Title         string `json:"title,omitempty"`
-	TitleFallback string `json:"title_fallback,omitempty"`
+	Title         string                 `json:"title,omitempty"`
+	TitleFallback string                 `json:"title_fallback,omitempty"`
+	ShowOnline    *bool                  `json:"show_online,omitempty"`
+	ShowAction    *bool                  `json:"show_action,omitempty"`
+	Extra         map[string]interface{} `json:"extra,omitempty"`
 }
 
 type CardSchema struct {
@@ -213,12 +217,21 @@ type Block struct {
 }
 
 type RecordPage struct {
-	Layout      *Layout                `json:"layout,omitempty"`
-	Sections    []RecordSection        `json:"sections,omitempty"`
-	DisplayData map[string]interface{} `json:"display_data,omitempty"`
-	Theme       map[string]interface{} `json:"theme,omitempty"`
-	Actions     []Action               `json:"actions,omitempty"`
-	Context     map[string]interface{} `json:"context,omitempty"`
+	ID            string                 `json:"id,omitempty"`
+	Title         string                 `json:"title,omitempty"`
+	Subtitle      string                 `json:"subtitle,omitempty"`
+	ShowHeader    *bool                  `json:"show_header,omitempty"`
+	Badge         string                 `json:"badge,omitempty"`
+	BadgeTone     string                 `json:"badge_tone,omitempty"`
+	BadgeTeleport string                 `json:"badge_teleport,omitempty"`
+	Navigation    map[string]interface{} `json:"navigation,omitempty"`
+	Layout        *Layout                `json:"layout,omitempty"`
+	Sections      []RecordSection        `json:"sections,omitempty"`
+	DisplayData   map[string]interface{} `json:"display_data,omitempty"`
+	Theme         map[string]interface{} `json:"theme,omitempty"`
+	Actions       []Action               `json:"actions,omitempty"`
+	Context       map[string]interface{} `json:"context,omitempty"`
+	Extra         map[string]interface{} `json:"extra,omitempty"`
 }
 
 type RecordSection struct {
@@ -238,7 +251,10 @@ type ResourceGridPage struct {
 	Update   *Action                `json:"update,omitempty"`
 	Card     *CardSchema            `json:"card,omitempty"`
 	Status   map[string]interface{} `json:"status,omitempty"`
+	Actions  map[string]interface{} `json:"actions,omitempty"`
+	Text     map[string]interface{} `json:"text,omitempty"`
 	Context  map[string]interface{} `json:"context,omitempty"`
+	Extra    map[string]interface{} `json:"extra,omitempty"`
 }
 
 type Action struct {


### PR DESCRIPTION
## Что сделано
- добавлены typed-поля title, title_fallback, title_level, title_tone в renderer.RecordSection
- это сохраняет заголовки секций record_page при typed UniversalRenderer response и убирает необходимость legacy/fallback extra

## Проверки
- go test ./...
- подтверждено через API profile view: секции details/rates/services отдают title metadata
