### PR TITLE
Add typed form field UI metadata

### DIFF
--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -216,8 +216,8 @@ func (generator *Generator) buildNavigation(c *gin.Context, role string, lang lo
 				target.Query = route.Query
 				target.Data = route.Data
 				target.Children = route.Children
-				if target.Query != nil && entry.Query != nil {
-					target.Query.Params = entry.Query
+				if target.Query != nil {
+					target.Query.Params = mergeRouteParams(entry.Target.Params, entry.Query)
 				}
 			}
 
@@ -243,6 +243,20 @@ func (generator *Generator) buildNavigation(c *gin.Context, role string, lang lo
 	})
 
 	return result, nil
+}
+
+func mergeRouteParams(params map[string]interface{}, query map[string]interface{}) map[string]interface{} {
+	if len(params) == 0 && len(query) == 0 {
+		return nil
+	}
+	result := make(map[string]interface{}, len(params)+len(query))
+	for key, value := range params {
+		result[key] = value
+	}
+	for key, value := range query {
+		result[key] = value
+	}
+	return result
 }
 
 func navigationRoleAllowed(entry NavigationEntry, role string) bool {

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -103,6 +103,21 @@ type FieldExtra struct {
 	Defrec interface{} `json:"-"`
 }
 
+type ModuleFieldMatrixBinding struct {
+	Row    string `json:"row,omitempty"`
+	Column string `json:"column,omitempty"`
+}
+
+type ModuleFieldLocationPicker struct {
+	CountryLabel       string   `json:"country_label,omitempty"`
+	CityLabel          string   `json:"city_label,omitempty"`
+	CountryPlaceholder string   `json:"country_placeholder,omitempty"`
+	CityPlaceholder    string   `json:"city_placeholder,omitempty"`
+	CityMode           string   `json:"city_mode,omitempty"`
+	HideInnerLabels    bool     `json:"hide_inner_labels,omitempty"`
+	AllowedCountries   []string `json:"allowed_countries,omitempty"`
+}
+
 type ModuleField struct {
 	Column           pg.Column                                       `json:"-"`
 	SelectExpression pg.Projection                                   `json:"-"`
@@ -134,6 +149,31 @@ type ModuleField struct {
 	Section              string                                                       `json:"section,omitempty"`
 	RoleSection          map[string]string                                            `json:"-"`
 	RoleFormType         map[string]ModuleFieldFormType                               `json:"-"`
+	RoleLocationPicker   map[string]ModuleFieldLocationPicker                         `json:"-"`
+	VisualKind           string                                                       `json:"visual_kind,omitempty"`
+	Width                string                                                       `json:"width,omitempty"`
+	Span                 string                                                       `json:"span,omitempty"`
+	HideLabel            bool                                                         `json:"hide_label,omitempty"`
+	Hint                 string                                                       `json:"hint,omitempty"`
+	Description          string                                                       `json:"description,omitempty"`
+	Meta                 string                                                       `json:"meta,omitempty"`
+	Prefix               string                                                       `json:"prefix,omitempty"`
+	Suffix               string                                                       `json:"suffix,omitempty"`
+	Icon                 string                                                       `json:"icon,omitempty"`
+	IconSVG              string                                                       `json:"icon_svg,omitempty"`
+	Glow                 string                                                       `json:"glow,omitempty"`
+	MaxLength            int                                                          `json:"max_length,omitempty"`
+	Rows                 int                                                          `json:"rows,omitempty"`
+	Searchable           *bool                                                        `json:"searchable,omitempty"`
+	OptionIcons          map[string]string                                            `json:"option_icons,omitempty"`
+	OptionsParams        map[string]interface{}                                       `json:"options_params,omitempty"`
+	VisibleWhen          map[string]interface{}                                       `json:"visible_when,omitempty"`
+	Matrix               *ModuleFieldMatrixBinding                                    `json:"matrix,omitempty"`
+	LocationPicker       *ModuleFieldLocationPicker                                   `json:"location_picker,omitempty"`
+	UploadLabel          string                                                       `json:"upload_label,omitempty"`
+	UploadingLabel       string                                                       `json:"uploading_label,omitempty"`
+	RecenterLabel        string                                                       `json:"recenter_label,omitempty"`
+	RemoveLabel          string                                                       `json:"remove_label,omitempty"`
 }
 
 // ColumnName returns the database column name from the Jet column.
@@ -151,6 +191,98 @@ func (f ModuleField) Name() string {
 		return f.FieldName
 	}
 	return f.ColumnName()
+}
+
+func (f ModuleField) UIMap() map[string]interface{} {
+	return f.UIMapForRole("")
+}
+
+func (f ModuleField) UIMapForRole(role string) map[string]interface{} {
+	item := map[string]interface{}{}
+	if f.VisualKind != "" {
+		item["visual_kind"] = f.VisualKind
+	}
+	if f.Width != "" {
+		item["width"] = f.Width
+	}
+	if f.Span != "" {
+		item["span"] = f.Span
+	}
+	if f.HideLabel {
+		item["hide_label"] = true
+	}
+	if f.Hint != "" {
+		item["hint"] = f.Hint
+	}
+	if f.Description != "" {
+		item["description"] = f.Description
+	}
+	if f.Meta != "" {
+		item["meta"] = f.Meta
+	}
+	if f.Prefix != "" {
+		item["prefix"] = f.Prefix
+	}
+	if f.Suffix != "" {
+		item["suffix"] = f.Suffix
+	}
+	if f.Icon != "" {
+		item["icon"] = f.Icon
+	}
+	if f.IconSVG != "" {
+		item["icon_svg"] = f.IconSVG
+	}
+	if f.Glow != "" {
+		item["glow"] = f.Glow
+	}
+	if f.MaxLength > 0 {
+		item["max_length"] = f.MaxLength
+	}
+	if f.Rows > 0 {
+		item["rows"] = f.Rows
+	}
+	if f.Searchable != nil {
+		item["searchable"] = *f.Searchable
+	}
+	if f.OptionsURL != "" {
+		item["options_url"] = f.OptionsURL
+	}
+	if len(f.OptionIcons) > 0 {
+		item["option_icons"] = f.OptionIcons
+	}
+	if len(f.OptionsParams) > 0 {
+		item["options_params"] = f.OptionsParams
+	}
+	if len(f.VisibleWhen) > 0 {
+		item["visible_when"] = f.VisibleWhen
+	}
+	if f.Matrix != nil {
+		item["matrix"] = f.Matrix
+	}
+	if role != "" && f.RoleLocationPicker != nil {
+		if locationPicker, ok := f.RoleLocationPicker[role]; ok {
+			item["location_picker"] = locationPicker
+		}
+	}
+	if _, ok := item["location_picker"]; !ok && f.LocationPicker != nil {
+		item["location_picker"] = f.LocationPicker
+	}
+	if f.UploadLabel != "" {
+		item["upload_label"] = f.UploadLabel
+	}
+	if f.UploadingLabel != "" {
+		item["uploading_label"] = f.UploadingLabel
+	}
+	if f.RecenterLabel != "" {
+		item["recenter_label"] = f.RecenterLabel
+	}
+	if f.RemoveLabel != "" {
+		item["remove_label"] = f.RemoveLabel
+	}
+	if len(item) == 0 {
+		return nil
+	}
+	return item
 }
 
 // GetProjection returns the SELECT expression for this field.

--- a/generator.go
+++ b/generator.go
@@ -950,8 +950,30 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 		generator.setTranslationContext(c, lang)
 		roleStr := string(role)
 
+		render, err := module.RenderFor(c)
+		if err != nil {
+			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
+			return
+		}
+		metadataRoleStr := roleStr
+		if pageType == renderer.PageTypeForm && render.Form != nil && render.Form.Context != nil {
+			if targetProfileType, ok := render.Form.Context["target_profile_type"].(string); ok && targetProfileType != "" {
+				metadataRoleStr = targetProfileType
+			}
+		}
+
 		item := make(map[string]interface{}, len(realFields))
 		for _, field := range realFields {
+			if field.RoleSection != nil {
+				if s, ok := field.RoleSection[metadataRoleStr]; ok {
+					field.Section = s
+				}
+			}
+			if field.RoleFormType != nil {
+				if ft, ok := field.RoleFormType[metadataRoleStr]; ok {
+					field.FormType = ft
+				}
+			}
 			fieldKey := field.ColumnName()
 			if field.Translatable {
 				fieldKey = field.Name()
@@ -965,9 +987,21 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 				"value":     value,
 				"edit":      containsColumn(editableColumns, field.Column),
 			}
+			if field.Section != "" {
+				fieldItem["section"] = field.Section
+			}
+			if field.Group != "" {
+				fieldItem["group"] = field.Group
+			}
+			if field.Order != 0 {
+				fieldItem["order"] = field.Order
+			}
 
-			if field.Extra != nil && field.Extra.View != nil {
+			if pageType != renderer.PageTypeForm && field.Extra != nil && field.Extra.View != nil {
 				fieldItem["extra"] = field.Extra.View
+			}
+			for key, value := range field.UIMapForRole(metadataRoleStr) {
+				fieldItem[key] = value
 			}
 
 			// Collect options
@@ -999,12 +1033,6 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 			extra = action.ExtraFunc(c)
 		} else {
 			extra = action.Extra
-		}
-
-		render, err := module.RenderFor(c)
-		if err != nil {
-			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
-			return
 		}
 
 		output := struct {

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -33,6 +33,7 @@ func cloneFormPage(v *FormPage) *FormPage {
 	cp := *v
 	cp.Actions = cloneActions(v.Actions)
 	cp.Sections = cloneFormSections(v.Sections)
+	cp.Groups = cloneFormGroups(v.Groups)
 	cp.Fields = cloneSlice(v.Fields)
 	cp.Context = cloneMap(v.Context)
 	return &cp
@@ -277,6 +278,48 @@ func cloneFormSections(values []FormSection) []FormSection {
 		out[i].ListPage = cloneListPage(v.ListPage)
 		out[i].Collection = cloneCollectionConfig(v.Collection)
 		out[i].Preferences = clonePreferencesConfig(v.Preferences)
+	}
+	return out
+}
+
+func cloneFormGroups(values []FormGroup) []FormGroup {
+	if values == nil {
+		return nil
+	}
+	out := make([]FormGroup, len(values))
+	for i, v := range values {
+		out[i] = v
+		out[i].Heads = cloneFormMatrixColumns(v.Heads)
+		out[i].Columns = cloneFormMatrixColumns(v.Columns)
+		out[i].Rows = cloneFormMatrixRows(v.Rows)
+		out[i].Values = cloneMap(v.Values)
+	}
+	return out
+}
+
+func cloneFormMatrixColumns(values []FormMatrixColumn) []FormMatrixColumn {
+	if values == nil {
+		return nil
+	}
+	out := make([]FormMatrixColumn, len(values))
+	copy(out, values)
+	return out
+}
+
+func cloneFormMatrixRows(values []FormMatrixRow) []FormMatrixRow {
+	if values == nil {
+		return nil
+	}
+	out := make([]FormMatrixRow, len(values))
+	for i, v := range values {
+		out[i] = v
+		out[i].Values = cloneMap(v.Values)
+		if v.ValueTypes != nil {
+			out[i].ValueTypes = make(map[string]string, len(v.ValueTypes))
+			for key, value := range v.ValueTypes {
+				out[i].ValueTypes[key] = value
+			}
+		}
 	}
 	return out
 }

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -229,8 +229,48 @@ type FormPage struct {
 	Layout   LayoutType             `json:"layout,omitempty"`
 	Actions  []Action               `json:"actions,omitempty"`
 	Sections []FormSection          `json:"sections,omitempty"`
+	Groups   []FormGroup            `json:"groups,omitempty"`
 	Fields   []string               `json:"fields,omitempty"`
 	Context  map[string]interface{} `json:"context,omitempty"`
+}
+
+type FormGroup struct {
+	ID                  string                 `json:"id,omitempty"`
+	Section             string                 `json:"section,omitempty"`
+	Title               string                 `json:"title,omitempty"`
+	Layout              string                 `json:"layout,omitempty"`
+	MatrixType          string                 `json:"matrix_type,omitempty"`
+	MatrixStyle         string                 `json:"matrix_style,omitempty"`
+	Label               string                 `json:"label,omitempty"`
+	LabelIcon           string                 `json:"label_icon,omitempty"`
+	Underline           string                 `json:"underline,omitempty"`
+	Compact             bool                   `json:"compact,omitempty"`
+	Readonly            bool                   `json:"readonly,omitempty"`
+	ReadonlyColumns     int                    `json:"readonly_columns,omitempty"`
+	SeparatorVariant    ToneToken              `json:"separator_variant,omitempty"`
+	SeparatorAppearance SeparatorAppearance    `json:"separator_appearance,omitempty"`
+	Heads               []FormMatrixColumn     `json:"heads,omitempty"`
+	Rows                []FormMatrixRow        `json:"rows,omitempty"`
+	Columns             []FormMatrixColumn     `json:"columns,omitempty"`
+	Values              map[string]interface{} `json:"values,omitempty"`
+}
+
+type FormMatrixColumn struct {
+	ID     string `json:"id,omitempty"`
+	Label  string `json:"label,omitempty"`
+	Icon   string `json:"icon,omitempty"`
+	Prefix string `json:"prefix,omitempty"`
+}
+
+type FormMatrixRow struct {
+	ID         string                 `json:"id,omitempty"`
+	Label      string                 `json:"label,omitempty"`
+	Span       string                 `json:"span,omitempty"`
+	Column     string                 `json:"column,omitempty"`
+	Value      interface{}            `json:"value,omitempty"`
+	ValueType  string                 `json:"value_type,omitempty"`
+	Values     map[string]interface{} `json:"values,omitempty"`
+	ValueTypes map[string]string      `json:"value_types,omitempty"`
 }
 
 type FormSection struct {

--- a/response/defrec.go
+++ b/response/defrec.go
@@ -29,6 +29,9 @@ func NewDefrecResponse(extra interface{}, fields []f.ModuleField) DefrecResponse
 		if field.Extra != nil && field.Extra.Defrec != nil {
 			item["extra"] = field.Extra.Defrec
 		}
+		for key, value := range field.UIMap() {
+			item[key] = value
+		}
 		if field.Section != "" {
 			item["section"] = field.Section
 		}

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -81,7 +81,19 @@ func setupUniversalRendererRouter(t *testing.T) *gin.Engine {
 		PrimaryKey: id,
 		Fields: []fields.ModuleField{
 			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
-			{Column: status, Title: "Status", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeSelect},
+			{
+				Column:      status,
+				Title:       "Status",
+				Type:        fields.ModuleFieldTypeString,
+				FormType:    fields.ModuleFieldFormTypeSelect,
+				VisualKind:  "select",
+				Width:       "full",
+				Hint:        "status hint",
+				Prefix:      "#",
+				OptionsURL:  "/options/statuses",
+				OptionIcons: map[string]string{"active": "check"},
+				Matrix:      &fields.ModuleFieldMatrixBinding{Row: "status", Column: "value"},
+			},
 		},
 		Render: renderer.Universal{
 			List: &renderer.ListPage{
@@ -166,8 +178,9 @@ func TestUniversalRendererMetadata_DefrecResponse(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var response struct {
-		Renderer *renderer.Identity `json:"renderer"`
-		FormPage *renderer.FormPage `json:"form_page"`
+		Renderer *renderer.Identity                `json:"renderer"`
+		FormPage *renderer.FormPage                `json:"form_page"`
+		Fields   map[string]map[string]interface{} `json:"fields"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 
@@ -177,6 +190,15 @@ func TestUniversalRendererMetadata_DefrecResponse(t *testing.T) {
 	require.NotNil(t, response.FormPage)
 	assert.Equal(t, "renderer-items-form", response.FormPage.ID)
 	assert.Equal(t, renderer.LayoutTwoColumn, response.FormPage.Layout)
+	require.Contains(t, response.Fields, "status")
+	assert.NotContains(t, response.Fields["status"], "extra")
+	assert.Equal(t, "select", response.Fields["status"]["visual_kind"])
+	assert.Equal(t, "full", response.Fields["status"]["width"])
+	assert.Equal(t, "status hint", response.Fields["status"]["hint"])
+	assert.Equal(t, "#", response.Fields["status"]["prefix"])
+	assert.Equal(t, "/options/statuses", response.Fields["status"]["options_url"])
+	assert.Equal(t, map[string]interface{}{"active": "check"}, response.Fields["status"]["option_icons"])
+	assert.Equal(t, map[string]interface{}{"row": "status", "column": "value"}, response.Fields["status"]["matrix"])
 }
 
 func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
@@ -212,12 +234,28 @@ func TestUniversalRendererMetadata_ViewFormPageResponse(t *testing.T) {
 		PrimaryKey: id,
 		Fields: []fields.ModuleField{
 			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
-			{Column: status, Title: "Status", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeText},
+			{
+				Column:     status,
+				Title:      "Status",
+				Type:       fields.ModuleFieldTypeString,
+				FormType:   fields.ModuleFieldFormTypeSelect,
+				VisualKind: "location_picker",
+				Width:      "full",
+				Section:    "profile",
+				Group:      "main",
+				Order:      2,
+				RoleFormType: map[string]fields.ModuleFieldFormType{
+					"model": fields.ModuleFieldFormTypeMultiselect,
+				},
+				LocationPicker:     &fields.ModuleFieldLocationPicker{CityMode: "single"},
+				RoleLocationPicker: map[string]fields.ModuleFieldLocationPicker{"model": {CityMode: "multiple"}},
+			},
 		},
 		Render: renderer.Universal{
 			Form: &renderer.FormPage{
-				ID:     "renderer-settings-form",
-				Layout: renderer.LayoutTwoColumn,
+				ID:      "renderer-settings-form",
+				Layout:  renderer.LayoutTwoColumn,
+				Context: map[string]interface{}{"target_profile_type": "model"},
 			},
 			Record: &renderer.RecordPage{
 				ID:     "renderer-settings-record",
@@ -280,27 +318,39 @@ func TestUniversalRendererMetadata_ViewFormPageResponse(t *testing.T) {
 	assert.Equal(t, renderer.PageTypeForm, config.Navigation[0].Target.PageType)
 	require.NotNil(t, config.Navigation[0].Target.Query)
 	assert.Equal(t, "/api/admin/renderer-settings/view/:bykey/:value", config.Navigation[0].Target.Query.Url)
+	assert.Equal(t, map[string]interface{}{"bykey": "current", "value": "current"}, config.Navigation[0].Target.Query.Params)
 
 	w = executeRequest(engine, http.MethodGet, "/admin/renderer-settings/view/id/1?settings=1", nil)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var response struct {
-		Renderer   *renderer.Identity   `json:"renderer"`
-		FormPage   *renderer.FormPage   `json:"form_page"`
-		RecordPage *renderer.RecordPage `json:"record_page"`
+		Renderer   *renderer.Identity                `json:"renderer"`
+		FormPage   *renderer.FormPage                `json:"form_page"`
+		RecordPage *renderer.RecordPage              `json:"record_page"`
+		Item       map[string]map[string]interface{} `json:"item"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.NotNil(t, response.Renderer)
 	require.NotNil(t, response.FormPage)
 	assert.Equal(t, "renderer-settings-form", response.FormPage.ID)
 	assert.Nil(t, response.RecordPage)
+	require.Contains(t, response.Item, "status")
+	assert.Equal(t, "location_picker", response.Item["status"]["visual_kind"])
+	assert.Equal(t, "full", response.Item["status"]["width"])
+	assert.Equal(t, "profile", response.Item["status"]["section"])
+	assert.Equal(t, "main", response.Item["status"]["group"])
+	assert.Equal(t, float64(2), response.Item["status"]["order"])
+	assert.Equal(t, "multiselect", response.Item["status"]["form_type"])
+	assert.Equal(t, map[string]interface{}{"city_mode": "multiple"}, response.Item["status"]["location_picker"])
+	assert.NotContains(t, response.Item["status"], "extra")
 
 	w = executeRequest(engine, http.MethodGet, "/admin/renderer-settings/view/id/1", nil)
 	require.Equal(t, http.StatusOK, w.Code)
 	response = struct {
-		Renderer   *renderer.Identity   `json:"renderer"`
-		FormPage   *renderer.FormPage   `json:"form_page"`
-		RecordPage *renderer.RecordPage `json:"record_page"`
+		Renderer   *renderer.Identity                `json:"renderer"`
+		FormPage   *renderer.FormPage                `json:"form_page"`
+		RecordPage *renderer.RecordPage              `json:"record_page"`
+		Item       map[string]map[string]interface{} `json:"item"`
 	}{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.NotNil(t, response.RecordPage)


### PR DESCRIPTION
## Что сделано
- Добавлен typed UI metadata contract для полей form renderer без использования legacy extra.
- Добавлены typed FormPage groups/matrix structures.
- View form responses больше не отдают field extra для form page и поддерживают target-aware role metadata.
- /api/config target params прокидываются в route query params.

## Проверки
- go test ./...
- go test ./tests/integration -run 'TestUniversalRendererMetadata_ViewFormPageResponse|TestUniversalRendererMetadata_DefrecResponse' -count=1