### PR TITLE
Support form page type for view actions

### DIFF
--- a/actions/view_module_action.go
+++ b/actions/view_module_action.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"github.com/darkrain/request-generator/renderer"
 	"github.com/gin-gonic/gin"
 	pg "github.com/go-jet/jet/v2/postgres"
 )
@@ -21,6 +22,8 @@ type ViewModuleAction struct {
 	ExtraFunc    func(c *gin.Context) interface{} `json:"-"`
 	Fields       []RoleContext                    `json:"-"`
 	Widget       *WidgetConfig                    `json:"widget,omitempty"`
+	PageType     renderer.PageType                `json:"page_type,omitempty"`
+	PageTypeFunc func(c *gin.Context) renderer.PageType
 }
 
 func (action ViewModuleAction) Action() ModuleActionName {

--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -207,6 +207,10 @@ func (generator *Generator) buildNavigation(c *gin.Context, role string, lang lo
 					return nil, err
 				}
 				route := generator.buildRouteForAction(module, render, action, role)
+				if entry.Target.PageType != "" {
+					route.Renderer = viewRouteIdentity(render, entry.Target.PageType)
+					route.PageType = viewRoutePageType(render, entry.Target.PageType)
+				}
 				target.Renderer = route.Renderer
 				target.PageType = route.PageType
 				target.Query = route.Query
@@ -404,11 +408,12 @@ func (generator *Generator) buildViewRoute(module *BaseModule, render renderer.U
 	if adapter, exists := generator.ViewAdapters["view"]; exists {
 		viewAdapter = adapter
 	}
+	pageType := viewActionPageType(action)
 
 	return RouteConfig{
 		Title:    action.Label,
-		Renderer: render.RecordIdentity(),
-		PageType: render.RecordRoutePageType(),
+		Renderer: viewRouteIdentity(render, pageType),
+		PageType: viewRoutePageType(render, pageType),
 		Query: &RouteQuery{
 			Url:    apiQueryURL(module.Path + "/" + module.Name + "/view/:bykey/:value"),
 			Method: "GET",
@@ -416,6 +421,44 @@ func (generator *Generator) buildViewRoute(module *BaseModule, render renderer.U
 		Data: map[string]interface{}{
 			"view_adapter": viewAdapter,
 		},
+	}
+}
+
+func viewActionPageType(action actions.ViewModuleAction) renderer.PageType {
+	if action.PageType != "" {
+		return action.PageType
+	}
+	return renderer.PageTypeRecord
+}
+
+func viewActionPageTypeForContext(action actions.ViewModuleAction, c *gin.Context) renderer.PageType {
+	if action.PageTypeFunc != nil {
+		if pageType := action.PageTypeFunc(c); pageType != "" {
+			return pageType
+		}
+	}
+	return viewActionPageType(action)
+}
+
+func viewRouteIdentity(render renderer.Universal, pageType renderer.PageType) *renderer.Identity {
+	switch pageType {
+	case renderer.PageTypeForm:
+		return render.FormIdentity()
+	case renderer.PageTypeRecord:
+		return render.RecordIdentity()
+	default:
+		return nil
+	}
+}
+
+func viewRoutePageType(render renderer.Universal, pageType renderer.PageType) renderer.PageType {
+	switch pageType {
+	case renderer.PageTypeForm:
+		return render.FormRoutePageType()
+	case renderer.PageTypeRecord:
+		return render.RecordRoutePageType()
+	default:
+		return ""
 	}
 }
 
@@ -549,8 +592,8 @@ func (generator *Generator) buildViewChild(module *BaseModule, render renderer.U
 
 	return RouteConfig{
 		Title:    a.Label,
-		Renderer: render.RecordIdentity(),
-		PageType: render.RecordRoutePageType(),
+		Renderer: viewRouteIdentity(render, viewActionPageType(a)),
+		PageType: viewRoutePageType(render, viewActionPageType(a)),
 		Query: &RouteQuery{
 			Url:    apiQueryURL(module.Path + "/" + module.Name + "/view/:bykey/:value"),
 			Method: "GET",

--- a/generator.go
+++ b/generator.go
@@ -862,6 +862,8 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 			}
 		}()
 
+		pageType := viewActionPageTypeForContext(action, c)
+
 		err := action.BeforeRequest(c)
 		if err != nil {
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
@@ -1012,11 +1014,15 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 			Extra      interface{}            `json:"extra,omitempty"`
 			Item       map[string]interface{} `json:"item"`
 		}{
-			Renderer:   render.RecordIdentity(),
-			RecordPage: render.Record,
-			FormPage:   render.Form,
-			Extra:      extra,
-			Item:       item,
+			Renderer: viewRouteIdentity(render, pageType),
+			Extra:    extra,
+			Item:     item,
+		}
+		switch pageType {
+		case renderer.PageTypeForm:
+			output.FormPage = render.Form
+		case renderer.PageTypeRecord:
+			output.RecordPage = render.Record
 		}
 
 		response.Response(l, c, output)

--- a/module.go
+++ b/module.go
@@ -24,9 +24,10 @@ type NavigationEntry struct {
 }
 
 type NavigationTarget struct {
-	Type   string                 `json:"type"`
-	Name   string                 `json:"name,omitempty"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	Type     string                 `json:"type"`
+	Name     string                 `json:"name,omitempty"`
+	Params   map[string]interface{} `json:"params,omitempty"`
+	PageType renderer.PageType      `json:"page_type,omitempty"`
 }
 
 type RenderFunc func(c *gin.Context, base renderer.Universal) (renderer.Universal, error)

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -197,6 +197,115 @@ func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	assert.Equal(t, renderer.LayoutThreeColumn, response.RecordPage.Layout.Type)
 }
 
+func TestUniversalRendererMetadata_ViewFormPageResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	id := postgres.IntegerColumn("id")
+	status := postgres.StringColumn("status")
+	table := postgres.NewTable("public", "renderer_settings", "", id, status)
+
+	testModule := &module.BaseModule{
+		Name:       "renderer-settings",
+		Path:       "/admin",
+		Table:      table,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
+			{Column: status, Title: "Status", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeText},
+		},
+		Render: renderer.Universal{
+			Form: &renderer.FormPage{
+				ID:     "renderer-settings-form",
+				Layout: renderer.LayoutTwoColumn,
+			},
+			Record: &renderer.RecordPage{
+				ID:     "renderer-settings-record",
+				Layout: &renderer.Layout{Type: renderer.LayoutThreeColumn},
+			},
+		},
+		Actions: []actions.ModuleAction{
+			actions.ViewModuleAction{
+				Columns:    []pg.Column{id, status},
+				By:         []pg.Column{id},
+				Permission: []actions.Role{actions.RoleAll},
+				Auth:       true,
+				Label:      "Settings",
+				PageTypeFunc: func(c *gin.Context) renderer.PageType {
+					if c.Query("settings") == "1" {
+						return renderer.PageTypeForm
+					}
+					return renderer.PageTypeRecord
+				},
+			},
+		},
+		Navigation: []module.NavigationEntry{
+			{
+				ActionName: "view",
+				Title:      "Settings",
+				Group:      "settings",
+				Show:       true,
+				Path:       "/settings",
+				Target: module.NavigationTarget{
+					Type:     "page",
+					PageType: renderer.PageTypeForm,
+					Params: map[string]interface{}{
+						"bykey": "current",
+						"value": "current",
+					},
+				},
+			},
+		},
+	}
+
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(
+		func(_ *module.BaseModule) dbpkg.DBExecutor { return fakeRendererDB{} },
+		*group,
+		[]*module.BaseModule{testModule},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+	)
+	generator.Run()
+
+	w := executeRequest(engine, http.MethodGet, "/api/config", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var config module.ConfigResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &config))
+	require.Len(t, config.Navigation, 1)
+	assert.Equal(t, renderer.PageTypeForm, config.Navigation[0].Target.PageType)
+	require.NotNil(t, config.Navigation[0].Target.Query)
+	assert.Equal(t, "/api/admin/renderer-settings/view/:bykey/:value", config.Navigation[0].Target.Query.Url)
+
+	w = executeRequest(engine, http.MethodGet, "/admin/renderer-settings/view/id/1?settings=1", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response struct {
+		Renderer   *renderer.Identity   `json:"renderer"`
+		FormPage   *renderer.FormPage   `json:"form_page"`
+		RecordPage *renderer.RecordPage `json:"record_page"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NotNil(t, response.Renderer)
+	require.NotNil(t, response.FormPage)
+	assert.Equal(t, "renderer-settings-form", response.FormPage.ID)
+	assert.Nil(t, response.RecordPage)
+
+	w = executeRequest(engine, http.MethodGet, "/admin/renderer-settings/view/id/1", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	response = struct {
+		Renderer   *renderer.Identity   `json:"renderer"`
+		FormPage   *renderer.FormPage   `json:"form_page"`
+		RecordPage *renderer.RecordPage `json:"record_page"`
+	}{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NotNil(t, response.RecordPage)
+	assert.Nil(t, response.FormPage)
+}
+
 func TestUniversalRendererMetadata_ListAndResourceGridAreMutuallyExclusive(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Что изменено

Добавлена typed-настройка `ViewModuleAction.PageType` для случаев, когда `view` action должен быть отрендерен не как `record`, а как `form`.

## Зачем

Некоторые API-driven страницы используют `view` endpoint для загрузки текущей записи, но визуально являются формой редактирования. Без action-level page type `/api/config` вынужден отдавать `page_type=record`, а response может содержать одновременно `record_page` и `form_page`, что оставляет фронту неоднозначный выбор renderer.

## Контракт

- если `PageType` не задан, `ViewModuleAction` работает как раньше: `record`;
- если `PageType: renderer.PageTypeForm`, route в `/api/config` получает `page_type=form`;
- response view action возвращает canonical page schema выбранного типа: для form только `form_page`, без competing `record_page`.

## Проверки

- `go test ./...`