### PR TITLE
Allow card schema on record pages

### DIFF
--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -48,6 +48,7 @@ func cloneRecordPage(v *RecordPage) *RecordPage {
 	cp.Layout = cloneLayout(v.Layout)
 	cp.Sections = cloneRecordSections(v.Sections)
 	cp.DisplayData = cloneRecordDisplayData(v.DisplayData)
+	cp.CardSchema = cloneCardSchema(v.CardSchema)
 	cp.Theme = cloneRecordTheme(v.Theme)
 	cp.Actions = cloneActions(v.Actions)
 	cp.Context = cloneMap(v.Context)

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -421,6 +421,7 @@ type RecordPage struct {
 	Layout        *Layout                `json:"layout,omitempty"`
 	Sections      []RecordSection        `json:"sections,omitempty"`
 	DisplayData   *RecordDisplayData     `json:"display_data,omitempty"`
+	CardSchema    *CardSchema            `json:"card_schema,omitempty"`
 	Theme         *RecordTheme           `json:"theme,omitempty"`
 	Actions       []Action               `json:"actions,omitempty"`
 	Context       map[string]interface{} `json:"context,omitempty"`

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -97,6 +97,13 @@ func setupUniversalRendererRouter(t *testing.T) *gin.Engine {
 			},
 			Record: &renderer.RecordPage{
 				Layout: &renderer.Layout{Type: renderer.LayoutThreeColumn},
+				CardSchema: &renderer.CardSchema{
+					Media: &renderer.Media{Field: "avatar", Renderer: renderer.RendererAvatar},
+					Title: &renderer.TextBinding{Field: "name"},
+					Badges: []renderer.Badge{
+						{ID: "status", Field: "status", Tone: "success"},
+					},
+				},
 			},
 		},
 		Actions: []actions.ModuleAction{
@@ -195,6 +202,13 @@ func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	assert.Equal(t, renderer.Version, response.Renderer.Version)
 	require.NotNil(t, response.RecordPage)
 	assert.Equal(t, renderer.LayoutThreeColumn, response.RecordPage.Layout.Type)
+	require.NotNil(t, response.RecordPage.CardSchema)
+	require.NotNil(t, response.RecordPage.CardSchema.Media)
+	assert.Equal(t, "avatar", response.RecordPage.CardSchema.Media.Field)
+	require.NotNil(t, response.RecordPage.CardSchema.Title)
+	assert.Equal(t, "name", response.RecordPage.CardSchema.Title.Field)
+	require.Len(t, response.RecordPage.CardSchema.Badges, 1)
+	assert.Equal(t, "status", response.RecordPage.CardSchema.Badges[0].Field)
 }
 
 func TestUniversalRendererMetadata_ListAndResourceGridAreMutuallyExclusive(t *testing.T) {


### PR DESCRIPTION
## Что изменилось

- В `renderer.RecordPage` добавлено поле `card_schema *CardSchema`.
- Используется уже существующая typed-структура `CardSchema`: `media`, `title`, `subtitle`, `badges`, `stats`, `actions`.
- Clone renderer-а теперь копирует `RecordPage.CardSchema`.
- Добавлен integration test на сериализацию `record_page.card_schema`.

## Зачем

Это позволяет описывать компактные record widgets, например account dropdown, без `map[string]interface{}` в `record_page.context` и без новой специализированной структуры.

## Проверка

- `go test ./...`
