### PR TITLE
Add option labels to view items

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -985,6 +985,9 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 			if len(options) > 0 {
 				for i, opt := range options {
 					options[i].Label = generator.Translate(lang, opt.Label)
+					if optionValueMatches(value, opt.Value) {
+						fieldItem["label"] = options[i].Label
+					}
 				}
 				fieldItem["options"] = options
 			}
@@ -1021,6 +1024,13 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 
 		action.AfterRequest(c)
 	}
+}
+
+func optionValueMatches(value interface{}, optionValue interface{}) bool {
+	if value == nil || optionValue == nil {
+		return value == optionValue
+	}
+	return fmt.Sprint(value) == fmt.Sprint(optionValue)
 }
 
 func (generator *Generator) actionUpdate(module *BaseModule, action actions.UpdateModuleAction) func(c *gin.Context) {

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -80,7 +80,16 @@ func setupUniversalRendererRouter(t *testing.T) *gin.Engine {
 		PrimaryKey: id,
 		Fields: []fields.ModuleField{
 			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
-			{Column: status, Title: "Status", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeSelect},
+			{
+				Column:   status,
+				Title:    "Status",
+				Type:     fields.ModuleFieldTypeString,
+				FormType: fields.ModuleFieldFormTypeSelect,
+				Options: []fields.ModuleFieldOptions{
+					{Value: "active", Label: "Active"},
+					{Value: "archived", Label: "Archived"},
+				},
+			},
 		},
 		Render: renderer.Universal{
 			List: &renderer.ListPage{
@@ -187,6 +196,10 @@ func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	var response struct {
 		Renderer   *renderer.Identity   `json:"renderer"`
 		RecordPage *renderer.RecordPage `json:"record_page"`
+		Item       map[string]struct {
+			Value interface{} `json:"value"`
+			Label string      `json:"label"`
+		} `json:"item"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 
@@ -195,6 +208,8 @@ func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	assert.Equal(t, renderer.Version, response.Renderer.Version)
 	require.NotNil(t, response.RecordPage)
 	assert.Equal(t, renderer.LayoutThreeColumn, response.RecordPage.Layout.Type)
+	assert.Equal(t, "active", response.Item["status"].Value)
+	assert.Equal(t, "Active", response.Item["status"].Label)
 }
 
 func TestUniversalRendererMetadata_ListAndResourceGridAreMutuallyExclusive(t *testing.T) {


### PR DESCRIPTION
## Что изменилось

- В `view` response для поля с `Options`, `OptionsFunc` или `RoleOptions` добавляется `item[field].label`, если `item[field].value` совпал с option value.
- `value` не меняется, поэтому существующие потребители не ломаются.
- Это нужно для universal renderer: UI берет отображаемый текст из `item[field].label || item[field].value` и не знает, как переводить enum values.

## Проверка

- `go test ./...`
