### PR TITLE
Add navigation and widget config contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ BaseModule
   ├── Render
   │     └── typed UniversalRenderer page metadata
   │
-  └── MenuItems
-        └── navigation/config metadata
+  └── Navigation
+        └── navigation/config metadata and page routes
 ```
 
 ### Ответственность модуля
@@ -107,7 +107,7 @@ Frontend должен получать готовую схему и рендер
 | Страница просмотра записи | `BaseModule.Render.Record` |
 | Рабочий grid с create/update/delete/status | `BaseModule.Render.ResourceGrid` |
 | Legacy/detail groups | `ViewModuleAction.Extra` |
-| Пункты меню | `BaseModule.MenuItems` |
+| Навигация и page routes | `BaseModule.Navigation` |
 | Динамический список колонок по роли | `ColumnsFunc` или `Fields`/`RoleContext` |
 | Динамические фильтры по роли | `FilterFunc` |
 | Права на строки | `Where`, `RoleWhere`, `BeforeAction`, `DataCheckRule` |
@@ -196,7 +196,7 @@ Extra: &fields.FieldExtra{
 
 Canonical UniversalRenderer metadata описывается через typed `BaseModule.Render`. Request-generator сам добавляет в response `renderer.name/version` и top-level page metadata: `list_page`, `form_page`, `record_page`, `resource_grid_page`.
 
-`/api/config` также получает route discovery metadata: `routes[path].renderer` и `routes[path].page_type`, поэтому frontend может выбрать renderer до загрузки данных страницы.
+`/api/config` также получает route discovery metadata в `navigation[].target.renderer` и `navigation[].target.page_type`, поэтому frontend может выбрать renderer до загрузки данных страницы.
 
 Если page metadata зависит от роли, query или текущего пользователя, используйте typed `RenderFunc`. Он получает deep clone базового `renderer.Universal`, возвращает итоговый `renderer.Universal`, а request-generator валидирует результат перед ответом. Clone покрывает pointer structs, slices, maps и стандартные JSON-like значения внутри `interface{}` (`map[string]interface{}`, `[]interface{}`, `map[string]string`, `[]string` и т.п.); произвольные custom objects внутри `interface{}` остаются ответственностью producer module.
 
@@ -432,24 +432,25 @@ func NewCoursesModule() *module.BaseModule {
 | `RoleJoin`       | `[]actions.RoleJoin`       | JOIN-ы по ролям                             |
 | `RoleBeforeHook` | `[]actions.RoleHook`       | Хуки до обработки по ролям                  |
 | `RoleAfterHook`  | `[]actions.RoleAfterHook`  | Хуки после обработки по ролям               |
-| `MenuItems`      | `[]module.MenuItem`        | Пункты произвольных меню для config endpoint |
+| `Navigation`     | `[]module.NavigationEntry` | Пункты навигации и frontend page routes для config endpoint |
 
-#### MenuItem
+#### NavigationEntry
 
-`MenuItem` описывает пункт меню, возвращаемого config endpoint. Меню строятся из `MenuItems` всех модулей, фильтруются по `Roles` текущего пользователя и группируются по `Menu` и `Group`.
+`NavigationEntry` описывает пункт навигации и связанный с ним frontend route. Навигация строится из `Navigation` всех модулей, фильтруется по `Roles` пункта и по permission указанного `ActionName`.
 
 ```go
-MenuItems: []module.MenuItem{
+Navigation: []module.NavigationEntry{
     {
         ActionName: "list",         // имя действия модуля (list/view/…)
+        ID:         "catalog.list", // стабильный id пункта, опционально
+        Path:       "/catalog",     // frontend route для page target
         Title:      "menu.catalog", // ключ i18n для заголовка пункта
         Icon:       "catalog",       // иконка (передаётся клиенту as-is)
         Show:       true,
         Order:      1,
-        Menu:       "sidebar",     // имя меню; по умолчанию sidebar
         Group:      "main",        // группа блока в левом меню
         Roles:      []actions.Role{"admin", "editor"},
-        Target:     module.MenuTarget{Type: "route", URL: "/catalog", RouteKey: "/api/catalog"},
+        Target:     module.NavigationTarget{Type: "page"},
     },
 },
 ```
@@ -461,9 +462,8 @@ MenuItems: []module.MenuItem{
 | `Icon`        | `string`                   | Имя иконки (передаётся клиенту)                       |
 | `Show`        | `bool`                     | Показывать пункт (`false` — скрыт, но в features есть) |
 | `Order`       | `int`                      | Порядок внутри группы                                 |
-| `Menu`        | `string`                   | Имя меню (`sidebar`, `mobile_bottom`, `profile`, ...) |
-| `Group`       | `string`                   | Ключ группы (становится `blockTitle` в ответе)        |
-| `Target`      | `module.MenuTarget`        | Явное поведение пункта меню                           |
+| `Group`       | `string`                   | Ключ группы для группировки на клиенте                |
+| `Target`      | `module.NavigationTarget`  | Явное поведение пункта навигации                      |
 | `Roles`       | `[]actions.Role`           | Роли, которым доступен пункт (пустой = все)           |
 | `Query`       | `map[string]interface{}`   | Доп. query-параметры для клиента                      |
 | `Data`        | `map[string]interface{}`   | Произвольные данные для клиента                       |
@@ -472,11 +472,32 @@ MenuItems: []module.MenuItem{
 
 | Type | Обязательные поля | Назначение |
 |---|---|---|
-| `route` | `URL`, `RouteKey` | Переход на frontend route и загрузка renderer/query из `routes[route_key]`. |
-| `widget` | `Name` | Открытие клиентского виджета, например `chat`. |
+| `page` | `Path` | Переход на frontend route. Renderer/query/children встраиваются в `navigation[].target`. |
 | `modal` | `Name` | Открытие клиентского popup/modal. |
-| `action` | `Name` | Выполнение клиентского действия. |
-| `external` | `URL` | Переход на внешний URL. |
+| `client_action` | `Name` | Выполнение клиентского действия, например `chat.open`. |
+| `external` | `Name` или `Data.url` | Переход на внешний URL по договоренности клиента. |
+
+#### WidgetConfig
+
+Глобальные виджеты описываются на конкретном действии модуля через `Widget`. Config endpoint автоматически возвращает такие действия в `widgets[]`; query строится из действия, на котором висит виджет.
+
+```go
+Actions: []actions.ModuleAction{
+    actions.ListModuleAction{
+        Label:      "profile_menu",
+        Permission: []actions.Role{actions.RoleAll},
+        Auth:       true,
+        Widget: &actions.WidgetConfig{
+            ID:        "profile-menu",
+            Type:      "module",
+            Placement: "topbar",
+            Order:     10,
+        },
+    },
+},
+```
+
+`DefrecModuleAction` тоже может быть widget source, если нужно автоматически получить форму добавления в `/api/config.widgets`.
 
 ### Этап 5. Описание полей (ModuleField)
 
@@ -1271,47 +1292,57 @@ type TranslationContext struct {
 | `GET` | `/admin/api/lang`         | Список поддерживаемых языков          |
 | `GET` | `/admin/api/lang/:key`    | Все переводы для языка                |
 | `GET` | `/admin/api/openapi.json` | OpenAPI 3.0 спецификация              |
-| `GET` | `<path>/config`           | Клиентский конфиг: меню, routes и роль   |
+| `GET` | `<path>/config`           | Клиентский конфиг: navigation, widgets и роль |
 
 ### Config endpoint
 
-Возвращает конфигурацию для клиентского приложения. Все меню фильтруются по роли текущего пользователя.
+Возвращает конфигурацию для клиентского приложения. Навигация и виджеты фильтруются по роли текущего пользователя и permission действия.
 
-**Query-параметры:** `lang` — код языка для перевода заголовков блоков меню.
+**Query-параметры:** `lang` — код языка для перевода заголовков навигации.
 
 **Пример ответа:**
 ```json
 {
-  "menus": {
-    "sidebar": [
-      {
-        "blockTitle": "Catalog",
-        "elements": [
-          {
-            "id": "sidebar.catalog.list",
-            "target": {
-              "type": "route",
-              "url": "/catalog",
-              "route_key": "/api/catalog"
-            },
-            "title": "Catalog",
-            "icon": "catalog",
-            "order": 10,
-            "group": "main"
-          }
-        ]
-      }
-    ]
-  },
-  "routes": {
-    "/api/catalog": {
+  "navigation": [
+    {
+      "id": "catalog.list",
+      "path": "/catalog",
+      "target": {
+        "type": "page",
+        "renderer": {
+          "name": "UniversalRenderer",
+          "version": "1.0.0"
+        },
+        "page_type": "list",
+        "query": {
+          "url": "/api/api/catalog",
+          "method": "GET"
+        },
+        "data": {
+          "view_adapter": "list_table"
+        },
+        "children": {}
+      },
+      "title": "Catalog",
+      "icon": "catalog",
+      "order": 10,
+      "group": "main"
+    }
+  ],
+  "widgets": [
+    {
+      "id": "profile-menu",
+      "type": "module",
+      "placement": "topbar",
+      "order": 10,
       "query": {
-        "url": "/api/api/catalog",
+        "url": "/api/api/profile-menu",
         "method": "GET"
       }
     }
-  }
+  ],
+  "role": "admin"
 }
 ```
 
-Меню строится из `MenuItems` каждого `BaseModule`. Пункты группируются по `Menu` и `Group`, сортируются по `Order`. Для `target.type=route` поле `route_key` связывает пункт меню с записью в `routes`. Для popup/widget/action route не требуется. `left_menu` может присутствовать как legacy alias для `menus.sidebar`, но новые клиенты должны использовать `menus`.
+Навигация строится из `Navigation` каждого `BaseModule`. Пункты сортируются по `Group`, затем по `Order`. Для `target.type=page` frontend route хранится в `path`, а renderer/query/children находятся прямо в `target`. Для popup/client_action route не требуется. Глобальные виджеты строятся из `WidgetConfig` на действиях модулей и возвращаются в `widgets`.

--- a/actions/add_module_action.go
+++ b/actions/add_module_action.go
@@ -13,9 +13,10 @@ type AddModuleAction struct {
 	Labels       map[string]string                `json:"-"`
 	Columns      []pg.Column                      `json:"-"`
 	ColumnsFunc  func(c *gin.Context) []pg.Column `json:"-"`
-	Permission   []Role        `json:"permission"`
-	Auth         bool          `json:"auth"`
-	Fields       []RoleContext `json:"-"`
+	Permission   []Role                           `json:"permission"`
+	Auth         bool                             `json:"auth"`
+	Fields       []RoleContext                    `json:"-"`
+	Widget       *WidgetConfig                    `json:"widget,omitempty"`
 }
 
 func (action AddModuleAction) Action() ModuleActionName {

--- a/actions/defrec_module_action.go
+++ b/actions/defrec_module_action.go
@@ -1,16 +1,22 @@
 package actions
 
 import (
+	"github.com/darkrain/request-generator/fields"
 	"github.com/gin-gonic/gin"
+	pg "github.com/go-jet/jet/v2/postgres"
 )
 
 type DefrecModuleAction struct {
 	ModuleAction
-	Label        string                         `json:"label"`
-	Labels       map[string]string              `json:"-"`
+	Label        string            `json:"label"`
+	Labels       map[string]string `json:"-"`
+	Permission   []Role            `json:"permission"`
+	Auth         bool              `json:"auth"`
+	Fields       []RoleContext     `json:"-"`
 	BeforeAction func(c *gin.Context) error
 	AfterAction  func(c *gin.Context)
 	ExtraFunc    func(c *gin.Context) interface{}
+	Widget       *WidgetConfig `json:"widget,omitempty"`
 }
 
 func (action DefrecModuleAction) Action() ModuleActionName {
@@ -31,4 +37,37 @@ func (action DefrecModuleAction) AfterRequest(c *gin.Context) {
 	}
 
 	action.AfterAction(c)
+}
+
+func (action DefrecModuleAction) GetColumns(c *gin.Context) []pg.Column {
+	if len(action.Fields) > 0 {
+		role := GetRoleFromContext(c)
+		if cols := ResolveRoleColumns(action.Fields, role); cols != nil {
+			return cols
+		}
+	}
+	return nil
+}
+
+func (action DefrecModuleAction) GetFields(c *gin.Context, moduleFields []fields.ModuleField) []fields.ModuleField {
+	if len(action.Fields) == 0 {
+		return moduleFields
+	}
+	role := GetRoleFromContext(c)
+	cols := ResolveRoleColumns(action.Fields, role)
+	if cols == nil {
+		return moduleFields
+	}
+
+	allowed := make(map[string]struct{}, len(cols))
+	for _, col := range cols {
+		allowed[col.Name()] = struct{}{}
+	}
+	result := make([]fields.ModuleField, 0, len(moduleFields))
+	for _, field := range moduleFields {
+		if _, ok := allowed[field.ColumnName()]; ok {
+			result = append(result, field)
+		}
+	}
+	return result
 }

--- a/actions/delete_module_action.go
+++ b/actions/delete_module_action.go
@@ -15,6 +15,7 @@ type DeleteModuleAction struct {
 	Auth         bool                                   `json:"auth"`
 	By           []pg.Column                            `json:"-"`
 	Where        func(c *gin.Context) pg.BoolExpression `json:"-"`
+	Widget       *WidgetConfig                          `json:"widget,omitempty"`
 }
 
 func (action DeleteModuleAction) Action() ModuleActionName {

--- a/actions/list_module_action.go
+++ b/actions/list_module_action.go
@@ -31,6 +31,7 @@ type ListModuleAction struct {
 	SortDefaultDirection SortDirection                          `json:"-"`
 	SortDefaultFunc      func(c *gin.Context) *SortOption       `json:"-"`
 	Fields               []RoleContext                          `json:"-"`
+	Widget               *WidgetConfig                          `json:"widget,omitempty"`
 }
 
 func (action ListModuleAction) Action() ModuleActionName {

--- a/actions/module_actions.go
+++ b/actions/module_actions.go
@@ -24,6 +24,16 @@ type ModuleAction interface {
 	GetColumns(c *gin.Context) []pg.Column
 }
 
+type WidgetConfig struct {
+	ID        string                 `json:"id"`
+	Type      string                 `json:"type"`
+	Placement string                 `json:"placement"`
+	Order     int                    `json:"order,omitempty"`
+	Renderer  string                 `json:"renderer,omitempty"`
+	Config    map[string]interface{} `json:"config,omitempty"`
+	Params    map[string]interface{} `json:"params,omitempty"`
+}
+
 type JoinType string
 
 const (

--- a/actions/update_module_action.go
+++ b/actions/update_module_action.go
@@ -19,6 +19,7 @@ type UpdateModuleAction struct {
 	Where           func(c *gin.Context) pg.BoolExpression `json:"-"`
 	Fields          []RoleContext                          `json:"-"`
 	ViewAfterUpdate *bool                                  `json:"-"` // default true; if true and ViewAction exists, return view response after update
+	Widget          *WidgetConfig                          `json:"widget,omitempty"`
 }
 
 func (action UpdateModuleAction) Action() ModuleActionName {

--- a/actions/view_module_action.go
+++ b/actions/view_module_action.go
@@ -20,6 +20,7 @@ type ViewModuleAction struct {
 	Extra        interface{}                      `json:"extra"`
 	ExtraFunc    func(c *gin.Context) interface{} `json:"-"`
 	Fields       []RoleContext                    `json:"-"`
+	Widget       *WidgetConfig                    `json:"widget,omitempty"`
 }
 
 func (action ViewModuleAction) Action() ModuleActionName {

--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,15 @@
 
 ### Added
 
-- **`MenuItem` на `BaseModule`** — декларативное описание пунктов произвольных меню для config endpoint.
-  Поля: `ActionName`, `Title`, `Icon`, `Show`, `Order`, `Menu`, `Group`, `Roles`, `URL`, `RouteKey`, `Query`, `Data`.
+- **`NavigationEntry` на `BaseModule`** — декларативное описание навигации и frontend routes для config endpoint.
+  Поля: `ActionName`, `ID`, `Path`, `Title`, `Icon`, `Show`, `Order`, `Group`, `Target`, `Roles`, `Query`, `Data`.
 
-- **Config endpoint** — возвращает клиентский конфиг с role-based меню (`menus`) и явным соответствием `route_key -> routes`.
-  Меню формируется из `MenuItems` каждого модуля, группируется по `Menu` и `Group`, фильтруется по `Roles` текущего пользователя.
-  Заголовки блоков переводятся через i18n (lang из query-параметра или `Accept-Language`).
+- **Config endpoint** — возвращает единый role-based список `navigation`, глобальные `widgets` и роль пользователя.
+  Навигация формируется из `Navigation` каждого модуля, фильтруется по правам действия и `Roles` пункта.
+  Для `target.type=page` renderer/query/children встраиваются прямо в `navigation[].target`, без отдельного `routes`.
+
+- **`WidgetConfig` на действиях модулей** — глобальные виджеты описываются на конкретном действии (`list`, `view`, `add`, `defrec`, ...).
+  Такие виджеты автоматически попадают в `/api/config.widgets` с query соответствующего действия.
 
 - **`ExtraFunc` на `ListModuleAction`** — динамические extra-данные per-request.
   Функция вызывается при каждом List-запросе; результат добавляется в ответ как `extra`.
@@ -128,5 +131,5 @@
   Convert: func(c *gin.Context, value interface{}) (interface{}, error) { ... }
   ```
 
-- `LeftMenuItem` расширен полями `Query` (`map[string]interface{}`) и `Data` (`map[string]interface{}`) для передачи дополнительных параметров клиенту.
-- `CustomLink` в `MenuEntry` позволяет переопределить URL пункта меню.
+- `NavigationEntry` поддерживает поля `Query` (`map[string]interface{}`) и `Data` (`map[string]interface{}`) для передачи дополнительных параметров клиенту.
+- `NavigationEntry.Path` позволяет явно задать frontend route для `target.type=page`.

--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -3,6 +3,7 @@ package module
 import (
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/darkrain/request-generator/actions"
 	"github.com/darkrain/request-generator/icontext"
@@ -14,16 +15,15 @@ import (
 
 // ConfigResponse структурирует ответ эндпоинта /api/config
 type ConfigResponse struct {
-	Menus    map[string][]MenuBlock `json:"menus"`
-	LeftMenu []MenuBlock            `json:"left_menu,omitempty"`
-	Routes   map[string]RouteConfig `json:"routes"`
-	Role     string                 `json:"role"`
+	Navigation []ConfigNavigationEntry `json:"navigation"`
+	Widgets    []ConfigWidget          `json:"widgets"`
+	Role       string                  `json:"role"`
 }
 
-// ConfigMenuItem представляет один пункт меню в клиентском конфиге.
-type ConfigMenuItem struct {
+type ConfigNavigationEntry struct {
 	ID     string                 `json:"id,omitempty"`
-	Target MenuTarget             `json:"target"`
+	Path   string                 `json:"path,omitempty"`
+	Target NavigationPageTarget   `json:"target"`
 	Title  string                 `json:"title"`
 	Icon   string                 `json:"icon,omitempty"`
 	Order  int                    `json:"order,omitempty"`
@@ -32,10 +32,26 @@ type ConfigMenuItem struct {
 	Data   map[string]interface{} `json:"data,omitempty"`
 }
 
-// MenuBlock представляет сгруппированный блок меню.
-type MenuBlock struct {
-	BlockTitle string           `json:"blockTitle"`
-	Elements   []ConfigMenuItem `json:"elements"`
+type NavigationPageTarget struct {
+	Type     string                 `json:"type"`
+	Name     string                 `json:"name,omitempty"`
+	Params   map[string]interface{} `json:"params,omitempty"`
+	Renderer *renderer.Identity     `json:"renderer,omitempty"`
+	PageType renderer.PageType      `json:"page_type,omitempty"`
+	Query    *RouteQuery            `json:"query,omitempty"`
+	Data     map[string]interface{} `json:"data,omitempty"`
+	Children map[string]RouteConfig `json:"children,omitempty"`
+}
+
+type ConfigWidget struct {
+	ID        string                 `json:"id"`
+	Type      string                 `json:"type"`
+	Placement string                 `json:"placement"`
+	Order     int                    `json:"order,omitempty"`
+	Renderer  string                 `json:"renderer,omitempty"`
+	Query     *RouteQuery            `json:"query,omitempty"`
+	Config    map[string]interface{} `json:"config,omitempty"`
+	Params    map[string]interface{} `json:"params,omitempty"`
 }
 
 // RouteConfig конфигурирует маршрут
@@ -51,8 +67,9 @@ type RouteConfig struct {
 
 // RouteQuery описывает параметры запроса для маршрута
 type RouteQuery struct {
-	Url    string `json:"url"`
-	Method string `json:"method"`
+	Url    string                 `json:"url"`
+	Method string                 `json:"method"`
+	Params map[string]interface{} `json:"params,omitempty"`
 }
 
 // actionConfigEndpoint генерирует конфиг для webapp
@@ -71,47 +88,21 @@ func (generator *Generator) actionConfigEndpoint() gin.HandlerFunc {
 		lang := generator.getLang(c)
 		generator.setTranslationContext(c, lang)
 
-		availableModules := make(map[string]*BaseModule)
-		moduleActions := make(map[string][]actions.ModuleAction)
-
-		for _, module := range generator.Modules {
-			moduleAvailable := false
-			var accessibleActions []actions.ModuleAction
-
-			for _, menuItem := range moduleMenuItems(module) {
-				if !menuItem.Show {
-					continue
-				}
-				for _, action := range module.Actions {
-					if string(action.Action()) == menuItem.ActionName {
-						if hasPermission(action, role) {
-							moduleAvailable = true
-							accessibleActions = append(accessibleActions, action)
-						}
-						break
-					}
-				}
-			}
-
-			if moduleAvailable {
-				availableModules[module.Name] = module
-				moduleActions[module.Name] = accessibleActions
-			}
+		navigation, err := generator.buildNavigation(c, role, lang)
+		if err != nil {
+			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
+			return
 		}
-
-		menus := generator.buildMenus(availableModules, moduleActions, role, lang)
-		leftMenu := menus["sidebar"]
-		routes, err := generator.buildRoutes(c, availableModules, moduleActions, role)
+		widgets, err := generator.buildWidgets(c, role)
 		if err != nil {
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
 
 		config := ConfigResponse{
-			Menus:    menus,
-			LeftMenu: leftMenu,
-			Routes:   routes,
-			Role:     role,
+			Navigation: navigation,
+			Widgets:    widgets,
+			Role:       role,
 		}
 
 		response.Response(l, c, config)
@@ -143,6 +134,10 @@ func hasPermission(action actions.ModuleAction, role string) bool {
 		permissions = a.Permission
 	case *actions.DeleteModuleAction:
 		permissions = a.Permission
+	case actions.DefrecModuleAction:
+		permissions = a.Permission
+	case *actions.DefrecModuleAction:
+		permissions = a.Permission
 	default:
 		return false
 	}
@@ -160,219 +155,220 @@ func hasPermission(action actions.ModuleAction, role string) bool {
 	return false
 }
 
-func moduleMenuItems(module *BaseModule) []MenuItem {
-	return module.MenuItems
-}
-
-func menuRouteKey(module *BaseModule, entry MenuItem) string {
-	if entry.Target.RouteKey != "" {
-		return entry.Target.RouteKey
+func navigationID(module *BaseModule, entry NavigationEntry) string {
+	if entry.ID != "" {
+		return entry.ID
 	}
-	return module.Path + "/" + module.Name
-}
-
-func menuURL(module *BaseModule, entry MenuItem) string {
-	if entry.Target.URL != "" {
-		return entry.Target.URL
-	}
-	return menuRouteKey(module, entry)
-}
-
-func menuName(entry MenuItem) string {
-	if entry.Menu != "" {
-		return entry.Menu
-	}
-	return "sidebar"
-}
-
-func menuTarget(module *BaseModule, entry MenuItem) MenuTarget {
-	target := entry.Target
-	if target.Type == "" {
-		target.Type = "route"
-	}
-	if target.Type == "route" {
-		if target.URL == "" {
-			target.URL = menuURL(module, entry)
-		}
-		if target.RouteKey == "" {
-			target.RouteKey = menuRouteKey(module, entry)
-		}
-	}
-	return target
-}
-
-func menuItemID(module *BaseModule, entry MenuItem) string {
-	if entry.Menu != "" || entry.Group != "" || entry.ActionName != "" {
-		return menuName(entry) + "." + module.Name + "." + entry.ActionName
+	if entry.Group != "" || entry.ActionName != "" {
+		return entry.Group + "." + module.Name + "." + entry.ActionName
 	}
 	return module.Name
 }
 
-// buildMenus формирует произвольные меню с группировкой по Menu и Group.
-func (generator *Generator) buildMenus(
-	availableModules map[string]*BaseModule,
-	moduleActions map[string][]actions.ModuleAction,
-	role string,
-	lang locale.Lang,
-) map[string][]MenuBlock {
-	type menuEntryWithModule struct {
-		entry  MenuItem
-		module *BaseModule
+func navigationPath(module *BaseModule, entry NavigationEntry, targetType string) string {
+	if entry.Path != "" {
+		return entry.Path
 	}
+	if targetType != "page" {
+		return ""
+	}
+	return module.Path + "/" + module.Name
+}
 
-	grouped := make(map[string]map[string][]menuEntryWithModule)
-	groupOrder := make(map[string]map[string]int)
+func navigationTarget(entry NavigationEntry) NavigationPageTarget {
+	target := NavigationPageTarget{
+		Type:   entry.Target.Type,
+		Name:   entry.Target.Name,
+		Params: entry.Target.Params,
+	}
+	if target.Type == "" {
+		target.Type = "page"
+	}
+	return target
+}
 
-	for _, module := range availableModules {
-		actionMap := make(map[string]bool)
-		for _, action := range moduleActions[module.Name] {
-			actionMap[string(action.Action())] = true
-		}
+func (generator *Generator) buildNavigation(c *gin.Context, role string, lang locale.Lang) ([]ConfigNavigationEntry, error) {
+	var result []ConfigNavigationEntry
 
-		for _, entry := range moduleMenuItems(module) {
+	for _, module := range generator.Modules {
+		for _, entry := range module.Navigation {
 			if !entry.Show {
 				continue
 			}
-			if !actionMap[entry.ActionName] {
+			action, ok := findModuleAction(module, entry.ActionName)
+			if !ok || !hasPermission(action, role) || !navigationRoleAllowed(entry, role) {
 				continue
 			}
 
-			// Role-specific visibility
-			if len(entry.Roles) > 0 {
-				allowed := false
-				for _, r := range entry.Roles {
-					if string(r) == role || r == actions.RoleAll {
-						allowed = true
-						break
-					}
+			target := navigationTarget(entry)
+			if target.Type == "page" {
+				render, err := module.RenderFor(c)
+				if err != nil {
+					return nil, err
 				}
-				if !allowed {
-					continue
+				route := generator.buildRouteForAction(module, render, action, role)
+				target.Renderer = route.Renderer
+				target.PageType = route.PageType
+				target.Query = route.Query
+				target.Data = route.Data
+				target.Children = route.Children
+				if target.Query != nil && entry.Query != nil {
+					target.Query.Params = entry.Query
 				}
 			}
 
-			group := entry.Group
-			if group == "" {
-				group = "default"
-			}
-			menu := menuName(entry)
-
-			if grouped[menu] == nil {
-				grouped[menu] = make(map[string][]menuEntryWithModule)
-			}
-			if groupOrder[menu] == nil {
-				groupOrder[menu] = make(map[string]int)
-			}
-
-			grouped[menu][group] = append(grouped[menu][group], menuEntryWithModule{
-				entry:  entry,
-				module: module,
+			result = append(result, ConfigNavigationEntry{
+				ID:     navigationID(module, entry),
+				Path:   navigationPath(module, entry, target.Type),
+				Title:  generator.Translate(lang, entry.Title),
+				Icon:   entry.Icon,
+				Group:  entry.Group,
+				Order:  entry.Order,
+				Target: target,
+				Query:  entry.Query,
+				Data:   entry.Data,
 			})
-
-			if _, exists := groupOrder[menu][group]; !exists {
-				groupOrder[menu][group] = entry.Order
-			} else if entry.Order < groupOrder[menu][group] {
-				groupOrder[menu][group] = entry.Order
-			}
 		}
 	}
 
-	result := make(map[string][]MenuBlock)
-	type groupInfo struct {
-		name  string
-		order int
-	}
-	for menu, orderByGroup := range groupOrder {
-		var groups []groupInfo
-		for name, order := range orderByGroup {
-			groups = append(groups, groupInfo{name: name, order: order})
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].Group == result[j].Group {
+			return result[i].Order < result[j].Order
 		}
-		sort.Slice(groups, func(i, j int) bool {
-			return groups[i].order < groups[j].order
-		})
+		return result[i].Group < result[j].Group
+	})
 
-		for _, group := range groups {
-			entries := grouped[menu][group.name]
-
-			sort.Slice(entries, func(i, j int) bool {
-				return entries[i].entry.Order < entries[j].entry.Order
-			})
-
-			blockTitle := group.name
-			if title, exists := generator.GroupTitles[group.name]; exists {
-				blockTitle = title
-			}
-
-			var elements []ConfigMenuItem
-			for _, item := range entries {
-				entry := item.entry
-				target := menuTarget(item.module, entry)
-				menuItem := ConfigMenuItem{
-					ID:     menuItemID(item.module, entry),
-					Title:  generator.Translate(lang, entry.Title),
-					Icon:   entry.Icon,
-					Target: target,
-					Order:  entry.Order,
-					Group:  group.name,
-				}
-
-				if entry.Query != nil {
-					menuItem.Query = entry.Query
-				}
-				if entry.Data != nil {
-					menuItem.Data = entry.Data
-				}
-
-				elements = append(elements, menuItem)
-			}
-
-			if len(elements) > 0 {
-				result[menu] = append(result[menu], MenuBlock{
-					BlockTitle: blockTitle,
-					Elements:   elements,
-				})
-			}
-		}
-	}
-
-	return result
+	return result, nil
 }
 
-// buildRoutes формирует маршруты с view-адаптерами, actions, children
-func (generator *Generator) buildRoutes(
-	c *gin.Context,
-	availableModules map[string]*BaseModule,
-	moduleActions map[string][]actions.ModuleAction,
-	role string,
-) (map[string]RouteConfig, error) {
-	routes := make(map[string]RouteConfig)
+func navigationRoleAllowed(entry NavigationEntry, role string) bool {
+	if len(entry.Roles) == 0 {
+		return true
+	}
+	for _, r := range entry.Roles {
+		if string(r) == role || r == actions.RoleAll {
+			return true
+		}
+	}
+	return false
+}
 
-	for _, module := range availableModules {
-		actionList := moduleActions[module.Name]
-		render, err := module.RenderFor(c)
-		if err != nil {
-			return nil, err
+func findModuleAction(module *BaseModule, actionName string) (actions.ModuleAction, bool) {
+	for _, action := range module.Actions {
+		if string(action.Action()) == actionName {
+			return action, true
+		}
+	}
+	return nil, false
+}
+
+func (generator *Generator) buildRouteForAction(module *BaseModule, render renderer.Universal, action actions.ModuleAction, role string) RouteConfig {
+	switch a := action.(type) {
+	case actions.ListModuleAction:
+		return generator.buildListRoute(module, render, a, role)
+	case *actions.ListModuleAction:
+		return generator.buildListRoute(module, render, *a, role)
+	case actions.ViewModuleAction:
+		return generator.buildViewRoute(module, render, a)
+	case *actions.ViewModuleAction:
+		return generator.buildViewRoute(module, render, *a)
+	case actions.AddModuleAction:
+		return generator.buildAddRoute(module, render, a)
+	case *actions.AddModuleAction:
+		return generator.buildAddRoute(module, render, *a)
+	case actions.DefrecModuleAction:
+		return generator.buildDefrecRoute(module, render, a)
+	case *actions.DefrecModuleAction:
+		return generator.buildDefrecRoute(module, render, *a)
+	default:
+		return RouteConfig{}
+	}
+}
+
+func (generator *Generator) buildWidgets(c *gin.Context, role string) ([]ConfigWidget, error) {
+	var result []ConfigWidget
+
+	for _, module := range generator.Modules {
+		for _, action := range module.Actions {
+			widget := actionWidget(action)
+			if widget == nil || !hasPermission(action, role) {
+				continue
+			}
+			render, err := module.RenderFor(c)
+			if err != nil {
+				return nil, err
+			}
+			route := generator.buildRouteForAction(module, render, action, role)
+			result = append(result, ConfigWidget{
+				ID:        widget.ID,
+				Type:      widget.Type,
+				Placement: widget.Placement,
+				Order:     widget.Order,
+				Renderer:  widget.Renderer,
+				Query:     route.Query,
+				Config:    widget.Config,
+				Params:    widget.Params,
+			})
 		}
 
-		for _, action := range actionList {
-			switch a := action.(type) {
-			case actions.ListModuleAction:
-				routes[module.Path+"/"+module.Name] = generator.buildListRoute(module, render, a, role)
-			case *actions.ListModuleAction:
-				routes[module.Path+"/"+module.Name] = generator.buildListRoute(module, render, *a, role)
-			case actions.ViewModuleAction:
-				routes[module.Path+"/"+module.Name+"/:id"] = generator.buildViewRoute(module, render, a)
-			case *actions.ViewModuleAction:
-				routes[module.Path+"/"+module.Name+"/:id"] = generator.buildViewRoute(module, render, *a)
-			case actions.AddModuleAction:
-				routes[module.Path+"/"+module.Name+"/add"] = generator.buildAddRoute(module, render, a)
-			case *actions.AddModuleAction:
-				routes[module.Path+"/"+module.Name+"/add"] = generator.buildAddRoute(module, render, *a)
+		if module.Defrec.Widget != nil && hasPermission(module.Defrec, role) {
+			render, err := module.RenderFor(c)
+			if err != nil {
+				return nil, err
 			}
+			route := generator.buildDefrecRoute(module, render, module.Defrec)
+			result = append(result, ConfigWidget{
+				ID:        module.Defrec.Widget.ID,
+				Type:      module.Defrec.Widget.Type,
+				Placement: module.Defrec.Widget.Placement,
+				Order:     module.Defrec.Widget.Order,
+				Renderer:  module.Defrec.Widget.Renderer,
+				Query:     route.Query,
+				Config:    module.Defrec.Widget.Config,
+				Params:    module.Defrec.Widget.Params,
+			})
 		}
 	}
 
-	return routes, nil
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].Placement == result[j].Placement {
+			return result[i].Order < result[j].Order
+		}
+		return result[i].Placement < result[j].Placement
+	})
+
+	return result, nil
+}
+
+func actionWidget(action actions.ModuleAction) *actions.WidgetConfig {
+	switch a := action.(type) {
+	case actions.ListModuleAction:
+		return a.Widget
+	case *actions.ListModuleAction:
+		return a.Widget
+	case actions.ViewModuleAction:
+		return a.Widget
+	case *actions.ViewModuleAction:
+		return a.Widget
+	case actions.AddModuleAction:
+		return a.Widget
+	case *actions.AddModuleAction:
+		return a.Widget
+	case actions.UpdateModuleAction:
+		return a.Widget
+	case *actions.UpdateModuleAction:
+		return a.Widget
+	case actions.DeleteModuleAction:
+		return a.Widget
+	case *actions.DeleteModuleAction:
+		return a.Widget
+	case actions.DefrecModuleAction:
+		return a.Widget
+	case *actions.DefrecModuleAction:
+		return a.Widget
+	default:
+		return nil
+	}
 }
 
 func (generator *Generator) buildListRoute(module *BaseModule, render renderer.Universal, action actions.ListModuleAction, role string) RouteConfig {
@@ -389,7 +385,7 @@ func (generator *Generator) buildListRoute(module *BaseModule, render renderer.U
 		Renderer:  render.ListIdentity(),
 		PageType:  render.ListRoutePageType(),
 		Query: &RouteQuery{
-			Url:    "/api" + routePath,
+			Url:    apiQueryURL(routePath),
 			Method: "GET",
 		},
 		Data: map[string]interface{}{
@@ -414,7 +410,7 @@ func (generator *Generator) buildViewRoute(module *BaseModule, render renderer.U
 		Renderer: render.RecordIdentity(),
 		PageType: render.RecordRoutePageType(),
 		Query: &RouteQuery{
-			Url:    "/api" + module.Path + "/" + module.Name + "/view/:bykey/:value",
+			Url:    apiQueryURL(module.Path + "/" + module.Name + "/view/:bykey/:value"),
 			Method: "GET",
 		},
 		Data: map[string]interface{}{
@@ -434,7 +430,7 @@ func (generator *Generator) buildAddRoute(module *BaseModule, render renderer.Un
 		Renderer: render.FormIdentity(),
 		PageType: render.FormRoutePageType(),
 		Query: &RouteQuery{
-			Url:    "/api" + module.Path + "/" + module.Name,
+			Url:    apiQueryURL(module.Path + "/" + module.Name),
 			Method: "PUT",
 		},
 		Data: map[string]interface{}{
@@ -443,11 +439,38 @@ func (generator *Generator) buildAddRoute(module *BaseModule, render renderer.Un
 	}
 }
 
+func (generator *Generator) buildDefrecRoute(module *BaseModule, render renderer.Universal, action actions.DefrecModuleAction) RouteConfig {
+	viewAdapter := "add"
+	if adapter, exists := generator.ViewAdapters["add"]; exists {
+		viewAdapter = adapter
+	}
+
+	return RouteConfig{
+		Title:    action.Label,
+		Renderer: render.FormIdentity(),
+		PageType: render.FormRoutePageType(),
+		Query: &RouteQuery{
+			Url:    apiQueryURL(module.Path + "/" + module.Name + "/defrec/"),
+			Method: "GET",
+		},
+		Data: map[string]interface{}{
+			"view_adapter": viewAdapter,
+		},
+	}
+}
+
+func apiQueryURL(path string) string {
+	if path == "/api" || strings.HasPrefix(path, "/api/") {
+		return path
+	}
+	return "/api" + path
+}
+
 // buildRouteActions формирует actions для маршрута
 func (generator *Generator) buildRouteActions(module *BaseModule, role string) []map[string]interface{} {
 	var result []map[string]interface{}
 
-	for _, entry := range moduleMenuItems(module) {
+	for _, entry := range module.Navigation {
 		for _, action := range module.Actions {
 			if string(action.Action()) != entry.ActionName {
 				continue
@@ -529,7 +552,7 @@ func (generator *Generator) buildViewChild(module *BaseModule, render renderer.U
 		Renderer: render.RecordIdentity(),
 		PageType: render.RecordRoutePageType(),
 		Query: &RouteQuery{
-			Url:    "/api" + module.Path + "/" + module.Name + "/view/:bykey/:value",
+			Url:    apiQueryURL(module.Path + "/" + module.Name + "/view/:bykey/:value"),
 			Method: "GET",
 		},
 		Data: map[string]interface{}{
@@ -553,7 +576,7 @@ func (generator *Generator) buildUpdateChild(module *BaseModule, render renderer
 		Renderer: render.FormIdentity(),
 		PageType: render.FormRoutePageType(),
 		Query: &RouteQuery{
-			Url:    "/api" + module.Path + "/" + module.Name + "/:bykey/:value",
+			Url:    apiQueryURL(module.Path + "/" + module.Name + "/:bykey/:value"),
 			Method: "POST",
 		},
 		Data: map[string]interface{}{
@@ -577,7 +600,7 @@ func (generator *Generator) buildAddChild(module *BaseModule, render renderer.Un
 		Renderer: render.FormIdentity(),
 		PageType: render.FormRoutePageType(),
 		Query: &RouteQuery{
-			Url:    "/api" + module.Path + "/" + module.Name,
+			Url:    apiQueryURL(module.Path + "/" + module.Name),
 			Method: "PUT",
 		},
 		Data: map[string]interface{}{

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -239,50 +239,57 @@ Closed enums должны использовать typed constants из package 
 
 ### Config Response
 
-`config` используется для navigation/routes и роли текущего пользователя, если producer service участвует в построении оболочки приложения.
+`config` используется для навигации, глобальных виджетов и роли текущего пользователя, если producer service участвует в построении оболочки приложения.
 
 ```json
 {
-  "menus": {
-    "sidebar": [
-      {
-        "blockTitle": "navigation.main",
-        "elements": [
-          {
-            "id": "sidebar.entities.list",
-            "target": {
-              "type": "route",
-              "url": "/entities",
-              "route_key": "/api/entities"
-            },
-            "title": "entities.menu.list",
-            "icon": "list",
-            "order": 10,
-            "group": "navigation.main",
-            "query": {},
-            "data": {}
-          }
-        ]
+  "navigation": [
+    {
+      "id": "entities.list",
+      "path": "/entities",
+      "target": {
+        "type": "page",
+        "renderer": {
+          "name": "UniversalRenderer",
+          "version": "1.0.0"
+        },
+        "page_type": "list",
+        "query": {
+          "url": "/api/entities",
+          "method": "GET"
+        },
+        "data": {},
+        "children": {}
+      },
+      "title": "entities.menu.list",
+      "icon": "list",
+      "order": 10,
+      "group": "navigation.main",
+      "query": {},
+      "data": {}
+    },
+    {
+      "id": "chat.open",
+      "target": {
+        "type": "client_action",
+        "name": "chat.open"
       }
-    ]
-  },
-  "routes": {
-    "/api/entities": {
-      "title": "entities.routes.list",
-      "menuTitle": "entities.menu.list",
-      "renderer": {
-        "name": "UniversalRenderer",
-        "version": "1.0.0"
-      },
-      "page_type": "list",
-      "query": {
-        "url": "/entities",
-        "method": "get"
-      },
-      "data": {},
-      "children": {}
     }
-  },
+  ],
+  "widgets": [
+    {
+      "id": "profile-menu",
+      "type": "module",
+      "placement": "topbar",
+      "order": 10,
+      "query": {
+        "url": "/api/profile-menu",
+        "method": "GET"
+      },
+      "config": {},
+      "params": {}
+    }
+  ],
   "role": "admin"
 }
 ```
@@ -291,19 +298,18 @@ Closed enums должны использовать typed constants из package 
 
 | Path | Назначение |
 |------|------------|
-| `menus` | Map меню, где ключ это имя меню (`sidebar`, `mobile_bottom`, `profile`, ...). |
-| `menus[name][]` | Группы пунктов конкретного меню. |
-| `menus[name][].elements[]` | Пункты меню. |
-| `menus[name][].elements[].target` | Поведение пункта меню. |
-| `menus[name][].elements[].target.type` | Тип поведения: `route`, `widget`, `modal`, `action`, `external`, `submenu`. |
-| `menus[name][].elements[].target.url` | Frontend URL для `route` или внешний URL для `external`. |
-| `menus[name][].elements[].target.route_key` | Ключ в `routes` для `target.type=route`. |
-| `menus[name][].elements[].target.name` | Имя widget/modal/action. |
-| `routes` | Map route config, где ключ совпадает с `route_key` из пункта меню. |
-| `routes[path].renderer` | Renderer identity/version для route discovery, если route использует typed `BaseModule.Render`. |
-| `routes[path].page_type` | Тип страницы: `list`, `form`, `record`, `resource_grid`. |
-| `routes[path].query` | Endpoint и method для загрузки данных route. |
-| `routes[path].children` | Вложенные route configs. |
+| `navigation` | Плоский список пунктов навигации. Это источник истины для frontend routes. |
+| `navigation[].path` | Frontend path для `target.type=page`. Для popup/client_action может отсутствовать. |
+| `navigation[].target` | Поведение пункта навигации. |
+| `navigation[].target.type` | Тип поведения: `page`, `modal`, `client_action`, `external`. |
+| `navigation[].target.name` | Имя modal/client_action/external target. |
+| `navigation[].target.renderer` | Renderer identity/version для page discovery, если route использует typed `BaseModule.Render`. |
+| `navigation[].target.page_type` | Тип страницы: `list`, `form`, `record`, `resource_grid`. |
+| `navigation[].target.query` | Endpoint и method для загрузки данных page route. |
+| `navigation[].target.children` | Вложенные route configs. |
+| `widgets` | Глобальные виджеты, построенные из действий модулей с `WidgetConfig`. |
+| `widgets[].placement` | Место отображения виджета в shell, например `topbar`. |
+| `widgets[].query` | Endpoint и method действия, данные которого нужны виджету. |
 | `role` | Роль текущего пользователя. |
 
 Renderer discovery происходит через `/api/config`: frontend может проверить compatibility с `UniversalRenderer` до загрузки данных страницы. Data responses (`list`, `defrec`, `view`) повторяют `renderer.name/version`, чтобы каждый response был самодостаточным.

--- a/module.go
+++ b/module.go
@@ -8,26 +8,25 @@ import (
 	pg "github.com/go-jet/jet/v2/postgres"
 )
 
-type MenuItem struct {
+type NavigationEntry struct {
 	ActionName string                 `json:"action"`
+	ID         string                 `json:"id,omitempty"`
+	Path       string                 `json:"path,omitempty"`
 	Title      string                 `json:"title"`
 	Icon       string                 `json:"icon,omitempty"`
 	Show       bool                   `json:"show"`
 	Order      int                    `json:"order"`
 	Group      string                 `json:"group"`
-	Menu       string                 `json:"menu,omitempty"`
-	Target     MenuTarget             `json:"target,omitempty"`
+	Target     NavigationTarget       `json:"target,omitempty"`
 	Roles      []actions.Role         `json:"roles,omitempty"`
 	Query      map[string]interface{} `json:"query,omitempty"`
 	Data       map[string]interface{} `json:"data,omitempty"`
 }
 
-type MenuTarget struct {
-	Type     string                 `json:"type"`
-	URL      string                 `json:"url,omitempty"`
-	RouteKey string                 `json:"route_key,omitempty"`
-	Name     string                 `json:"name,omitempty"`
-	Params   map[string]interface{} `json:"params,omitempty"`
+type NavigationTarget struct {
+	Type   string                 `json:"type"`
+	Name   string                 `json:"name,omitempty"`
+	Params map[string]interface{} `json:"params,omitempty"`
 }
 
 type RenderFunc func(c *gin.Context, base renderer.Universal) (renderer.Universal, error)
@@ -47,7 +46,7 @@ type BaseModule struct {
 	RoleBeforeHook []actions.RoleHook         `json:"-"`
 	RoleAfterHook  []actions.RoleAfterHook    `json:"-"`
 	EntityName     string                     `json:"-"`
-	MenuItems      []MenuItem                 `json:"menu_items,omitempty"`
+	Navigation     []NavigationEntry          `json:"navigation,omitempty"`
 	Render         renderer.Universal         `json:"-"`
 	RenderFunc     RenderFunc                 `json:"-"`
 }

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -29,7 +29,7 @@ func setupTestRouter(authMiddleware func(actions.ModuleAction) gin.HandlerFunc) 
 				ID: "users",
 			},
 		},
-		MenuItems: []module.MenuItem{
+		Navigation: []module.NavigationEntry{
 			{
 				ActionName: "list",
 				Title:      "Пользователи",
@@ -37,6 +37,7 @@ func setupTestRouter(authMiddleware func(actions.ModuleAction) gin.HandlerFunc) 
 				Order:      1,
 				Icon:       "user",
 				Show:       true,
+				Path:       "/admin/users",
 			},
 			{
 				ActionName: "add",
@@ -45,6 +46,7 @@ func setupTestRouter(authMiddleware func(actions.ModuleAction) gin.HandlerFunc) 
 				Order:      2,
 				Icon:       "plus",
 				Show:       true,
+				Path:       "/admin/users/add",
 			},
 		},
 		Actions: []actions.ModuleAction{
@@ -135,8 +137,8 @@ func TestConfigEndpoint_ValidToken(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
 
-	assert.Contains(t, response, "menus")
-	assert.Contains(t, response, "routes")
+	assert.Contains(t, response, "navigation")
+	assert.Contains(t, response, "widgets")
 	assert.Contains(t, response, "role")
 	assert.Equal(t, "admin", response["role"])
 }
@@ -182,13 +184,14 @@ func TestConfigEndpoint_RoleFiltering(t *testing.T) {
 	testModule := &module.BaseModule{
 		Name: "restricted",
 		Path: "/admin",
-		MenuItems: []module.MenuItem{
+		Navigation: []module.NavigationEntry{
 			{
 				ActionName: "list",
 				Title:      "Restricted Module",
 				Group:      "Admin",
 				Order:      1,
 				Show:       true,
+				Path:       "/admin/restricted",
 			},
 		},
 		Actions: []actions.ModuleAction{
@@ -223,7 +226,7 @@ func TestConfigEndpoint_RoleFiltering(t *testing.T) {
 	var adminResponse module.ConfigResponse
 	err := json.Unmarshal(w.Body.Bytes(), &adminResponse)
 	require.NoError(t, err)
-	assert.NotEmpty(t, adminResponse.Routes, "Admin should see routes")
+	assert.NotEmpty(t, adminResponse.Navigation, "Admin should see navigation")
 
 	// Тестируем доступ для менеджера (НЕ должен видеть модуль)
 	managerEngine := gin.New()
@@ -238,11 +241,11 @@ func TestConfigEndpoint_RoleFiltering(t *testing.T) {
 	var managerResponse module.ConfigResponse
 	err = json.Unmarshal(w.Body.Bytes(), &managerResponse)
 	require.NoError(t, err)
-	assert.Empty(t, managerResponse.Routes, "Manager should not see admin-only routes")
+	assert.Empty(t, managerResponse.Navigation, "Manager should not see admin-only navigation")
 }
 
-// TestConfigEndpoint_MenuStructure — проверка структуры menus
-func TestConfigEndpoint_MenuStructure(t *testing.T) {
+// TestConfigEndpoint_NavigationStructure — проверка структуры navigation
+func TestConfigEndpoint_NavigationStructure(t *testing.T) {
 	mockUser := &icontext.UserInfo{
 		ID:   1,
 		Role: "admin",
@@ -258,24 +261,19 @@ func TestConfigEndpoint_MenuStructure(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, response.Menus, "Menus should not be empty")
-	require.NotEmpty(t, response.Menus["sidebar"], "Sidebar menu should not be empty")
+	require.NotEmpty(t, response.Navigation, "Navigation should not be empty")
 
-	// Проверяем структуру первого блока меню
-	sidebarBlock := response.Menus["sidebar"][0]
-	assert.NotEmpty(t, sidebarBlock.BlockTitle, "Block title should not be empty")
-	assert.NotEmpty(t, sidebarBlock.Elements, "Block should have elements")
-
-	for _, element := range sidebarBlock.Elements {
-		assert.Equal(t, "route", element.Target.Type, "Menu item should default to route target")
-		assert.NotEmpty(t, element.Target.URL, "Route menu item target URL should not be empty")
-		assert.NotEmpty(t, element.Target.RouteKey, "Route menu item target route_key should not be empty")
-		assert.Contains(t, response.Routes, element.Target.RouteKey, "Menu item target route_key should point to routes")
+	for _, element := range response.Navigation {
+		assert.Equal(t, "page", element.Target.Type, "Navigation item should default to page target")
+		assert.NotEmpty(t, element.Path, "Page navigation item path should not be empty")
+		assert.NotEmpty(t, element.Target.Query.Url, "Page navigation target query URL should not be empty")
+		assert.NotEmpty(t, element.Target.Query.Method, "Page navigation target query method should not be empty")
+		assert.NotNil(t, element.Target.Data, "Page navigation target data should not be nil")
 	}
 }
 
-// TestConfigEndpoint_RoutesStructure — проверка структуры routes
-func TestConfigEndpoint_RoutesStructure(t *testing.T) {
+// TestConfigEndpoint_PageTargetStructure — проверка структуры page target
+func TestConfigEndpoint_PageTargetStructure(t *testing.T) {
 	mockUser := &icontext.UserInfo{
 		ID:   1,
 		Role: "admin",
@@ -291,36 +289,22 @@ func TestConfigEndpoint_RoutesStructure(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, response.Routes, "Routes should not be empty")
+	require.NotEmpty(t, response.Navigation, "Navigation should not be empty")
 
-	// Проверяем структуру маршрутов
-	for routePath, routeConfig := range response.Routes {
-		assert.NotEmpty(t, routePath, "Route path should not be empty")
-		assert.NotEmpty(t, routeConfig.Title, "Route title should not be empty")
-
-		// Проверяем наличие query для маршрута
-		if routeConfig.Query != nil {
-			assert.NotEmpty(t, routeConfig.Query.Url, "Query URL should not be empty")
-			assert.NotEmpty(t, routeConfig.Query.Method, "Query method should not be empty")
-		}
-
-		// Проверяем наличие data
-		assert.NotNil(t, routeConfig.Data, "Route data should not be nil")
-	}
-
-	// Проверяем, что есть хотя бы один маршрут для нашего тестового модуля
-	foundUsersRoute := false
-	for routePath := range response.Routes {
-		if routePath == "/admin/users" {
-			foundUsersRoute = true
+	var usersEntry *module.ConfigNavigationEntry
+	for i := range response.Navigation {
+		if response.Navigation[i].Path == "/admin/users" {
+			usersEntry = &response.Navigation[i]
 			break
 		}
 	}
-	assert.True(t, foundUsersRoute, "Should have route for /admin/users")
+	require.NotNil(t, usersEntry, "Should have navigation entry for /admin/users")
 
-	usersRoute := response.Routes["/admin/users"]
-	require.NotNil(t, usersRoute.Renderer, "Users route should expose renderer discovery")
-	assert.Equal(t, renderer.Name, usersRoute.Renderer.Name)
-	assert.Equal(t, renderer.Version, usersRoute.Renderer.Version)
-	assert.Equal(t, renderer.PageTypeList, usersRoute.PageType)
+	require.NotNil(t, usersEntry.Target.Renderer, "Users page target should expose renderer discovery")
+	assert.Equal(t, renderer.Name, usersEntry.Target.Renderer.Name)
+	assert.Equal(t, renderer.Version, usersEntry.Target.Renderer.Version)
+	assert.Equal(t, renderer.PageTypeList, usersEntry.Target.PageType)
+	assert.Equal(t, "/api/admin/users", usersEntry.Target.Query.Url)
+	assert.Equal(t, "GET", usersEntry.Target.Query.Method)
+	assert.NotNil(t, usersEntry.Target.Data, "Users page target data should not be nil")
 }

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -268,8 +268,8 @@ func TestUniversalRendererMetadata_RenderFuncBuildsTypedRuntimeMetadata(t *testi
 			}
 			return base, nil
 		},
-		MenuItems: []module.MenuItem{
-			{ActionName: "list", Title: "Dynamic", Group: "Admin", Order: 1, Show: true},
+		Navigation: []module.NavigationEntry{
+			{ActionName: "list", Title: "Dynamic", Group: "Admin", Order: 1, Show: true, Path: "/admin/dynamic-renderer-items"},
 		},
 		Actions: []actions.ModuleAction{
 			actions.ListModuleAction{
@@ -312,9 +312,16 @@ func TestUniversalRendererMetadata_RenderFuncBuildsTypedRuntimeMetadata(t *testi
 
 	var configResponse module.ConfigResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &configResponse))
-	route := configResponse.Routes["/admin/dynamic-renderer-items"]
-	require.NotNil(t, route.Renderer)
-	assert.Equal(t, renderer.PageTypeList, route.PageType)
+	var entry *module.ConfigNavigationEntry
+	for i := range configResponse.Navigation {
+		if configResponse.Navigation[i].Path == "/admin/dynamic-renderer-items" {
+			entry = &configResponse.Navigation[i]
+			break
+		}
+	}
+	require.NotNil(t, entry)
+	require.NotNil(t, entry.Target.Renderer)
+	assert.Equal(t, renderer.PageTypeList, entry.Target.PageType)
 }
 
 func TestUniversalRendererMetadata_RenderFuncResultIsValidated(t *testing.T) {


### PR DESCRIPTION
## Что изменено

- Объединен старый config `menus/routes` в единый `navigation[]`: page route теперь описан прямо в `navigation[].target`.
- Добавлен `WidgetConfig` на действия модулей, чтобы глобальные виджеты возвращались через `/api/config.widgets`.
- Для `defrec` добавлена возможность быть source для widget.
- Query URL больше не получает двойной `/api`, если `module.Path` уже начинается с `/api`.
- Обновлены интеграционные тесты и документация UniversalRenderer/config contract.

## Новый контракт

- `/api/config.navigation[]` - источник истины для меню и frontend routes.
- `target.type=page` содержит `renderer`, `page_type`, `query`, `children`.
- `target.type=client_action/modal/external` не требует route path.
- `/api/config.widgets[]` строится из действий модулей с `Widget`.

## Проверка

- `go test ./...`

## Зависимые PR

- API v2 должен перейти с `MenuItems/MenuTarget` на `Navigation/NavigationTarget`.
- Webapp v2 должен читать новый `/api/config` contract.