### PR TITLE
Expose form page in view responses

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -1008,11 +1008,13 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 		output := struct {
 			Renderer   *renderer.Identity     `json:"renderer,omitempty"`
 			RecordPage *renderer.RecordPage   `json:"record_page,omitempty"`
+			FormPage   *renderer.FormPage     `json:"form_page,omitempty"`
 			Extra      interface{}            `json:"extra,omitempty"`
 			Item       map[string]interface{} `json:"item"`
 		}{
 			Renderer:   render.RecordIdentity(),
 			RecordPage: render.Record,
+			FormPage:   render.Form,
 			Extra:      extra,
 			Item:       item,
 		}


### PR DESCRIPTION
## Что изменено
- `view` response теперь может дополнительно возвращать `form_page`, если модуль собрал форму через `RenderFor`.
- Это универсальная поддержка смешанного экрана `item + form_page`, без привязки к конкретному проекту или модулю.

## Зачем
- API-driven экраны настроек могут загружать текущую запись и схему формы одним `view` запросом.

## Проверки
- `go test ./...`
