### PR TITLE
Validate submitted fields with checks outside action columns

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"database/sql"
 	"fmt"
 	"strconv"
 	"strings"
@@ -80,6 +81,7 @@ func (generator *Generator) checkRequest(
 ) map[string]string {
 	errs := make(map[string]string)
 	actionColumns := action.GetColumns(context)
+	checked := make(map[string]struct{}, len(actionColumns))
 
 	for _, col := range actionColumns {
 		colName := col.Name()
@@ -87,57 +89,124 @@ func (generator *Generator) checkRequest(
 		if field == nil {
 			continue
 		}
-
+		fieldKey := field.ColumnName()
 		if field.Translatable {
-			// For translatable fields, look up by FieldName and validate each language
-			value := data[field.Name()]
-			rules := module.GetRules(context, *field, scenario)
+			fieldKey = field.Name()
+		}
+		checked[fieldKey] = struct{}{}
+		validateRequestField(context, data, *field, scenario, lang, generator.db(module).RawDB(), errs)
+	}
 
-			if langMap, ok := value.(map[string]interface{}); ok {
-				for langKey, langVal := range langMap {
-					for _, rule := range rules {
-						err := rule.Validate(langVal, string(lang))
-						if err != nil {
-							errs[field.Name()+"."+langKey] = err.Error()
-						}
-					}
-				}
-			} else {
-				for _, rule := range rules {
-					err := rule.Validate(value, string(lang))
-					if err != nil {
-						errs[field.Name()] = err.Error()
-					}
-				}
-			}
+	for key := range data {
+		if _, ok := checked[key]; ok {
 			continue
 		}
-
-		value := data[colName]
-		rules := module.GetRules(context, *field, scenario)
-
-		for _, rule := range rules {
-			if dr, ok := rule.(fields.DataCheckRule); ok {
-				if err := dr.ValidateData(context, generator.db(module).RawDB(), data, string(lang)); err != nil {
-					errs[colName] = err.Error()
-				}
-				continue
-			}
-			err := rule.Validate(value, string(lang))
-			if err != nil {
-				errs[colName] = err.Error()
-			}
+		field := module.GetField(key)
+		if field == nil {
+			continue
 		}
-
-		if field.Convert != nil && value != nil {
-			_, err := field.Convert(context, value)
-			if err != nil {
-				errs[colName] = err.Error()
-			}
+		if len(module.GetRules(context, *field, scenario)) == 0 {
+			continue
 		}
+		validateRequestField(context, data, *field, scenario, lang, generator.db(module).RawDB(), errs)
 	}
 
 	return errs
+}
+
+func validateRequestField(
+	context *gin.Context,
+	data map[string]interface{},
+	field fields.ModuleField,
+	scenario fields.Scenario,
+	lang locale.Lang,
+	rawDB *sql.DB,
+	errs map[string]string,
+) {
+	if field.Translatable {
+		value := data[field.Name()]
+		rules := contextFieldRules(context, field, scenario)
+		if langMap, ok := value.(map[string]interface{}); ok {
+			for langKey, langVal := range langMap {
+				for _, rule := range rules {
+					err := rule.Validate(langVal, string(lang))
+					if err != nil {
+						errs[field.Name()+"."+langKey] = err.Error()
+					}
+				}
+			}
+		} else {
+			for _, rule := range rules {
+				err := rule.Validate(value, string(lang))
+				if err != nil {
+					errs[field.Name()] = err.Error()
+				}
+			}
+		}
+		return
+	}
+
+	colName := field.ColumnName()
+	value := data[colName]
+	rules := contextFieldRules(context, field, scenario)
+	for _, rule := range rules {
+		if dr, ok := rule.(fields.DataCheckRule); ok {
+			if err := dr.ValidateData(context, rawDB, data, string(lang)); err != nil {
+				errs[colName] = err.Error()
+			}
+			continue
+		}
+		err := rule.Validate(value, string(lang))
+		if err != nil {
+			errs[colName] = err.Error()
+		}
+	}
+
+	if field.Convert != nil && value != nil {
+		_, err := field.Convert(context, value)
+		if err != nil {
+			errs[colName] = err.Error()
+		}
+	}
+}
+
+func contextFieldRules(context *gin.Context, field fields.ModuleField, scenario fields.Scenario) []fields.CheckRules {
+	rules := make([]fields.CheckRules, 0, 10)
+	if field.Check != nil {
+		for _, rule := range field.Check {
+			if scenarioMatches(rule.GetScenarios(), scenario) {
+				rules = append(rules, rule)
+			}
+		}
+	}
+	if field.CheckFunc != nil {
+		for _, rule := range field.CheckFunc(context) {
+			if scenarioMatches(rule.GetScenarios(), scenario) {
+				rules = append(rules, rule)
+			}
+		}
+	}
+	role := actions.GetRoleFromContext(context)
+	for _, rc := range field.RoleCheck {
+		if rc.Role == string(role) || rc.Role == string(actions.RoleAll) {
+			for _, rule := range rc.Rules {
+				if scenarioMatches(rule.GetScenarios(), scenario) {
+					rules = append(rules, rule)
+				}
+			}
+			break
+		}
+	}
+	return rules
+}
+
+func scenarioMatches(scenarios []fields.Scenario, scenario fields.Scenario) bool {
+	for _, current := range scenarios {
+		if current == scenario {
+			return true
+		}
+	}
+	return false
 }
 
 func (generator *Generator) mapRequestInput(

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -113,6 +114,15 @@ func executeRequest(engine *gin.Engine, method, path string, headers map[string]
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	return w
+}
+
+func executeJSONRequest(engine *gin.Engine, method, path string, body interface{}) *httptest.ResponseRecorder {
+	data, _ := json.Marshal(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	return w

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -304,6 +305,66 @@ func TestUniversalRendererMetadata_ViewFormPageResponse(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.NotNil(t, response.RecordPage)
 	assert.Nil(t, response.FormPage)
+}
+
+func TestCheckRequest_ValidatesSubmittedFieldsOutsideActionColumns(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	id := postgres.IntegerColumn("id")
+	status := postgres.StringColumn("status")
+	table := postgres.NewTable("public", "guarded_items", "", id, status)
+
+	testModule := &module.BaseModule{
+		Name:       "guarded-items",
+		Path:       "/admin",
+		Table:      table,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
+			{
+				Column:   status,
+				Title:    "Status",
+				Type:     fields.ModuleFieldTypeString,
+				FormType: fields.ModuleFieldFormTypeSelect,
+				Check: []fields.CheckRules{
+					fields.DataRule(func(_ *gin.Context, _ *sql.DB, data map[string]interface{}, _ string) error {
+						if _, exists := data["status"]; exists {
+							return fmt.Errorf("status is read-only")
+						}
+						return nil
+					}, []fields.Scenario{fields.ScenarioUpdate}),
+				},
+			},
+		},
+		Actions: []actions.ModuleAction{
+			actions.UpdateModuleAction{
+				Columns:    []pg.Column{id},
+				By:         []pg.Column{id},
+				Permission: []actions.Role{actions.RoleAll},
+				Auth:       true,
+				Label:      "Update",
+			},
+		},
+	}
+
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(
+		func(_ *module.BaseModule) dbpkg.DBExecutor { return fakeRendererDB{} },
+		*group,
+		[]*module.BaseModule{testModule},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+	)
+	generator.Run()
+
+	w := executeJSONRequest(engine, http.MethodPost, "/admin/guarded-items/id/1", map[string]interface{}{
+		"status": "verified",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "status is read-only")
 }
 
 func TestUniversalRendererMetadata_ListAndResourceGridAreMutuallyExclusive(t *testing.T) {


### PR DESCRIPTION
## Что изменено

`checkRequest` теперь дополнительно проверяет поля, которые пришли в payload, но не входят в `action.Columns`, если у этих полей есть `Check`, `CheckFunc` или `RoleCheck` для текущего scenario.

## Зачем

Это нужно, чтобы модуль мог описать запрет через `DataRule` на самом поле и получить field-level ошибку, даже если поле не является editable и не будет передано в `mapRequestInput`. Раньше такие поля молча игнорировались.

## Контракт

- editable/action columns по-прежнему определяют, какие поля реально попадут в update/add;
- submitted non-action fields без checks игнорируются как раньше;
- submitted non-action fields с checks валидируются и могут вернуть `errors[field]`;
- это не открывает запись скрытых полей, потому что `mapRequestInput` все равно берет только action columns.

## Проверки

- `go test ./...`