### PR TITLE
Add target-based menu config

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ renderer.Action{
 Render: renderer.Universal{
     ResourceGrid: &renderer.ResourceGridPage{
         Endpoint: "/catalog_items",
-        List: map[string]interface{}{
-            "size":    100,
-            "filters": map[string]interface{}{"scope": "owned"},
+        List: &renderer.ResourceGridListConfig{
+            Size:    100,
+            Filters: map[string]interface{}{"scope": "owned"},
         },
         Create: &renderer.Action{
             Type:         renderer.ActionAPI,
@@ -306,13 +306,13 @@ Render: renderer.Universal{
             BadgeSize:      renderer.SizeSM,
             ActionSize:     renderer.SizeMD,
         },
-        Status: map[string]interface{}{
-            "verifyField":         "review_status",
-            "activeField":         "status",
-            "verifiedValue":       "approved",
-            "pendingValue":        "pending",
-            "inactiveActionValue": "inactive",
-            "activeActionValue":   "active",
+        Status: &renderer.ResourceGridStatusConfig{
+            VerifyField:         "review_status",
+            ActiveField:         "status",
+            VerifiedValue:       "approved",
+            PendingValue:        "pending",
+            InactiveActionValue: "inactive",
+            ActiveActionValue:   "active",
         },
     }
 }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ BaseModule
   ├── Render
   │     └── typed UniversalRenderer page metadata
   │
-  └── MenuEntries
+  └── MenuItems
         └── navigation/config metadata
 ```
 
@@ -107,7 +107,7 @@ Frontend должен получать готовую схему и рендер
 | Страница просмотра записи | `BaseModule.Render.Record` |
 | Рабочий grid с create/update/delete/status | `BaseModule.Render.ResourceGrid` |
 | Legacy/detail groups | `ViewModuleAction.Extra` |
-| Пункты меню | `BaseModule.MenuEntries` |
+| Пункты меню | `BaseModule.MenuItems` |
 | Динамический список колонок по роли | `ColumnsFunc` или `Fields`/`RoleContext` |
 | Динамические фильтры по роли | `FilterFunc` |
 | Права на строки | `Where`, `RoleWhere`, `BeforeAction`, `DataCheckRule` |
@@ -432,23 +432,24 @@ func NewCoursesModule() *module.BaseModule {
 | `RoleJoin`       | `[]actions.RoleJoin`       | JOIN-ы по ролям                             |
 | `RoleBeforeHook` | `[]actions.RoleHook`       | Хуки до обработки по ролям                  |
 | `RoleAfterHook`  | `[]actions.RoleAfterHook`  | Хуки после обработки по ролям               |
-| `MenuEntries`    | `[]module.MenuEntry`       | Пункты левого меню для config endpoint      |
+| `MenuItems`      | `[]module.MenuItem`        | Пункты произвольных меню для config endpoint |
 
-#### MenuEntry
+#### MenuItem
 
-`MenuEntry` описывает пункт левого меню, возвращаемого config endpoint. Меню строится из `MenuEntries` всех модулей, фильтруется по `Roles` текущего пользователя и группируется по `Group`.
+`MenuItem` описывает пункт меню, возвращаемого config endpoint. Меню строятся из `MenuItems` всех модулей, фильтруются по `Roles` текущего пользователя и группируются по `Menu` и `Group`.
 
 ```go
-MenuEntries: []module.MenuEntry{
+MenuItems: []module.MenuItem{
     {
         ActionName: "list",         // имя действия модуля (list/view/…)
         Title:      "menu.catalog", // ключ i18n для заголовка пункта
         Icon:       "catalog",       // иконка (передаётся клиенту as-is)
         Show:       true,
         Order:      1,
+        Menu:       "sidebar",     // имя меню; по умолчанию sidebar
         Group:      "main",        // группа блока в левом меню
         Roles:      []actions.Role{"admin", "editor"},
-        CustomLink: "/catalog",     // переопределяет URL (вместо API-пути)
+        Target:     module.MenuTarget{Type: "route", URL: "/catalog", RouteKey: "/api/catalog"},
     },
 },
 ```
@@ -460,11 +461,22 @@ MenuEntries: []module.MenuEntry{
 | `Icon`        | `string`                   | Имя иконки (передаётся клиенту)                       |
 | `Show`        | `bool`                     | Показывать пункт (`false` — скрыт, но в features есть) |
 | `Order`       | `int`                      | Порядок внутри группы                                 |
+| `Menu`        | `string`                   | Имя меню (`sidebar`, `mobile_bottom`, `profile`, ...) |
 | `Group`       | `string`                   | Ключ группы (становится `blockTitle` в ответе)        |
+| `Target`      | `module.MenuTarget`        | Явное поведение пункта меню                           |
 | `Roles`       | `[]actions.Role`           | Роли, которым доступен пункт (пустой = все)           |
-| `CustomLink`  | `string`                   | Переопределяет URL (напр. SPA-маршрут `/catalog`)      |
-| `CustomQuery` | `map[string]interface{}`   | Доп. query-параметры для клиента                      |
-| `CustomData`  | `map[string]interface{}`   | Произвольные данные для клиента                       |
+| `Query`       | `map[string]interface{}`   | Доп. query-параметры для клиента                      |
+| `Data`        | `map[string]interface{}`   | Произвольные данные для клиента                       |
+
+`Target.Type` определяет поведение пункта:
+
+| Type | Обязательные поля | Назначение |
+|---|---|---|
+| `route` | `URL`, `RouteKey` | Переход на frontend route и загрузка renderer/query из `routes[route_key]`. |
+| `widget` | `Name` | Открытие клиентского виджета, например `chat`. |
+| `modal` | `Name` | Открытие клиентского popup/modal. |
+| `action` | `Name` | Выполнение клиентского действия. |
+| `external` | `URL` | Переход на внешний URL. |
 
 ### Этап 5. Описание полей (ModuleField)
 
@@ -1259,30 +1271,47 @@ type TranslationContext struct {
 | `GET` | `/admin/api/lang`         | Список поддерживаемых языков          |
 | `GET` | `/admin/api/lang/:key`    | Все переводы для языка                |
 | `GET` | `/admin/api/openapi.json` | OpenAPI 3.0 спецификация              |
-| `GET` | `<path>/config`           | Клиентский конфиг: левое меню по ролям   |
+| `GET` | `<path>/config`           | Клиентский конфиг: меню, routes и роль   |
 
 ### Config endpoint
 
-Возвращает конфигурацию для клиентского приложения. Меню фильтруется по роли текущего пользователя.
+Возвращает конфигурацию для клиентского приложения. Все меню фильтруются по роли текущего пользователя.
 
 **Query-параметры:** `lang` — код языка для перевода заголовков блоков меню.
 
 **Пример ответа:**
 ```json
 {
-  "left_menu": [
-    {
-      "blockTitle": "Catalog",
-      "elements": [
-        {
-          "url": "/catalog",
-          "title": "Catalog",
-          "icon": "catalog"
-        }
-      ]
+  "menus": {
+    "sidebar": [
+      {
+        "blockTitle": "Catalog",
+        "elements": [
+          {
+            "id": "sidebar.catalog.list",
+            "target": {
+              "type": "route",
+              "url": "/catalog",
+              "route_key": "/api/catalog"
+            },
+            "title": "Catalog",
+            "icon": "catalog",
+            "order": 10,
+            "group": "main"
+          }
+        ]
+      }
+    ]
+  },
+  "routes": {
+    "/api/catalog": {
+      "query": {
+        "url": "/api/api/catalog",
+        "method": "GET"
+      }
     }
-  ]
+  }
 }
 ```
 
-Меню строится из `MenuEntries` каждого `BaseModule`. Пункты группируются по `Group`, сортируются по `Order`. `blockTitle` — переведённый `Title` первого пункта группы (ключ i18n).
+Меню строится из `MenuItems` каждого `BaseModule`. Пункты группируются по `Menu` и `Group`, сортируются по `Order`. Для `target.type=route` поле `route_key` связывает пункт меню с записью в `routes`. Для popup/widget/action route не требуется. `left_menu` может присутствовать как legacy alias для `menus.sidebar`, но новые клиенты должны использовать `menus`.

--- a/changelog.md
+++ b/changelog.md
@@ -4,11 +4,11 @@
 
 ### Added
 
-- **`MenuEntry` на `BaseModule`** — декларативное описание пунктов левого меню для config endpoint.
-  Поля: `ActionName`, `Title`, `Icon`, `Show`, `Order`, `Group`, `Roles`, `CustomLink`, `CustomQuery`, `CustomData`.
+- **`MenuItem` на `BaseModule`** — декларативное описание пунктов произвольных меню для config endpoint.
+  Поля: `ActionName`, `Title`, `Icon`, `Show`, `Order`, `Menu`, `Group`, `Roles`, `URL`, `RouteKey`, `Query`, `Data`.
 
-- **Config endpoint** — возвращает клиентский конфиг с role-based левым меню (`left_menu`).
-  Меню формируется из `MenuEntries` каждого модуля, группируется по `Group`, фильтруется по `Roles` текущего пользователя.
+- **Config endpoint** — возвращает клиентский конфиг с role-based меню (`menus`) и явным соответствием `route_key -> routes`.
+  Меню формируется из `MenuItems` каждого модуля, группируется по `Menu` и `Group`, фильтруется по `Roles` текущего пользователя.
   Заголовки блоков переводятся через i18n (lang из query-параметра или `Accept-Language`).
 
 - **`ExtraFunc` на `ListModuleAction`** — динамические extra-данные per-request.

--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -14,24 +14,28 @@ import (
 
 // ConfigResponse структурирует ответ эндпоинта /api/config
 type ConfigResponse struct {
-	LeftMenu []LeftMenuBlock        `json:"left_menu"`
+	Menus    map[string][]MenuBlock `json:"menus"`
+	LeftMenu []MenuBlock            `json:"left_menu,omitempty"`
 	Routes   map[string]RouteConfig `json:"routes"`
 	Role     string                 `json:"role"`
 }
 
-// LeftMenuItem представляет один пункт меню
-type LeftMenuItem struct {
-	URL   string                 `json:"url"`
-	Title string                 `json:"title"`
-	Icon  string                 `json:"icon,omitempty"`
-	Query map[string]interface{} `json:"query,omitempty"`
-	Data  map[string]interface{} `json:"data,omitempty"`
+// ConfigMenuItem представляет один пункт меню в клиентском конфиге.
+type ConfigMenuItem struct {
+	ID     string                 `json:"id,omitempty"`
+	Target MenuTarget             `json:"target"`
+	Title  string                 `json:"title"`
+	Icon   string                 `json:"icon,omitempty"`
+	Order  int                    `json:"order,omitempty"`
+	Group  string                 `json:"group,omitempty"`
+	Query  map[string]interface{} `json:"query,omitempty"`
+	Data   map[string]interface{} `json:"data,omitempty"`
 }
 
-// LeftMenuBlock представляет блок левого меню
-type LeftMenuBlock struct {
-	BlockTitle string         `json:"blockTitle"`
-	Elements   []LeftMenuItem `json:"elements"`
+// MenuBlock представляет сгруппированный блок меню.
+type MenuBlock struct {
+	BlockTitle string           `json:"blockTitle"`
+	Elements   []ConfigMenuItem `json:"elements"`
 }
 
 // RouteConfig конфигурирует маршрут
@@ -74,12 +78,12 @@ func (generator *Generator) actionConfigEndpoint() gin.HandlerFunc {
 			moduleAvailable := false
 			var accessibleActions []actions.ModuleAction
 
-			for _, menuEntry := range module.MenuEntries {
-				if !menuEntry.Show {
+			for _, menuItem := range moduleMenuItems(module) {
+				if !menuItem.Show {
 					continue
 				}
 				for _, action := range module.Actions {
-					if string(action.Action()) == menuEntry.ActionName {
+					if string(action.Action()) == menuItem.ActionName {
 						if hasPermission(action, role) {
 							moduleAvailable = true
 							accessibleActions = append(accessibleActions, action)
@@ -95,7 +99,8 @@ func (generator *Generator) actionConfigEndpoint() gin.HandlerFunc {
 			}
 		}
 
-		leftMenu := generator.buildLeftMenu(availableModules, moduleActions, role, lang)
+		menus := generator.buildMenus(availableModules, moduleActions, role, lang)
+		leftMenu := menus["sidebar"]
 		routes, err := generator.buildRoutes(c, availableModules, moduleActions, role)
 		if err != nil {
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
@@ -103,6 +108,7 @@ func (generator *Generator) actionConfigEndpoint() gin.HandlerFunc {
 		}
 
 		config := ConfigResponse{
+			Menus:    menus,
 			LeftMenu: leftMenu,
 			Routes:   routes,
 			Role:     role,
@@ -154,20 +160,68 @@ func hasPermission(action actions.ModuleAction, role string) bool {
 	return false
 }
 
-// buildLeftMenu формирует левое меню с группировкой по Group
-func (generator *Generator) buildLeftMenu(
+func moduleMenuItems(module *BaseModule) []MenuItem {
+	return module.MenuItems
+}
+
+func menuRouteKey(module *BaseModule, entry MenuItem) string {
+	if entry.Target.RouteKey != "" {
+		return entry.Target.RouteKey
+	}
+	return module.Path + "/" + module.Name
+}
+
+func menuURL(module *BaseModule, entry MenuItem) string {
+	if entry.Target.URL != "" {
+		return entry.Target.URL
+	}
+	return menuRouteKey(module, entry)
+}
+
+func menuName(entry MenuItem) string {
+	if entry.Menu != "" {
+		return entry.Menu
+	}
+	return "sidebar"
+}
+
+func menuTarget(module *BaseModule, entry MenuItem) MenuTarget {
+	target := entry.Target
+	if target.Type == "" {
+		target.Type = "route"
+	}
+	if target.Type == "route" {
+		if target.URL == "" {
+			target.URL = menuURL(module, entry)
+		}
+		if target.RouteKey == "" {
+			target.RouteKey = menuRouteKey(module, entry)
+		}
+	}
+	return target
+}
+
+func menuItemID(module *BaseModule, entry MenuItem) string {
+	if entry.Menu != "" || entry.Group != "" || entry.ActionName != "" {
+		return menuName(entry) + "." + module.Name + "." + entry.ActionName
+	}
+	return module.Name
+}
+
+// buildMenus формирует произвольные меню с группировкой по Menu и Group.
+func (generator *Generator) buildMenus(
 	availableModules map[string]*BaseModule,
 	moduleActions map[string][]actions.ModuleAction,
 	role string,
 	lang locale.Lang,
-) []LeftMenuBlock {
+) map[string][]MenuBlock {
 	type menuEntryWithModule struct {
-		entry  MenuEntry
+		entry  MenuItem
 		module *BaseModule
 	}
 
-	grouped := make(map[string][]menuEntryWithModule)
-	groupOrder := make(map[string]int)
+	grouped := make(map[string]map[string][]menuEntryWithModule)
+	groupOrder := make(map[string]map[string]int)
 
 	for _, module := range availableModules {
 		actionMap := make(map[string]bool)
@@ -175,7 +229,7 @@ func (generator *Generator) buildLeftMenu(
 			actionMap[string(action.Action())] = true
 		}
 
-		for _, entry := range module.MenuEntries {
+		for _, entry := range moduleMenuItems(module) {
 			if !entry.Show {
 				continue
 			}
@@ -201,73 +255,83 @@ func (generator *Generator) buildLeftMenu(
 			if group == "" {
 				group = "default"
 			}
+			menu := menuName(entry)
 
-			grouped[group] = append(grouped[group], menuEntryWithModule{
+			if grouped[menu] == nil {
+				grouped[menu] = make(map[string][]menuEntryWithModule)
+			}
+			if groupOrder[menu] == nil {
+				groupOrder[menu] = make(map[string]int)
+			}
+
+			grouped[menu][group] = append(grouped[menu][group], menuEntryWithModule{
 				entry:  entry,
 				module: module,
 			})
 
-			if _, exists := groupOrder[group]; !exists {
-				groupOrder[group] = entry.Order
-			} else if entry.Order < groupOrder[group] {
-				groupOrder[group] = entry.Order
+			if _, exists := groupOrder[menu][group]; !exists {
+				groupOrder[menu][group] = entry.Order
+			} else if entry.Order < groupOrder[menu][group] {
+				groupOrder[menu][group] = entry.Order
 			}
 		}
 	}
 
+	result := make(map[string][]MenuBlock)
 	type groupInfo struct {
 		name  string
 		order int
 	}
-	var groups []groupInfo
-	for name, order := range groupOrder {
-		groups = append(groups, groupInfo{name: name, order: order})
-	}
-	sort.Slice(groups, func(i, j int) bool {
-		return groups[i].order < groups[j].order
-	})
-
-	var result []LeftMenuBlock
-	for _, group := range groups {
-		entries := grouped[group.name]
-
-		sort.Slice(entries, func(i, j int) bool {
-			return entries[i].entry.Order < entries[j].entry.Order
+	for menu, orderByGroup := range groupOrder {
+		var groups []groupInfo
+		for name, order := range orderByGroup {
+			groups = append(groups, groupInfo{name: name, order: order})
+		}
+		sort.Slice(groups, func(i, j int) bool {
+			return groups[i].order < groups[j].order
 		})
 
-		blockTitle := group.name
-		if title, exists := generator.GroupTitles[group.name]; exists {
-			blockTitle = title
-		}
+		for _, group := range groups {
+			entries := grouped[menu][group.name]
 
-		var elements []LeftMenuItem
-		for _, item := range entries {
-			entry := item.entry
-			menuItem := LeftMenuItem{
-				Title: generator.Translate(lang, entry.Title),
-				Icon:  entry.Icon,
-			}
-
-			if entry.CustomLink != "" {
-				menuItem.URL = entry.CustomLink
-			} else {
-				menuItem.URL = item.module.Path + "/" + item.module.Name
-			}
-			if entry.CustomQuery != nil {
-				menuItem.Query = entry.CustomQuery
-			}
-			if entry.CustomData != nil {
-				menuItem.Data = entry.CustomData
-			}
-
-			elements = append(elements, menuItem)
-		}
-
-		if len(elements) > 0 {
-			result = append(result, LeftMenuBlock{
-				BlockTitle: blockTitle,
-				Elements:   elements,
+			sort.Slice(entries, func(i, j int) bool {
+				return entries[i].entry.Order < entries[j].entry.Order
 			})
+
+			blockTitle := group.name
+			if title, exists := generator.GroupTitles[group.name]; exists {
+				blockTitle = title
+			}
+
+			var elements []ConfigMenuItem
+			for _, item := range entries {
+				entry := item.entry
+				target := menuTarget(item.module, entry)
+				menuItem := ConfigMenuItem{
+					ID:     menuItemID(item.module, entry),
+					Title:  generator.Translate(lang, entry.Title),
+					Icon:   entry.Icon,
+					Target: target,
+					Order:  entry.Order,
+					Group:  group.name,
+				}
+
+				if entry.Query != nil {
+					menuItem.Query = entry.Query
+				}
+				if entry.Data != nil {
+					menuItem.Data = entry.Data
+				}
+
+				elements = append(elements, menuItem)
+			}
+
+			if len(elements) > 0 {
+				result[menu] = append(result[menu], MenuBlock{
+					BlockTitle: blockTitle,
+					Elements:   elements,
+				})
+			}
 		}
 	}
 
@@ -383,7 +447,7 @@ func (generator *Generator) buildAddRoute(module *BaseModule, render renderer.Un
 func (generator *Generator) buildRouteActions(module *BaseModule, role string) []map[string]interface{} {
 	var result []map[string]interface{}
 
-	for _, entry := range module.MenuEntries {
+	for _, entry := range moduleMenuItems(module) {
 		for _, action := range module.Actions {
 			if string(action.Action()) != entry.ActionName {
 				continue
@@ -399,11 +463,11 @@ func (generator *Generator) buildRouteActions(module *BaseModule, role string) [
 				"show":  entry.Show,
 			}
 
-			if entry.CustomQuery != nil {
-				actionMap["query"] = entry.CustomQuery
+			if entry.Query != nil {
+				actionMap["query"] = entry.Query
 			}
-			if entry.CustomData != nil {
-				actionMap["data"] = entry.CustomData
+			if entry.Data != nil {
+				actionMap["data"] = entry.Data
 			}
 
 			result = append(result, actionMap)

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -533,6 +533,14 @@ Actions используются в `card_schema.actions`, `record_page.actions`
   "appearance": "outline",
   "visible_if": {"path": "record.status", "equals": "active"},
   "disabled_if": {"path": "record.locked", "equals": true},
+  "endpoint": "/entities/:id/action",
+  "method": "post",
+  "uniqueEndpoint": "/entities/view/slug/:slug",
+  "afterRoute": {
+    "path": "/entities/:id",
+    "queryParam": "record",
+    "source": "id"
+  },
   "route": {
     "path": "/entities/:id",
     "params": {"id": "record.id"},
@@ -849,6 +857,5 @@ Legacy forms:
 - `display` как string вместо object, например `"display": "badge"`;
 - `{"path": "...", "not": true}` вместо `{"not": {"path": "...", "truthy": true}}`;
 - `external: true` action without explicit `type`;
-- application-specific route fields such as `uniqueEndpoint` and `afterRoute` in `resource_grid_page`.
 
 `response.extra` остается deprecated escape hatch для старых модулей и application-specific данных вне UniversalRenderer. Новые producer modules должны описывать UniversalRenderer metadata через typed `BaseModule.Render renderer.Universal`, а request-generator должен отдавать canonical top-level `renderer` + page metadata fields.

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -587,6 +587,19 @@ Supported `action.type`:
 
 `external: true` является legacy shorthand для action, который текущий webapp обрабатывает вне generic action executor. Для новых producer-сервисов предпочтительно использовать `type`.
 
+## Typed Renderer Tokens
+
+Producer code must build UniversalRenderer metadata with typed renderer structs and token types, not by assembling ad-hoc `map[string]interface{}` trees or stringly typed renderer fields.
+
+Core renderer package owns only stable universal values:
+
+- renderer keys: `RendererUniversalDisplay`, `RendererUniversalSection`, `RendererUniversalFilters`, `RendererUniversalPagination`, `RendererMediaGallery`, `RendererCollectionManager`;
+- record layout slots: `LayoutSlotLeft`, `LayoutSlotCenter`, `LayoutSlotRight`;
+- display component types: `DisplayMediaGallery`, `DisplayActions`, `DisplayIdentity`, `DisplayStatList`, `DisplayDataList`, `DisplayBadgeList`, `DisplayRateGroups`, `DisplayAccordionGroups`;
+- generic tokens: spacing, inset, radius, alignment, semantic tones, separator appearance.
+
+Application-specific values, especially visual color names such as `cyan`, `violet`, `magenta`, shell variants, section IDs, business IDs and translation keys, must be declared by the application as typed constants when reused. The renderer package should not try to maintain every project's color or shell catalog.
+
 ## Conditions
 
 `visible_if`, `hidden_if`, `disabled_if` и похожие condition fields используют один grammar.

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -243,22 +243,31 @@ Closed enums должны использовать typed constants из package 
 
 ```json
 {
-  "left_menu": [
-    {
-      "blockTitle": "navigation.main",
-      "elements": [
-        {
-          "url": "/entities",
-          "title": "entities.menu.list",
-          "icon": "list",
-          "query": {},
-          "data": {}
-        }
-      ]
-    }
-  ],
+  "menus": {
+    "sidebar": [
+      {
+        "blockTitle": "navigation.main",
+        "elements": [
+          {
+            "id": "sidebar.entities.list",
+            "target": {
+              "type": "route",
+              "url": "/entities",
+              "route_key": "/api/entities"
+            },
+            "title": "entities.menu.list",
+            "icon": "list",
+            "order": 10,
+            "group": "navigation.main",
+            "query": {},
+            "data": {}
+          }
+        ]
+      }
+    ]
+  },
   "routes": {
-    "/entities": {
+    "/api/entities": {
       "title": "entities.routes.list",
       "menuTitle": "entities.menu.list",
       "renderer": {
@@ -282,9 +291,15 @@ Closed enums должны использовать typed constants из package 
 
 | Path | Назначение |
 |------|------------|
-| `left_menu[]` | Группы навигации. |
-| `left_menu[].elements[]` | Пункты меню. |
-| `routes` | Map route config, где ключ это frontend path. |
+| `menus` | Map меню, где ключ это имя меню (`sidebar`, `mobile_bottom`, `profile`, ...). |
+| `menus[name][]` | Группы пунктов конкретного меню. |
+| `menus[name][].elements[]` | Пункты меню. |
+| `menus[name][].elements[].target` | Поведение пункта меню. |
+| `menus[name][].elements[].target.type` | Тип поведения: `route`, `widget`, `modal`, `action`, `external`, `submenu`. |
+| `menus[name][].elements[].target.url` | Frontend URL для `route` или внешний URL для `external`. |
+| `menus[name][].elements[].target.route_key` | Ключ в `routes` для `target.type=route`. |
+| `menus[name][].elements[].target.name` | Имя widget/modal/action. |
+| `routes` | Map route config, где ключ совпадает с `route_key` из пункта меню. |
 | `routes[path].renderer` | Renderer identity/version для route discovery, если route использует typed `BaseModule.Render`. |
 | `routes[path].page_type` | Тип страницы: `list`, `form`, `record`, `resource_grid`. |
 | `routes[path].query` | Endpoint и method для загрузки данных route. |

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -105,7 +105,7 @@ RenderFunc: func(c *gin.Context, base renderer.Universal) (renderer.Universal, e
 
 `Render` задает базовую статическую схему. `RenderFunc` является optional typed runtime override/merge и вызывается request-generator через `RenderFor(c)` перед построением `/api/config`, list, defrec и view responses. В `RenderFunc` передается deep clone базового `Render`, поэтому producer module может безопасно менять pointer structs, slices, maps и стандартные JSON-like значения внутри `interface{}` (`map[string]interface{}`, `[]interface{}`, `map[string]string`, `[]string` и т.п.) без протекания state в следующие запросы. Произвольные custom objects внутри `interface{}` не клонируются и остаются ответственностью producer module. Результат `RenderFunc` остается `renderer.Universal` и валидируется через `Validate()` уже после runtime изменений. Legacy `ExtraFunc` не должен использоваться для canonical UniversalRenderer metadata.
 
-Closed enums должны использовать typed constants из package `renderer`. `map[string]interface{}` допустим только в явно typed extension/context/payload полях (`Extra`, `Context`, `Payload`, `Query`, `Status` и т.п.), где metadata заранее является application-specific extension или transport payload.
+Closed enums должны использовать typed constants из package `renderer`. `map[string]interface{}` допустим только в явно typed runtime/transport полях (`Context`, `Payload`, `Query`, route query и т.п.), где содержимое является данными запроса или состоянием выполнения, а не схемой UI. Если producer-у нужен новый UI metadata block, он должен быть добавлен в typed renderer contract, а не передан через ad-hoc map.
 
 ### List Response
 
@@ -662,14 +662,14 @@ Conditions отвечают только за отображение. Любое
     },
     "card": {"type": "entity", "size": "md"},
     "status": {"activeField": "status"},
-    "actions": {},
-    "text": {},
+    "actions": {"editRoute": {"path": "/entities/:id"}},
+    "text": {"title": "entities.title"},
     "context": {}
   }
 }
 ```
 
-`resource_grid_page.actions`, `resource_grid_page.text` и `resource_grid_page.context` предназначены для reusable resource management screens: route/action wiring, translation keys and runtime context.
+`resource_grid_page.list`, `resource_grid_page.status`, `resource_grid_page.actions` и `resource_grid_page.text` являются typed renderer contract. `resource_grid_page.context` предназначен только для runtime state, который не описывает структуру UI.
 
 ## Form Page
 
@@ -728,8 +728,20 @@ Conditions отвечают только за отображение. Любое
         "components": []
       }
     ],
-    "display_data": {},
-    "theme": {},
+    "display_data": {
+      "gallery": {"items": [], "current": 0},
+      "hero": {"identity": {}, "stats": []},
+      "details": {"items": []}
+    },
+    "theme": {
+      "profile": {
+        "panels": {},
+        "headings": {},
+        "badges": {},
+        "buttons": {},
+        "avatar": {}
+      }
+    },
     "actions": [],
     "context": {}
   }

--- a/module.go
+++ b/module.go
@@ -8,17 +8,26 @@ import (
 	pg "github.com/go-jet/jet/v2/postgres"
 )
 
-type MenuEntry struct {
-	ActionName  string                 `json:"action"`
-	Title       string                 `json:"title"`
-	Icon        string                 `json:"icon,omitempty"`
-	Show        bool                   `json:"show"`
-	Order       int                    `json:"order"`
-	Group       string                 `json:"group"`
-	Roles       []actions.Role         `json:"roles,omitempty"`
-	CustomLink  string                 `json:"custom_link,omitempty"`
-	CustomQuery map[string]interface{} `json:"custom_query,omitempty"`
-	CustomData  map[string]interface{} `json:"custom_data,omitempty"`
+type MenuItem struct {
+	ActionName string                 `json:"action"`
+	Title      string                 `json:"title"`
+	Icon       string                 `json:"icon,omitempty"`
+	Show       bool                   `json:"show"`
+	Order      int                    `json:"order"`
+	Group      string                 `json:"group"`
+	Menu       string                 `json:"menu,omitempty"`
+	Target     MenuTarget             `json:"target,omitempty"`
+	Roles      []actions.Role         `json:"roles,omitempty"`
+	Query      map[string]interface{} `json:"query,omitempty"`
+	Data       map[string]interface{} `json:"data,omitempty"`
+}
+
+type MenuTarget struct {
+	Type     string                 `json:"type"`
+	URL      string                 `json:"url,omitempty"`
+	RouteKey string                 `json:"route_key,omitempty"`
+	Name     string                 `json:"name,omitempty"`
+	Params   map[string]interface{} `json:"params,omitempty"`
 }
 
 type RenderFunc func(c *gin.Context, base renderer.Universal) (renderer.Universal, error)
@@ -38,7 +47,7 @@ type BaseModule struct {
 	RoleBeforeHook []actions.RoleHook         `json:"-"`
 	RoleAfterHook  []actions.RoleAfterHook    `json:"-"`
 	EntityName     string                     `json:"-"`
-	MenuEntries    []MenuEntry                `json:"menu_entries,omitempty"`
+	MenuItems      []MenuItem                 `json:"menu_items,omitempty"`
 	Render         renderer.Universal         `json:"-"`
 	RenderFunc     RenderFunc                 `json:"-"`
 }

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -322,6 +322,7 @@ func cloneActionValue(v Action) Action {
 	v.VisibleIf = cloneCondition(v.VisibleIf)
 	v.HiddenIf = cloneCondition(v.HiddenIf)
 	v.DisabledIf = cloneCondition(v.DisabledIf)
+	v.AfterRoute = cloneRouteValue(v.AfterRoute)
 	v.Route = cloneRouteValue(v.Route)
 	v.API = cloneAPIAction(v.API)
 	v.Modal = cloneModalAction(v.Modal)

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -382,15 +382,6 @@ func cloneRecordDisplayData(v *RecordDisplayData) *RecordDisplayData {
 		services.Groups = cloneSlice(v.Services.Groups)
 		cp.Services = &services
 	}
-	if v.Tours != nil {
-		tours := *v.Tours
-		tours.Cards = cloneSlice(v.Tours.Cards)
-		if v.Tours.MakeTourButton != nil {
-			button := *v.Tours.MakeTourButton
-			tours.MakeTourButton = &button
-		}
-		cp.Tours = &tours
-	}
 	if v.Contacts != nil {
 		contacts := *v.Contacts
 		contacts.Items = cloneSlice(v.Contacts.Items)

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -44,13 +44,33 @@ func cloneRecordPage(v *RecordPage) *RecordPage {
 	}
 	cp := *v
 	cp.ShowHeader = clonePtr(v.ShowHeader)
-	cp.Navigation = cloneMap(v.Navigation)
+	cp.Navigation = cloneRecordNavigation(v.Navigation)
 	cp.Layout = cloneLayout(v.Layout)
 	cp.Sections = cloneRecordSections(v.Sections)
-	cp.DisplayData = cloneMap(v.DisplayData)
-	cp.Theme = cloneMap(v.Theme)
+	cp.DisplayData = cloneRecordDisplayData(v.DisplayData)
+	cp.Theme = cloneRecordTheme(v.Theme)
 	cp.Actions = cloneActions(v.Actions)
 	cp.Context = cloneMap(v.Context)
+	return &cp
+}
+
+func cloneRecordNavigation(v *RecordNavigation) *RecordNavigation {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	return &cp
+}
+
+func cloneRecordTheme(v *RecordTheme) *RecordTheme {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	if v.Profile != nil {
+		profile := *v.Profile
+		cp.Profile = &profile
+	}
 	return &cp
 }
 
@@ -59,15 +79,43 @@ func cloneResourceGridPage(v *ResourceGridPage) *ResourceGridPage {
 		return nil
 	}
 	cp := *v
-	cp.List = cloneMap(v.List)
+	cp.List = cloneResourceGridListConfig(v.List)
 	cp.Create = cloneAction(v.Create)
 	cp.Delete = cloneAction(v.Delete)
 	cp.Update = cloneAction(v.Update)
 	cp.Card = cloneCardSchema(v.Card)
-	cp.Status = cloneMap(v.Status)
-	cp.Actions = cloneMap(v.Actions)
+	cp.Status = cloneResourceGridStatusConfig(v.Status)
+	cp.Actions = cloneResourceGridActionsConfig(v.Actions)
 	cp.Text = cloneMap(v.Text)
 	cp.Context = cloneMap(v.Context)
+	return &cp
+}
+
+func cloneResourceGridListConfig(v *ResourceGridListConfig) *ResourceGridListConfig {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.Filters = cloneMap(v.Filters)
+	return &cp
+}
+
+func cloneResourceGridStatusConfig(v *ResourceGridStatusConfig) *ResourceGridStatusConfig {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.DraftValues = cloneSlice(v.DraftValues)
+	cp.PendingPayload = cloneInterface(v.PendingPayload)
+	return &cp
+}
+
+func cloneResourceGridActionsConfig(v *ResourceGridActionsConfig) *ResourceGridActionsConfig {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.EditRoute = cloneRouteValue(v.EditRoute)
 	return &cp
 }
 
@@ -97,18 +145,18 @@ func cloneFilters(v *Filters) *Filters {
 	return &cp
 }
 
-func cloneMapRows(values [][]map[string]interface{}) [][]map[string]interface{} {
+func cloneMapRows(values [][]FilterPill) [][]FilterPill {
 	if values == nil {
 		return nil
 	}
-	out := make([][]map[string]interface{}, len(values))
+	out := make([][]FilterPill, len(values))
 	for i, row := range values {
 		if row == nil {
 			continue
 		}
-		out[i] = make([]map[string]interface{}, len(row))
+		out[i] = make([]FilterPill, len(row))
 		for j, item := range row {
-			out[i][j] = cloneMap(item)
+			out[i][j] = item
 		}
 	}
 	return out
@@ -191,10 +239,19 @@ func cloneBadges(values []Badge) []Badge {
 		out[i] = v
 		out[i].Marker = clonePtr(v.Marker)
 		out[i].ToneMap = cloneMap(v.ToneMap)
-		out[i].Then = cloneMap(v.Then)
-		out[i].Else = cloneMap(v.Else)
+		out[i].Then = cloneBadgeState(v.Then)
+		out[i].Else = cloneBadgeState(v.Else)
 	}
 	return out
+}
+
+func cloneBadgeState(v *BadgeState) *BadgeState {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.Marker = clonePtr(v.Marker)
+	return &cp
 }
 
 func cloneStatusBinding(v *StatusBinding) *StatusBinding {
@@ -229,10 +286,117 @@ func cloneFormSections(values []FormSection) []FormSection {
 		out[i].Block = cloneBlock(v.Block)
 		out[i].Fields = cloneSlice(v.Fields)
 		out[i].ListPage = cloneListPage(v.ListPage)
-		out[i].Collection = cloneMap(v.Collection)
-		out[i].Preferences = cloneMap(v.Preferences)
+		out[i].Collection = cloneCollectionConfig(v.Collection)
+		out[i].Preferences = clonePreferencesConfig(v.Preferences)
 	}
 	return out
+}
+
+func cloneCollectionConfig(v *CollectionConfig) *CollectionConfig {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.Collections = cloneSlice(v.Collections)
+	cp.Modal = cloneCollectionModal(v.Modal)
+	return &cp
+}
+
+func cloneCollectionModal(v *CollectionModal) *CollectionModal {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	return &cp
+}
+
+func clonePreferencesConfig(v *PreferencesConfig) *PreferencesConfig {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.Channels = cloneSlice(v.Channels)
+	cp.Blocks = cloneSlice(v.Blocks)
+	cp.ConnectionPrompts = cloneSlice(v.ConnectionPrompts)
+	return &cp
+}
+
+func cloneRecordDisplayData(v *RecordDisplayData) *RecordDisplayData {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	if v.Gallery != nil {
+		gallery := *v.Gallery
+		gallery.Items = cloneSlice(v.Gallery.Items)
+		gallery.Actions = cloneSlice(v.Gallery.Actions)
+		gallery.Overlays = cloneSlice(v.Gallery.Overlays)
+		cp.Gallery = &gallery
+	}
+	if v.Hero != nil {
+		hero := *v.Hero
+		if v.Hero.Identity != nil {
+			identity := *v.Hero.Identity
+			if v.Hero.Identity.Avatar != nil {
+				avatar := *v.Hero.Identity.Avatar
+				identity.Avatar = &avatar
+			}
+			identity.CornerBadges = cloneSlice(v.Hero.Identity.CornerBadges)
+			if v.Hero.Identity.Location != nil {
+				location := *v.Hero.Identity.Location
+				identity.Location = &location
+			}
+			hero.Identity = &identity
+		}
+		hero.Stats = cloneSlice(v.Hero.Stats)
+		cp.Hero = &hero
+	}
+	if v.Details != nil {
+		details := *v.Details
+		details.Items = cloneSlice(v.Details.Items)
+		details.Commercial = cloneSlice(v.Details.Commercial)
+		cp.Details = &details
+	}
+	if v.About != nil {
+		about := *v.About
+		cp.About = &about
+	}
+	if v.Meetings != nil {
+		meetings := *v.Meetings
+		meetings.Items = cloneSlice(v.Meetings.Items)
+		meetings.Commission = cloneSlice(v.Meetings.Commission)
+		meetings.WorkArea = cloneSlice(v.Meetings.WorkArea)
+		meetings.Payments = cloneSlice(v.Meetings.Payments)
+		cp.Meetings = &meetings
+	}
+	if v.Rates != nil {
+		rates := *v.Rates
+		rates.Items = cloneSlice(v.Rates.Items)
+		rates.Groups = cloneSlice(v.Rates.Groups)
+		cp.Rates = &rates
+	}
+	if v.Services != nil {
+		services := *v.Services
+		services.Included = cloneSlice(v.Services.Included)
+		services.Extra = cloneSlice(v.Services.Extra)
+		services.Groups = cloneSlice(v.Services.Groups)
+		cp.Services = &services
+	}
+	if v.Tours != nil {
+		tours := *v.Tours
+		tours.Cards = cloneSlice(v.Tours.Cards)
+		if v.Tours.MakeTourButton != nil {
+			button := *v.Tours.MakeTourButton
+			tours.MakeTourButton = &button
+		}
+		cp.Tours = &tours
+	}
+	if v.Contacts != nil {
+		contacts := *v.Contacts
+		contacts.Items = cloneSlice(v.Contacts.Items)
+		cp.Contacts = &contacts
+	}
+	return &cp
 }
 
 func cloneRecordSections(values []RecordSection) []RecordSection {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -77,9 +77,9 @@ type Layout struct {
 	Type     LayoutType   `json:"type,omitempty"`
 	Mode     string       `json:"mode,omitempty"`
 	Slots    []string     `json:"slots,omitempty"`
-	Left     string       `json:"left,omitempty"`
-	Center   string       `json:"center,omitempty"`
-	Right    string       `json:"right,omitempty"`
+	Left     SizeToken    `json:"left,omitempty"`
+	Center   SizeToken    `json:"center,omitempty"`
+	Right    SizeToken    `json:"right,omitempty"`
 	Align    AlignToken   `json:"align,omitempty"`
 	MaxWidth MaxWidth     `json:"max_width,omitempty"`
 	Gap      SpacingToken `json:"gap,omitempty"`

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -86,7 +86,7 @@ type Layout struct {
 }
 
 type Filters struct {
-	Renderer          string                     `json:"renderer,omitempty"`
+	Renderer          RendererKey                `json:"renderer,omitempty"`
 	Enabled           bool                       `json:"enabled"`
 	PrimaryPlacement  string                     `json:"primary_placement,omitempty"`
 	SecondaryEnabled  *bool                      `json:"secondary_enabled,omitempty"`
@@ -111,7 +111,7 @@ type Grid struct {
 }
 
 type Pagination struct {
-	Renderer string         `json:"renderer,omitempty"`
+	Renderer RendererKey    `json:"renderer,omitempty"`
 	Mode     PaginationMode `json:"mode,omitempty"`
 }
 
@@ -159,16 +159,16 @@ type CardSchema struct {
 }
 
 type Media struct {
-	Field        string     `json:"field,omitempty"`
-	Renderer     string     `json:"renderer,omitempty"`
-	Ratio        MediaRatio `json:"ratio,omitempty"`
-	Size         MediaSize  `json:"size,omitempty"`
-	Variant      string     `json:"variant,omitempty"`
-	GlowField    string     `json:"glow_field,omitempty"`
-	GlowFallback string     `json:"glow_fallback,omitempty"`
-	GlowEnabled  *bool      `json:"glow_enabled,omitempty"`
-	StatusField  string     `json:"status_field,omitempty"`
-	Fallback     string     `json:"fallback,omitempty"`
+	Field        string      `json:"field,omitempty"`
+	Renderer     RendererKey `json:"renderer,omitempty"`
+	Ratio        MediaRatio  `json:"ratio,omitempty"`
+	Size         MediaSize   `json:"size,omitempty"`
+	Variant      string      `json:"variant,omitempty"`
+	GlowField    string      `json:"glow_field,omitempty"`
+	GlowFallback string      `json:"glow_fallback,omitempty"`
+	GlowEnabled  *bool       `json:"glow_enabled,omitempty"`
+	StatusField  string      `json:"status_field,omitempty"`
+	Fallback     string      `json:"fallback,omitempty"`
 }
 
 type TextBinding struct {
@@ -231,7 +231,7 @@ type FormSection struct {
 	Title       string                 `json:"title,omitempty"`
 	PanelTitle  string                 `json:"panel_title,omitempty"`
 	Subtitle    string                 `json:"subtitle,omitempty"`
-	Renderer    string                 `json:"renderer,omitempty"`
+	Renderer    RendererKey            `json:"renderer,omitempty"`
 	Group       string                 `json:"group,omitempty"`
 	GroupTitle  string                 `json:"group_title,omitempty"`
 	Icon        string                 `json:"icon,omitempty"`
@@ -245,59 +245,59 @@ type FormSection struct {
 }
 
 type Block struct {
-	Type           BlockType    `json:"type,omitempty"`
-	Variant        BlockVariant `json:"variant,omitempty"`
-	TitleDecor     string       `json:"title_decor,omitempty"`
-	TitleBar       string       `json:"title_bar,omitempty"`
-	TitleUnderline string       `json:"title_underline,omitempty"`
-	Inset          string       `json:"inset,omitempty"`
-	MaxWidth       string       `json:"max_width,omitempty"`
-	BodyClass      string       `json:"body_class,omitempty"`
-	BorderStyle    string       `json:"border_style,omitempty"`
-	HoverEnabled   *bool        `json:"hover_enabled,omitempty"`
-	Effect         string       `json:"effect,omitempty"`
+	Type           BlockType       `json:"type,omitempty"`
+	Variant        BlockVariant    `json:"variant,omitempty"`
+	TitleDecor     TitleDecorToken `json:"title_decor,omitempty"`
+	TitleBar       ToneToken       `json:"title_bar,omitempty"`
+	TitleUnderline ToneToken       `json:"title_underline,omitempty"`
+	Inset          InsetToken      `json:"inset,omitempty"`
+	MaxWidth       string          `json:"max_width,omitempty"`
+	BodyClass      string          `json:"body_class,omitempty"`
+	BorderStyle    string          `json:"border_style,omitempty"`
+	HoverEnabled   *bool           `json:"hover_enabled,omitempty"`
+	Effect         string          `json:"effect,omitempty"`
 }
 
 type Stack struct {
-	Gap       string `json:"gap,omitempty"`
-	Direction string `json:"direction,omitempty"`
-	Wrap      *bool  `json:"wrap,omitempty"`
-	Justify   string `json:"justify,omitempty"`
-	Align     string `json:"align,omitempty"`
-	Inset     string `json:"inset,omitempty"`
+	Gap       SpacingToken   `json:"gap,omitempty"`
+	Direction DirectionToken `json:"direction,omitempty"`
+	Wrap      *bool          `json:"wrap,omitempty"`
+	Justify   JustifyToken   `json:"justify,omitempty"`
+	Align     AlignToken     `json:"align,omitempty"`
+	Inset     InsetToken     `json:"inset,omitempty"`
 }
 
 type DisplayComponent struct {
 	ID                  string                   `json:"id,omitempty"`
-	Type                string                   `json:"type,omitempty"`
-	Data                string                   `json:"data,omitempty"`
+	Type                DisplayComponentType     `json:"type,omitempty"`
+	Data                DataPath                 `json:"data,omitempty"`
 	Value               interface{}              `json:"value,omitempty"`
 	Default             interface{}              `json:"default,omitempty"`
 	Visible             *bool                    `json:"visible,omitempty"`
-	ModelValue          string                   `json:"model_value,omitempty"`
-	Overlays            string                   `json:"overlays,omitempty"`
-	OverlayData         string                   `json:"overlay_data,omitempty"`
-	UpdateAction        string                   `json:"update_action,omitempty"`
-	MainRatio           string                   `json:"main_ratio,omitempty"`
-	MainRadius          string                   `json:"main_radius,omitempty"`
-	MainRadiusToken     string                   `json:"main_radius_token,omitempty"`
-	ThumbRatio          string                   `json:"thumb_ratio,omitempty"`
-	ThumbsInset         string                   `json:"thumbs_inset,omitempty"`
-	ThumbsInsetToken    string                   `json:"thumbs_inset_token,omitempty"`
+	ModelValue          DataPath                 `json:"model_value,omitempty"`
+	Overlays            DataPath                 `json:"overlays,omitempty"`
+	OverlayData         DataPath                 `json:"overlay_data,omitempty"`
+	UpdateAction        ComponentAction          `json:"update_action,omitempty"`
+	MainRatio           ComponentRatio           `json:"main_ratio,omitempty"`
+	MainRadius          ComponentRadiusToken     `json:"main_radius,omitempty"`
+	MainRadiusToken     ComponentRadiusToken     `json:"main_radius_token,omitempty"`
+	ThumbRatio          ComponentRatio           `json:"thumb_ratio,omitempty"`
+	ThumbsInset         InsetToken               `json:"thumbs_inset,omitempty"`
+	ThumbsInsetToken    SpacingToken             `json:"thumbs_inset_token,omitempty"`
 	VideoControls       *bool                    `json:"video_controls,omitempty"`
-	Size                string                   `json:"size,omitempty"`
+	Size                SizeToken                `json:"size,omitempty"`
 	Wrap                *bool                    `json:"wrap,omitempty"`
-	Gap                 string                   `json:"gap,omitempty"`
-	Direction           string                   `json:"direction,omitempty"`
-	Justify             string                   `json:"justify,omitempty"`
-	Align               string                   `json:"align,omitempty"`
-	Inset               string                   `json:"inset,omitempty"`
+	Gap                 SpacingToken             `json:"gap,omitempty"`
+	Direction           DirectionToken           `json:"direction,omitempty"`
+	Justify             JustifyToken             `json:"justify,omitempty"`
+	Align               AlignToken               `json:"align,omitempty"`
+	Inset               InsetToken               `json:"inset,omitempty"`
 	Compact             bool                     `json:"compact,omitempty"`
 	Columns             int                      `json:"columns,omitempty"`
 	ReadonlyColumns     int                      `json:"readonly_columns,omitempty"`
-	DisplayType         string                   `json:"display_type,omitempty"`
-	SeparatorVariant    string                   `json:"separator_variant,omitempty"`
-	SeparatorAppearance string                   `json:"separator_appearance,omitempty"`
+	DisplayType         ComponentDisplayType     `json:"display_type,omitempty"`
+	SeparatorVariant    ToneToken                `json:"separator_variant,omitempty"`
+	SeparatorAppearance SeparatorAppearance      `json:"separator_appearance,omitempty"`
 	MatrixColumns       []map[string]interface{} `json:"matrix_columns,omitempty"`
 	ValueLabel          string                   `json:"value_label,omitempty"`
 	ValueFallback       string                   `json:"value_fallback,omitempty"`
@@ -309,7 +309,7 @@ type DisplayComponent struct {
 	Subtitle            string                   `json:"subtitle,omitempty"`
 	SubtitleFallback    string                   `json:"subtitle_fallback,omitempty"`
 	TitleLevel          int                      `json:"title_level,omitempty"`
-	TitleTone           string                   `json:"title_tone,omitempty"`
+	TitleTone           ToneToken                `json:"title_tone,omitempty"`
 	BodyClass           string                   `json:"body_class,omitempty"`
 }
 
@@ -331,17 +331,17 @@ type RecordPage struct {
 }
 
 type RecordSection struct {
-	ID            string             `json:"id,omitempty"`
-	Title         string             `json:"title,omitempty"`
-	TitleFallback string             `json:"title_fallback,omitempty"`
-	TitleLevel    int                `json:"title_level,omitempty"`
-	TitleTone     string             `json:"title_tone,omitempty"`
-	Renderer      string             `json:"renderer,omitempty"`
-	LayoutSlot    string             `json:"layout_slot,omitempty"`
-	Order         int                `json:"order,omitempty"`
-	Block         *Block             `json:"block,omitempty"`
-	Stack         *Stack             `json:"stack,omitempty"`
-	Components    []DisplayComponent `json:"components,omitempty"`
+	ID            string                `json:"id,omitempty"`
+	Title         string                `json:"title,omitempty"`
+	TitleFallback string                `json:"title_fallback,omitempty"`
+	TitleLevel    int                   `json:"title_level,omitempty"`
+	TitleTone     ToneToken             `json:"title_tone,omitempty"`
+	Renderer      RecordSectionRenderer `json:"renderer,omitempty"`
+	LayoutSlot    LayoutSlotToken       `json:"layout_slot,omitempty"`
+	Order         int                   `json:"order,omitempty"`
+	Block         *Block                `json:"block,omitempty"`
+	Stack         *Stack                `json:"stack,omitempty"`
+	Components    []DisplayComponent    `json:"components,omitempty"`
 }
 
 type ResourceGridPage struct {
@@ -402,7 +402,7 @@ type APIAction struct {
 }
 
 type ModalAction struct {
-	Renderer string                 `json:"renderer,omitempty"`
+	Renderer RendererKey            `json:"renderer,omitempty"`
 	Title    string                 `json:"title,omitempty"`
 	Data     map[string]interface{} `json:"data,omitempty"`
 }

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -372,6 +372,10 @@ type Action struct {
 	VisibleIf        *Condition       `json:"visible_if,omitempty"`
 	HiddenIf         *Condition       `json:"hidden_if,omitempty"`
 	DisabledIf       *Condition       `json:"disabled_if,omitempty"`
+	Endpoint         string           `json:"endpoint,omitempty"`
+	Method           string           `json:"method,omitempty"`
+	UniqueEndpoint   string           `json:"uniqueEndpoint,omitempty"`
+	AfterRoute       interface{}      `json:"afterRoute,omitempty"`
 	Route            interface{}      `json:"route,omitempty"`
 	API              *APIAction       `json:"api,omitempty"`
 	Modal            *ModalAction     `json:"modal,omitempty"`

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -86,19 +86,27 @@ type Layout struct {
 }
 
 type Filters struct {
-	Renderer          RendererKey                `json:"renderer,omitempty"`
-	Enabled           bool                       `json:"enabled"`
-	PrimaryPlacement  string                     `json:"primary_placement,omitempty"`
-	SecondaryEnabled  *bool                      `json:"secondary_enabled,omitempty"`
-	ResetPlacement    string                     `json:"reset_placement,omitempty"`
-	Levels            []string                   `json:"levels,omitempty"`
-	Primary           []string                   `json:"primary,omitempty"`
-	Secondary         []string                   `json:"secondary,omitempty"`
-	More              []string                   `json:"more,omitempty"`
-	Nested            []string                   `json:"nested,omitempty"`
-	PillRows          [][]map[string]interface{} `json:"pill_rows,omitempty"`
-	SecondaryPillRows [][]map[string]interface{} `json:"secondary_pill_rows,omitempty"`
-	Reset             *FilterReset               `json:"reset,omitempty"`
+	Renderer          RendererKey    `json:"renderer,omitempty"`
+	Enabled           bool           `json:"enabled"`
+	PrimaryPlacement  string         `json:"primary_placement,omitempty"`
+	SecondaryEnabled  *bool          `json:"secondary_enabled,omitempty"`
+	ResetPlacement    string         `json:"reset_placement,omitempty"`
+	Levels            []string       `json:"levels,omitempty"`
+	Primary           []string       `json:"primary,omitempty"`
+	Secondary         []string       `json:"secondary,omitempty"`
+	More              []string       `json:"more,omitempty"`
+	Nested            []string       `json:"nested,omitempty"`
+	PillRows          [][]FilterPill `json:"pill_rows,omitempty"`
+	SecondaryPillRows [][]FilterPill `json:"secondary_pill_rows,omitempty"`
+	Reset             *FilterReset   `json:"reset,omitempty"`
+}
+
+type FilterPill struct {
+	Label    string `json:"label,omitempty"`
+	LabelKey string `json:"label_key,omitempty"`
+	Key      string `json:"key,omitempty"`
+	Val      string `json:"val,omitempty"`
+	Dot      bool   `json:"dot,omitempty"`
 }
 
 type FilterReset struct {
@@ -188,19 +196,27 @@ type StatusBinding struct {
 }
 
 type Badge struct {
-	ID        string                 `json:"id,omitempty"`
-	Type      string                 `json:"type,omitempty"`
-	Field     string                 `json:"field,omitempty"`
-	IfField   string                 `json:"if_field,omitempty"`
-	Option    string                 `json:"option,omitempty"`
-	Placement string                 `json:"placement,omitempty"`
-	Label     string                 `json:"label,omitempty"`
-	LabelKey  string                 `json:"label_key,omitempty"`
-	Tone      string                 `json:"tone,omitempty"`
-	ToneMap   map[string]string      `json:"tone_map,omitempty"`
-	Marker    *bool                  `json:"marker,omitempty"`
-	Then      map[string]interface{} `json:"then,omitempty"`
-	Else      map[string]interface{} `json:"else,omitempty"`
+	ID        string            `json:"id,omitempty"`
+	Type      string            `json:"type,omitempty"`
+	Field     string            `json:"field,omitempty"`
+	IfField   string            `json:"if_field,omitempty"`
+	Option    string            `json:"option,omitempty"`
+	Placement string            `json:"placement,omitempty"`
+	Label     string            `json:"label,omitempty"`
+	LabelKey  string            `json:"label_key,omitempty"`
+	Tone      string            `json:"tone,omitempty"`
+	ToneMap   map[string]string `json:"tone_map,omitempty"`
+	Marker    *bool             `json:"marker,omitempty"`
+	Then      *BadgeState       `json:"then,omitempty"`
+	Else      *BadgeState       `json:"else,omitempty"`
+}
+
+type BadgeState struct {
+	ID       string `json:"id,omitempty"`
+	Label    string `json:"label,omitempty"`
+	LabelKey string `json:"label_key,omitempty"`
+	Tone     string `json:"tone,omitempty"`
+	Marker   *bool  `json:"marker,omitempty"`
 }
 
 type Stat struct {
@@ -227,21 +243,101 @@ type FormPage struct {
 }
 
 type FormSection struct {
-	ID          string                 `json:"id,omitempty"`
-	Title       string                 `json:"title,omitempty"`
-	PanelTitle  string                 `json:"panel_title,omitempty"`
-	Subtitle    string                 `json:"subtitle,omitempty"`
-	Renderer    RendererKey            `json:"renderer,omitempty"`
-	Group       string                 `json:"group,omitempty"`
-	GroupTitle  string                 `json:"group_title,omitempty"`
-	Icon        string                 `json:"icon,omitempty"`
-	Action      string                 `json:"action,omitempty"`
-	Mode        string                 `json:"mode,omitempty"`
-	Block       *Block                 `json:"block,omitempty"`
-	Fields      []string               `json:"fields,omitempty"`
-	ListPage    *ListPage              `json:"list_page,omitempty"`
-	Collection  map[string]interface{} `json:"collection,omitempty"`
-	Preferences map[string]interface{} `json:"preferences,omitempty"`
+	ID          string             `json:"id,omitempty"`
+	Title       string             `json:"title,omitempty"`
+	PanelTitle  string             `json:"panel_title,omitempty"`
+	Subtitle    string             `json:"subtitle,omitempty"`
+	Renderer    RendererKey        `json:"renderer,omitempty"`
+	Group       string             `json:"group,omitempty"`
+	GroupTitle  string             `json:"group_title,omitempty"`
+	Icon        string             `json:"icon,omitempty"`
+	Action      string             `json:"action,omitempty"`
+	Mode        string             `json:"mode,omitempty"`
+	Block       *Block             `json:"block,omitempty"`
+	Fields      []string           `json:"fields,omitempty"`
+	ListPage    *ListPage          `json:"list_page,omitempty"`
+	Collection  *CollectionConfig  `json:"collection,omitempty"`
+	Preferences *PreferencesConfig `json:"preferences,omitempty"`
+}
+
+type CollectionConfig struct {
+	Resource       string             `json:"resource,omitempty"`
+	ListEndpoint   string             `json:"list_endpoint,omitempty"`
+	DefrecEndpoint string             `json:"defrec_endpoint,omitempty"`
+	ProfileField   string             `json:"profile_field,omitempty"`
+	ValueField     string             `json:"value_field,omitempty"`
+	PriceField     string             `json:"price_field,omitempty"`
+	PricePrefix    string             `json:"price_prefix,omitempty"`
+	Size           int                `json:"size,omitempty"`
+	LoadingLabel   string             `json:"loading_label,omitempty"`
+	Collections    []CollectionBucket `json:"collections,omitempty"`
+	Modal          *CollectionModal   `json:"modal,omitempty"`
+}
+
+type CollectionBucket struct {
+	ID            string                  `json:"id,omitempty"`
+	Title         string                  `json:"title,omitempty"`
+	CountLabel    string                  `json:"count_label,omitempty"`
+	AddLabel      string                  `json:"add_label,omitempty"`
+	ClearLabel    string                  `json:"clear_label,omitempty"`
+	ModalTitle    string                  `json:"modal_title,omitempty"`
+	ModalSubtitle string                  `json:"modal_subtitle,omitempty"`
+	ConfirmLabel  string                  `json:"confirm_label,omitempty"`
+	Tone          string                  `json:"tone,omitempty"`
+	PriceEnabled  bool                    `json:"price_enabled"`
+	DefaultPrice  int                     `json:"default_price"`
+	PricePrefix   string                  `json:"price_prefix,omitempty"`
+	EditFields    []CollectionEditField   `json:"edit_fields,omitempty"`
+	Filter        *CollectionBucketFilter `json:"filter,omitempty"`
+}
+
+type CollectionEditField struct {
+	ID      string `json:"id,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Variant string `json:"variant,omitempty"`
+	Prefix  string `json:"prefix,omitempty"`
+	Min     int    `json:"min"`
+}
+
+type CollectionBucketFilter struct {
+	Price string `json:"price,omitempty"`
+}
+
+type CollectionModal struct {
+	Icon                string `json:"icon,omitempty"`
+	Search              bool   `json:"search"`
+	SearchPlaceholder   string `json:"search_placeholder,omitempty"`
+	EmptyLabel          string `json:"empty_label,omitempty"`
+	SelectedLabel       string `json:"selected_label,omitempty"`
+	TakenLabel          string `json:"taken_label,omitempty"`
+	CancelLabel         string `json:"cancel_label,omitempty"`
+	ConfirmLoadingLabel string `json:"confirm_loading_label,omitempty"`
+}
+
+type PreferencesConfig struct {
+	Resource          string                        `json:"resource,omitempty"`
+	ListEndpoint      string                        `json:"list_endpoint,omitempty"`
+	SaveEndpoint      string                        `json:"save_endpoint,omitempty"`
+	Channels          []string                      `json:"channels,omitempty"`
+	Blocks            []PreferencesBlock            `json:"blocks,omitempty"`
+	ConnectionPrompts []PreferencesConnectionPrompt `json:"connection_prompts,omitempty"`
+}
+
+type PreferencesBlock struct {
+	ID       string `json:"id,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Subtitle string `json:"subtitle,omitempty"`
+}
+
+type PreferencesConnectionPrompt struct {
+	ID               string           `json:"id,omitempty"`
+	Channel          string           `json:"channel,omitempty"`
+	Icon             string           `json:"icon,omitempty"`
+	Tone             string           `json:"tone,omitempty"`
+	Text             string           `json:"text,omitempty"`
+	ActionLabel      string           `json:"action_label,omitempty"`
+	ActionVariant    ActionVariant    `json:"action_variant,omitempty"`
+	ActionAppearance ActionAppearance `json:"action_appearance,omitempty"`
 }
 
 type Block struct {
@@ -321,13 +417,260 @@ type RecordPage struct {
 	Badge         string                 `json:"badge,omitempty"`
 	BadgeTone     string                 `json:"badge_tone,omitempty"`
 	BadgeTeleport string                 `json:"badge_teleport,omitempty"`
-	Navigation    map[string]interface{} `json:"navigation,omitempty"`
+	Navigation    *RecordNavigation      `json:"navigation,omitempty"`
 	Layout        *Layout                `json:"layout,omitempty"`
 	Sections      []RecordSection        `json:"sections,omitempty"`
-	DisplayData   map[string]interface{} `json:"display_data,omitempty"`
-	Theme         map[string]interface{} `json:"theme,omitempty"`
+	DisplayData   *RecordDisplayData     `json:"display_data,omitempty"`
+	Theme         *RecordTheme           `json:"theme,omitempty"`
 	Actions       []Action               `json:"actions,omitempty"`
 	Context       map[string]interface{} `json:"context,omitempty"`
+}
+
+type RecordNavigation struct {
+	Type    string `json:"type,omitempty"`
+	Enabled bool   `json:"enabled"`
+}
+
+type RecordTheme struct {
+	Profile *ProfileRecordTheme `json:"profile,omitempty"`
+}
+
+type ProfileRecordTheme struct {
+	Panels   ProfilePanelTheme   `json:"panels,omitempty"`
+	Headings ProfileHeadingTheme `json:"headings,omitempty"`
+	Badges   ProfileBadgeTheme   `json:"badges,omitempty"`
+	Buttons  ProfileButtonTheme  `json:"buttons,omitempty"`
+	Avatar   ProfileAvatarTheme  `json:"avatar,omitempty"`
+}
+
+type ProfilePanelTheme struct {
+	DefaultVariant string `json:"default_variant,omitempty"`
+	GalleryVariant string `json:"gallery_variant,omitempty"`
+	HeroVariant    string `json:"hero_variant,omitempty"`
+	NestedVariant  string `json:"nested_variant,omitempty"`
+}
+
+type ProfileHeadingTheme struct {
+	TitleDecor     TitleDecorToken `json:"title_decor,omitempty"`
+	TitleBar       ToneToken       `json:"title_bar,omitempty"`
+	TitleUnderline ToneToken       `json:"title_underline,omitempty"`
+}
+
+type ProfileBadgeTheme struct {
+	VerifiedTone  string `json:"verified_tone,omitempty"`
+	RoleTone      string `json:"role_tone,omitempty"`
+	StatusOnline  string `json:"status_online,omitempty"`
+	StatusOffline string `json:"status_offline,omitempty"`
+	LanguageTone  string `json:"language_tone,omitempty"`
+	WorkIncall    string `json:"work_incall,omitempty"`
+	WorkOutcall   string `json:"work_outcall,omitempty"`
+	TourStatus    string `json:"tour_status,omitempty"`
+}
+
+type ProfileButtonTheme struct {
+	DefaultVariant      ActionVariant    `json:"default_variant,omitempty"`
+	DefaultAppearance   ActionAppearance `json:"default_appearance,omitempty"`
+	SecondaryVariant    ActionVariant    `json:"secondary_variant,omitempty"`
+	SecondaryAppearance ActionAppearance `json:"secondary_appearance,omitempty"`
+	PrimaryVariant      ActionVariant    `json:"primary_variant,omitempty"`
+	PrimaryAppearance   ActionAppearance `json:"primary_appearance,omitempty"`
+	WarningVariant      ActionVariant    `json:"warning_variant,omitempty"`
+	MutedVariant        ActionVariant    `json:"muted_variant,omitempty"`
+	LightVariant        ActionVariant    `json:"light_variant,omitempty"`
+}
+
+type ProfileAvatarTheme struct {
+	Glow string `json:"glow,omitempty"`
+}
+
+type RecordDisplayData struct {
+	Gallery  *DisplayGallery  `json:"gallery,omitempty"`
+	Hero     *DisplayHero     `json:"hero,omitempty"`
+	Details  *DisplayDetails  `json:"details,omitempty"`
+	About    *DisplayAbout    `json:"about,omitempty"`
+	Meetings *DisplayMeetings `json:"meetings,omitempty"`
+	Rates    *DisplayRates    `json:"rates,omitempty"`
+	Services *DisplayServices `json:"services,omitempty"`
+	Tours    *DisplayTours    `json:"tours,omitempty"`
+	Contacts *DisplayContacts `json:"contacts,omitempty"`
+}
+
+type DisplayGallery struct {
+	Items    []MediaItem     `json:"items,omitempty"`
+	Current  int             `json:"current"`
+	Actions  []DisplayAction `json:"actions,omitempty"`
+	Overlays []OverlayGroup  `json:"overlays,omitempty"`
+}
+
+type MediaItem struct {
+	ID        interface{} `json:"id,omitempty"`
+	Kind      string      `json:"kind,omitempty"`
+	Src       string      `json:"src,omitempty"`
+	Thumbnail string      `json:"thumbnail,omitempty"`
+	Title     string      `json:"title,omitempty"`
+	Alt       string      `json:"alt,omitempty"`
+}
+
+type OverlayGroup struct {
+	ID       string         `json:"id,omitempty"`
+	Position string         `json:"position,omitempty"`
+	Items    []DisplayBadge `json:"items,omitempty"`
+}
+
+type DisplayHero struct {
+	Identity *HeroIdentity `json:"identity,omitempty"`
+	Stats    []DisplayStat `json:"stats,omitempty"`
+}
+
+type HeroIdentity struct {
+	Avatar       *HeroAvatar    `json:"avatar,omitempty"`
+	Name         string         `json:"name,omitempty"`
+	Handle       string         `json:"handle,omitempty"`
+	CornerBadges []DisplayBadge `json:"cornerBadges,omitempty"`
+	Location     *LocationValue `json:"location,omitempty"`
+	StatusText   string         `json:"statusText,omitempty"`
+}
+
+type HeroAvatar struct {
+	Src  string `json:"src,omitempty"`
+	Name string `json:"name,omitempty"`
+	Size string `json:"size,omitempty"`
+	Glow string `json:"glow,omitempty"`
+}
+
+type LocationValue struct {
+	Country string `json:"country,omitempty"`
+	City    string `json:"city,omitempty"`
+}
+
+type DisplayStat struct {
+	ID       string      `json:"id,omitempty"`
+	Icon     string      `json:"icon,omitempty"`
+	Value    interface{} `json:"value,omitempty"`
+	Label    string      `json:"label,omitempty"`
+	LabelKey string      `json:"label_key,omitempty"`
+}
+
+type DisplayDetails struct {
+	Items      []DetailItem      `json:"items,omitempty"`
+	Commercial []CommercialGroup `json:"commercial,omitempty"`
+}
+
+type DetailItem struct {
+	ID        string      `json:"id,omitempty"`
+	Label     string      `json:"label,omitempty"`
+	LabelKey  string      `json:"label_key,omitempty"`
+	Fallback  string      `json:"fallback,omitempty"`
+	Value     interface{} `json:"value,omitempty"`
+	ValueKey  string      `json:"value_key,omitempty"`
+	ValueType string      `json:"value_type,omitempty"`
+	Span      string      `json:"span,omitempty"`
+}
+
+type CommercialGroup struct {
+	ID       string         `json:"id,omitempty"`
+	Label    string         `json:"label,omitempty"`
+	LabelKey string         `json:"label_key,omitempty"`
+	Items    []DisplayBadge `json:"items,omitempty"`
+}
+
+type DisplayAbout struct {
+	Description string `json:"description,omitempty"`
+}
+
+type DisplayMeetings struct {
+	Items      []DisplayBadge `json:"items,omitempty"`
+	Commission []DisplayBadge `json:"commission,omitempty"`
+	WorkArea   []DisplayBadge `json:"workArea,omitempty"`
+	Payments   []DisplayBadge `json:"payments,omitempty"`
+}
+
+type DisplayRates struct {
+	Items  []RateItem  `json:"items,omitempty"`
+	Groups []RateGroup `json:"groups,omitempty"`
+}
+
+type RateGroup struct {
+	ID       string     `json:"id,omitempty"`
+	Label    string     `json:"label,omitempty"`
+	LabelKey string     `json:"label_key,omitempty"`
+	Tone     ToneToken  `json:"tone,omitempty"`
+	Items    []RateItem `json:"items,omitempty"`
+}
+
+type RateItem struct {
+	ID            string `json:"id,omitempty"`
+	Label         string `json:"label,omitempty"`
+	LabelKey      string `json:"label_key,omitempty"`
+	DurationCount int    `json:"duration_count,omitempty"`
+	DurationUnit  string `json:"duration_unit,omitempty"`
+	Value         string `json:"value,omitempty"`
+	Featured      bool   `json:"featured,omitempty"`
+}
+
+type DisplayServices struct {
+	Included []ServiceItem  `json:"included,omitempty"`
+	Extra    []ServiceItem  `json:"extra,omitempty"`
+	Groups   []ServiceGroup `json:"groups,omitempty"`
+}
+
+type ServiceGroup struct {
+	ID         string        `json:"id,omitempty"`
+	Label      string        `json:"label,omitempty"`
+	LabelKey   string        `json:"label_key,omitempty"`
+	Count      int           `json:"count"`
+	CountKey   string        `json:"count_key,omitempty"`
+	CountLabel string        `json:"count_label,omitempty"`
+	Tone       string        `json:"tone,omitempty"`
+	Open       bool          `json:"open"`
+	Items      []ServiceItem `json:"items,omitempty"`
+}
+
+type ServiceItem struct {
+	ID       interface{} `json:"id,omitempty"`
+	Label    string      `json:"label,omitempty"`
+	LabelKey string      `json:"label_key,omitempty"`
+	Price    string      `json:"price,omitempty"`
+}
+
+type DisplayTours struct {
+	Cards          []TourCard     `json:"cards,omitempty"`
+	Empty          string         `json:"empty,omitempty"`
+	MakeTourButton *DisplayAction `json:"makeTourButton,omitempty"`
+}
+
+type TourCard struct {
+	ID       interface{}     `json:"id,omitempty"`
+	Title    string          `json:"title,omitempty"`
+	Subtitle string          `json:"subtitle,omitempty"`
+	Block    *Block          `json:"block,omitempty"`
+	Badges   []DisplayBadge  `json:"badges,omitempty"`
+	Actions  []DisplayAction `json:"actions,omitempty"`
+}
+
+type DisplayContacts struct {
+	Items []DetailItem `json:"items,omitempty"`
+}
+
+type DisplayBadge struct {
+	ID       string            `json:"id,omitempty"`
+	Label    string            `json:"label,omitempty"`
+	LabelKey string            `json:"label_key,omitempty"`
+	Tone     string            `json:"tone,omitempty"`
+	Marker   *bool             `json:"marker,omitempty"`
+	Icon     string            `json:"icon,omitempty"`
+	Style    map[string]string `json:"style,omitempty"`
+}
+
+type DisplayAction struct {
+	ID         string           `json:"id,omitempty"`
+	Label      string           `json:"label,omitempty"`
+	LabelKey   string           `json:"label_key,omitempty"`
+	Variant    ActionVariant    `json:"variant,omitempty"`
+	Appearance ActionAppearance `json:"appearance,omitempty"`
+	Icon       string           `json:"icon,omitempty"`
+	Block      bool             `json:"block,omitempty"`
+	Route      interface{}      `json:"route,omitempty"`
 }
 
 type RecordSection struct {
@@ -345,16 +688,37 @@ type RecordSection struct {
 }
 
 type ResourceGridPage struct {
-	Endpoint string                 `json:"endpoint,omitempty"`
-	List     map[string]interface{} `json:"list,omitempty"`
-	Create   *Action                `json:"create,omitempty"`
-	Delete   *Action                `json:"delete,omitempty"`
-	Update   *Action                `json:"update,omitempty"`
-	Card     *CardSchema            `json:"card,omitempty"`
-	Status   map[string]interface{} `json:"status,omitempty"`
-	Actions  map[string]interface{} `json:"actions,omitempty"`
-	Text     map[string]interface{} `json:"text,omitempty"`
-	Context  map[string]interface{} `json:"context,omitempty"`
+	Endpoint string                     `json:"endpoint,omitempty"`
+	List     *ResourceGridListConfig    `json:"list,omitempty"`
+	Create   *Action                    `json:"create,omitempty"`
+	Delete   *Action                    `json:"delete,omitempty"`
+	Update   *Action                    `json:"update,omitempty"`
+	Card     *CardSchema                `json:"card,omitempty"`
+	Status   *ResourceGridStatusConfig  `json:"status,omitempty"`
+	Actions  *ResourceGridActionsConfig `json:"actions,omitempty"`
+	Text     map[string]string          `json:"text,omitempty"`
+	Context  map[string]interface{}     `json:"context,omitempty"`
+}
+
+type ResourceGridListConfig struct {
+	Size    int                    `json:"size,omitempty"`
+	Filters map[string]interface{} `json:"filters,omitempty"`
+}
+
+type ResourceGridStatusConfig struct {
+	VerifyField         string        `json:"verifyField,omitempty"`
+	ActiveField         string        `json:"activeField,omitempty"`
+	VerifiedValue       string        `json:"verifiedValue,omitempty"`
+	PendingValue        string        `json:"pendingValue,omitempty"`
+	InactiveValue       string        `json:"inactiveValue,omitempty"`
+	InactiveActionValue string        `json:"inactiveActionValue,omitempty"`
+	ActiveActionValue   string        `json:"activeActionValue,omitempty"`
+	DraftValues         []interface{} `json:"draftValues,omitempty"`
+	PendingPayload      interface{}   `json:"pendingPayload,omitempty"`
+}
+
+type ResourceGridActionsConfig struct {
+	EditRoute interface{} `json:"editRoute,omitempty"`
 }
 
 type Action struct {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -491,7 +491,6 @@ type RecordDisplayData struct {
 	Meetings *DisplayMeetings `json:"meetings,omitempty"`
 	Rates    *DisplayRates    `json:"rates,omitempty"`
 	Services *DisplayServices `json:"services,omitempty"`
-	Tours    *DisplayTours    `json:"tours,omitempty"`
 	Contacts *DisplayContacts `json:"contacts,omitempty"`
 }
 
@@ -631,21 +630,6 @@ type ServiceItem struct {
 	Label    string      `json:"label,omitempty"`
 	LabelKey string      `json:"label_key,omitempty"`
 	Price    string      `json:"price,omitempty"`
-}
-
-type DisplayTours struct {
-	Cards          []TourCard     `json:"cards,omitempty"`
-	Empty          string         `json:"empty,omitempty"`
-	MakeTourButton *DisplayAction `json:"makeTourButton,omitempty"`
-}
-
-type TourCard struct {
-	ID       interface{}     `json:"id,omitempty"`
-	Title    string          `json:"title,omitempty"`
-	Subtitle string          `json:"subtitle,omitempty"`
-	Block    *Block          `json:"block,omitempty"`
-	Badges   []DisplayBadge  `json:"badges,omitempty"`
-	Actions  []DisplayAction `json:"actions,omitempty"`
 }
 
 type DisplayContacts struct {

--- a/renderer/tokens.go
+++ b/renderer/tokens.go
@@ -45,6 +45,21 @@ const (
 	RadiusFull RadiusToken = "full"
 )
 
+type InsetToken string
+
+const (
+	InsetNone       InsetToken = "none"
+	InsetInlineMD   InsetToken = "inline-md"
+	InsetMediaFrame InsetToken = "media-frame"
+)
+
+type ComponentRadiusToken string
+
+const (
+	ComponentRadiusNone     ComponentRadiusToken = "none"
+	ComponentRadiusMediaTop ComponentRadiusToken = "media-top"
+)
+
 type SizeToken string
 
 const (
@@ -71,6 +86,18 @@ const (
 	AlignCenter  AlignToken = "center"
 	AlignEnd     AlignToken = "end"
 	AlignStretch AlignToken = "stretch"
+)
+
+type ToneToken string
+
+const (
+	ToneDefault ToneToken = "default"
+	ToneMuted   ToneToken = "muted"
+	ToneSoft    ToneToken = "soft"
+	ToneAccent  ToneToken = "accent"
+	ToneSuccess ToneToken = "success"
+	ToneWarning ToneToken = "warning"
+	ToneDanger  ToneToken = "danger"
 )
 
 type LayoutType string
@@ -162,6 +189,40 @@ const (
 	BlockVariantCompact BlockVariant = "compact"
 )
 
+type TitleDecorToken string
+
+const (
+	TitleDecorNone    TitleDecorToken = "none"
+	TitleDecorSection TitleDecorToken = "section"
+)
+
+type RendererKey string
+
+const (
+	RendererUniversalDisplay     RendererKey = "universal.display"
+	RendererUniversalSection     RendererKey = "universal.section"
+	RendererUniversalPreferences RendererKey = "universal.preferences"
+	RendererUniversalFilters     RendererKey = "universal.filters"
+	RendererUniversalPagination  RendererKey = "universal.pagination"
+	RendererMediaGallery         RendererKey = "media.gallery"
+	RendererCollectionManager    RendererKey = "collection.manager"
+	RendererAvatar               RendererKey = "avatar"
+)
+
+type RecordSectionRenderer = RendererKey
+
+const (
+	RecordRendererDisplay RecordSectionRenderer = RendererUniversalDisplay
+)
+
+type LayoutSlotToken string
+
+const (
+	LayoutSlotLeft   LayoutSlotToken = "left"
+	LayoutSlotCenter LayoutSlotToken = "center"
+	LayoutSlotRight  LayoutSlotToken = "right"
+)
+
 type ActionType string
 
 const (
@@ -191,4 +252,83 @@ const (
 	ActionAppearanceGhost   ActionAppearance = "ghost"
 	ActionAppearanceSoft    ActionAppearance = "soft"
 	ActionAppearanceLink    ActionAppearance = "link"
+)
+
+type DisplayComponentType string
+
+const (
+	DisplayMediaGallery    DisplayComponentType = "media_gallery"
+	DisplayActions         DisplayComponentType = "actions"
+	DisplayIdentity        DisplayComponentType = "identity"
+	DisplayStatList        DisplayComponentType = "stat_list"
+	DisplayDataList        DisplayComponentType = "data_list"
+	DisplayBadgeGroupBlock DisplayComponentType = "badge_group_block"
+	DisplayText            DisplayComponentType = "text"
+	DisplayBadgeList       DisplayComponentType = "badge_list"
+	DisplayRateGroups      DisplayComponentType = "rate_groups"
+	DisplayAccordionGroups DisplayComponentType = "accordion_groups"
+)
+
+type DataPath string
+
+const (
+	DataGalleryItems       DataPath = "gallery.items"
+	DataGalleryCurrent     DataPath = "gallery.current"
+	DataGalleryOverlays    DataPath = "gallery.overlays"
+	DataGalleryActions     DataPath = "gallery.actions"
+	DataHeroIdentity       DataPath = "hero.identity"
+	DataHeroStats          DataPath = "hero.stats"
+	DataDetailsItems       DataPath = "details.items"
+	DataDetailsCommercial  DataPath = "details.commercial"
+	DataAboutDescription   DataPath = "about.description"
+	DataMeetingsItems      DataPath = "meetings.items"
+	DataMeetingsCommission DataPath = "meetings.commission"
+	DataMeetingsWorkArea   DataPath = "meetings.workArea"
+	DataMeetingsPayments   DataPath = "meetings.payments"
+	DataRatesGroups        DataPath = "rates.groups"
+	DataServicesGroups     DataPath = "services.groups"
+	DataContactsItems      DataPath = "contacts.items"
+)
+
+type ComponentAction string
+
+const (
+	ComponentActionGallerySet ComponentAction = "gallery:set"
+)
+
+type ComponentDisplayType string
+
+const (
+	ComponentDisplayKeyValueGrid ComponentDisplayType = "key_value_grid"
+)
+
+type ComponentRatio string
+
+const (
+	ComponentRatioSquare   ComponentRatio = "square"
+	ComponentRatioPortrait ComponentRatio = "portrait"
+)
+
+type DirectionToken string
+
+const (
+	DirectionRow    DirectionToken = "row"
+	DirectionColumn DirectionToken = "column"
+)
+
+type JustifyToken string
+
+const (
+	JustifyStart   JustifyToken = "start"
+	JustifyCenter  JustifyToken = "center"
+	JustifyEnd     JustifyToken = "end"
+	JustifyStretch JustifyToken = "stretch"
+	JustifyBetween JustifyToken = "between"
+)
+
+type SeparatorAppearance string
+
+const (
+	SeparatorSolid    SeparatorAppearance = "solid"
+	SeparatorGradient SeparatorAppearance = "gradient"
 )

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -29,7 +29,7 @@ func setupTestRouter(authMiddleware func(actions.ModuleAction) gin.HandlerFunc) 
 				ID: "users",
 			},
 		},
-		MenuEntries: []module.MenuEntry{
+		MenuItems: []module.MenuItem{
 			{
 				ActionName: "list",
 				Title:      "Пользователи",
@@ -135,7 +135,7 @@ func TestConfigEndpoint_ValidToken(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
 
-	assert.Contains(t, response, "left_menu")
+	assert.Contains(t, response, "menus")
 	assert.Contains(t, response, "routes")
 	assert.Contains(t, response, "role")
 	assert.Equal(t, "admin", response["role"])
@@ -182,7 +182,7 @@ func TestConfigEndpoint_RoleFiltering(t *testing.T) {
 	testModule := &module.BaseModule{
 		Name: "restricted",
 		Path: "/admin",
-		MenuEntries: []module.MenuEntry{
+		MenuItems: []module.MenuItem{
 			{
 				ActionName: "list",
 				Title:      "Restricted Module",
@@ -241,8 +241,8 @@ func TestConfigEndpoint_RoleFiltering(t *testing.T) {
 	assert.Empty(t, managerResponse.Routes, "Manager should not see admin-only routes")
 }
 
-// TestConfigEndpoint_LeftMenuStructure — проверка структуры left_menu
-func TestConfigEndpoint_LeftMenuStructure(t *testing.T) {
+// TestConfigEndpoint_MenuStructure — проверка структуры menus
+func TestConfigEndpoint_MenuStructure(t *testing.T) {
 	mockUser := &icontext.UserInfo{
 		ID:   1,
 		Role: "admin",
@@ -258,16 +258,19 @@ func TestConfigEndpoint_LeftMenuStructure(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, response.LeftMenu, "Left menu should not be empty")
+	require.NotEmpty(t, response.Menus, "Menus should not be empty")
+	require.NotEmpty(t, response.Menus["sidebar"], "Sidebar menu should not be empty")
 
 	// Проверяем структуру первого блока меню
-	leftMenuBlock := response.LeftMenu[0]
-	assert.NotEmpty(t, leftMenuBlock.BlockTitle, "Block title should not be empty")
-	assert.NotEmpty(t, leftMenuBlock.Elements, "Block should have elements")
+	sidebarBlock := response.Menus["sidebar"][0]
+	assert.NotEmpty(t, sidebarBlock.BlockTitle, "Block title should not be empty")
+	assert.NotEmpty(t, sidebarBlock.Elements, "Block should have elements")
 
-	// Проверяем, что элементы являются строками (ссылками)
-	for _, element := range leftMenuBlock.Elements {
-		assert.NotEmpty(t, element, "Menu element should not be empty")
+	for _, element := range sidebarBlock.Elements {
+		assert.Equal(t, "route", element.Target.Type, "Menu item should default to route target")
+		assert.NotEmpty(t, element.Target.URL, "Route menu item target URL should not be empty")
+		assert.NotEmpty(t, element.Target.RouteKey, "Route menu item target route_key should not be empty")
+		assert.Contains(t, response.Routes, element.Target.RouteKey, "Menu item target route_key should point to routes")
 	}
 }
 

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -268,7 +268,7 @@ func TestUniversalRendererMetadata_RenderFuncBuildsTypedRuntimeMetadata(t *testi
 			}
 			return base, nil
 		},
-		MenuEntries: []module.MenuEntry{
+		MenuItems: []module.MenuItem{
 			{ActionName: "list", Title: "Dynamic", Group: "Admin", Order: 1, Show: true},
 		},
 		Actions: []actions.ModuleAction{


### PR DESCRIPTION
## Что изменено

- Добавлен универсальный `MenuItem` вместо старой модели левого меню.
- `/api/config` теперь отдает `menus`, где каждый пункт меню описывает поведение через `target`.
- Для `target.type=route` используется `target.url` и `target.route_key`; для `widget/modal/action/external` route не требуется.
- `left_menu` оставлен только как legacy alias для `menus.sidebar` на время перехода клиентов.
- Обновлены README, changelog и UniversalRenderer contract.

## Зачем

Раньше пункт меню мог описывать только ссылку и не имел явной связи с `routes`. Теперь frontend не должен угадывать, какой route config использовать, и может поддерживать не только sidebar, но и любые N меню, включая popup/widget пункты.

## Проверка

```bash
go test ./...
```