### PR TITLE
Add typed media gallery form section contract

### DIFF
--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -277,8 +277,24 @@ func cloneFormSections(values []FormSection) []FormSection {
 		out[i].ListPage = cloneListPage(v.ListPage)
 		out[i].Collection = cloneCollectionConfig(v.Collection)
 		out[i].Preferences = clonePreferencesConfig(v.Preferences)
+		out[i].MediaUpload = clonePtr(v.MediaUpload)
+		out[i].MediaItems = cloneSlice(v.MediaItems)
+		out[i].MediaLabels = clonePtr(v.MediaLabels)
+		out[i].MediaActions = cloneMediaGalleryActions(v.MediaActions)
 	}
 	return out
+}
+
+func cloneMediaGalleryActions(v *MediaGalleryActions) *MediaGalleryActions {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.Upload = cloneAction(v.Upload)
+	cp.Link = cloneAction(v.Link)
+	cp.Reorder = cloneAction(v.Reorder)
+	cp.Remove = cloneAction(v.Remove)
+	return &cp
 }
 
 func cloneCollectionConfig(v *CollectionConfig) *CollectionConfig {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -234,21 +234,65 @@ type FormPage struct {
 }
 
 type FormSection struct {
-	ID          string             `json:"id,omitempty"`
-	Title       string             `json:"title,omitempty"`
-	PanelTitle  string             `json:"panel_title,omitempty"`
-	Subtitle    string             `json:"subtitle,omitempty"`
-	Renderer    RendererKey        `json:"renderer,omitempty"`
-	Group       string             `json:"group,omitempty"`
-	GroupTitle  string             `json:"group_title,omitempty"`
-	Icon        string             `json:"icon,omitempty"`
-	Action      string             `json:"action,omitempty"`
-	Mode        string             `json:"mode,omitempty"`
-	Block       *Block             `json:"block,omitempty"`
-	Fields      []string           `json:"fields,omitempty"`
-	ListPage    *ListPage          `json:"list_page,omitempty"`
-	Collection  *CollectionConfig  `json:"collection,omitempty"`
-	Preferences *PreferencesConfig `json:"preferences,omitempty"`
+	ID           string               `json:"id,omitempty"`
+	Title        string               `json:"title,omitempty"`
+	PanelTitle   string               `json:"panel_title,omitempty"`
+	Subtitle     string               `json:"subtitle,omitempty"`
+	Renderer     RendererKey          `json:"renderer,omitempty"`
+	Group        string               `json:"group,omitempty"`
+	GroupTitle   string               `json:"group_title,omitempty"`
+	Icon         string               `json:"icon,omitempty"`
+	Action       string               `json:"action,omitempty"`
+	Mode         string               `json:"mode,omitempty"`
+	Block        *Block               `json:"block,omitempty"`
+	Fields       []string             `json:"fields,omitempty"`
+	ListPage     *ListPage            `json:"list_page,omitempty"`
+	Collection   *CollectionConfig    `json:"collection,omitempty"`
+	Preferences  *PreferencesConfig   `json:"preferences,omitempty"`
+	MediaUpload  *MediaUploadConfig   `json:"media_upload,omitempty"`
+	MediaItems   []MediaGalleryItem   `json:"media_items,omitempty"`
+	MediaLabels  *MediaGalleryLabels  `json:"media_labels,omitempty"`
+	MediaActions *MediaGalleryActions `json:"media_actions,omitempty"`
+}
+
+type MediaUploadConfig struct {
+	Title        string `json:"title,omitempty"`
+	Subtitle     string `json:"subtitle,omitempty"`
+	LoadingTitle string `json:"loading_title,omitempty"`
+	Accept       string `json:"accept,omitempty"`
+	Multiple     bool   `json:"multiple"`
+}
+
+type MediaGalleryItem struct {
+	ID          string          `json:"id,omitempty"`
+	MediaID     int64           `json:"media_id,omitempty"`
+	LinkID      int64           `json:"link_id,omitempty"`
+	Kind        MediaKind       `json:"kind,omitempty"`
+	Src         string          `json:"src,omitempty"`
+	Poster      string          `json:"poster,omitempty"`
+	Visibility  MediaVisibility `json:"visibility,omitempty"`
+	Usage       MediaUsage      `json:"usage,omitempty"`
+	SortOrder   int             `json:"sort_order"`
+	Title       string          `json:"title,omitempty"`
+	Description string          `json:"description,omitempty"`
+}
+
+type MediaGalleryLabels struct {
+	Public       string `json:"public,omitempty"`
+	Private      string `json:"private,omitempty"`
+	Empty        string `json:"empty,omitempty"`
+	CoverBadge   string `json:"cover_badge,omitempty"`
+	Remove       string `json:"remove,omitempty"`
+	Reorder      string `json:"reorder,omitempty"`
+	FirstIsCover string `json:"first_is_cover,omitempty"`
+	PrivateHint  string `json:"private_hint,omitempty"`
+}
+
+type MediaGalleryActions struct {
+	Upload  *Action `json:"upload,omitempty"`
+	Link    *Action `json:"link,omitempty"`
+	Reorder *Action `json:"reorder,omitempty"`
+	Remove  *Action `json:"remove,omitempty"`
 }
 
 type CollectionConfig struct {

--- a/renderer/tokens.go
+++ b/renderer/tokens.go
@@ -254,6 +254,31 @@ const (
 	ActionAppearanceLink    ActionAppearance = "link"
 )
 
+type MediaKind string
+
+const (
+	MediaKindPhoto MediaKind = "photo"
+	MediaKindVideo MediaKind = "video"
+	MediaKindFile  MediaKind = "file"
+)
+
+type MediaVisibility string
+
+const (
+	MediaVisibilityPublic   MediaVisibility = "public"
+	MediaVisibilityPrivate  MediaVisibility = "private"
+	MediaVisibilityPaid     MediaVisibility = "paid"
+	MediaVisibilityInternal MediaVisibility = "internal"
+)
+
+type MediaUsage string
+
+const (
+	MediaUsageGallery MediaUsage = "gallery"
+	MediaUsageAvatar  MediaUsage = "avatar"
+	MediaUsagePoster  MediaUsage = "poster"
+)
+
 type DisplayComponentType string
 
 const (

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -179,6 +179,122 @@ func TestUniversalRendererMetadata_DefrecResponse(t *testing.T) {
 	assert.Equal(t, renderer.LayoutTwoColumn, response.FormPage.Layout)
 }
 
+func TestUniversalRendererMetadata_FormSectionMediaGallery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	id := postgres.IntegerColumn("id")
+	table := postgres.NewTable("public", "media_renderer_items", "", id)
+
+	testModule := &module.BaseModule{
+		Name:       "media-renderer-items",
+		Path:       "/admin",
+		Table:      table,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
+		},
+		Render: renderer.Universal{
+			Form: &renderer.FormPage{
+				ID:     "media-renderer-items-form",
+				Layout: renderer.LayoutTwoColumn,
+				Sections: []renderer.FormSection{
+					{
+						ID:       "media",
+						Renderer: renderer.RendererMediaGallery,
+						MediaUpload: &renderer.MediaUploadConfig{
+							Title:        "Upload media",
+							Subtitle:     "Images and videos",
+							LoadingTitle: "Uploading",
+							Accept:       "image/jpeg,video/mp4",
+							Multiple:     true,
+						},
+						MediaItems: []renderer.MediaGalleryItem{
+							{
+								ID:         "media-link-1",
+								MediaID:    10,
+								LinkID:     1,
+								Kind:       renderer.MediaKindVideo,
+								Src:        "ipfs://video",
+								Poster:     "ipfs://poster",
+								Visibility: renderer.MediaVisibilityPublic,
+								Usage:      renderer.MediaUsageGallery,
+								SortOrder:  1,
+							},
+						},
+						MediaLabels: &renderer.MediaGalleryLabels{
+							Public:     "Public",
+							Private:    "Private",
+							Empty:      "No media yet",
+							CoverBadge: "Cover",
+						},
+						MediaActions: &renderer.MediaGalleryActions{
+							Upload: &renderer.Action{
+								ID:   "upload",
+								Type: renderer.ActionAPI,
+								API:  &renderer.APIAction{Method: "PUT", Endpoint: "/media_assets"},
+							},
+							Remove: &renderer.Action{
+								ID:   "remove",
+								Type: renderer.ActionAPI,
+								API:  &renderer.APIAction{Method: "DELETE", Endpoint: "/media_links/:id"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Defrec: actions.DefrecModuleAction{
+			Permission: []actions.Role{actions.RoleAll},
+			Auth:       true,
+			Label:      "Defrec",
+		},
+		Actions: []actions.ModuleAction{
+			actions.AddModuleAction{
+				Columns:    []pg.Column{id},
+				Permission: []actions.Role{actions.RoleAll},
+				Auth:       true,
+				Label:      "Add",
+			},
+		},
+	}
+
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(
+		func(_ *module.BaseModule) dbpkg.DBExecutor { return fakeRendererDB{} },
+		*group,
+		[]*module.BaseModule{testModule},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+	)
+	generator.Run()
+
+	w := executeRequest(engine, http.MethodGet, "/admin/media-renderer-items/defrec/", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response struct {
+		FormPage *renderer.FormPage `json:"form_page"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NotNil(t, response.FormPage)
+	require.Len(t, response.FormPage.Sections, 1)
+
+	section := response.FormPage.Sections[0]
+	require.NotNil(t, section.MediaUpload)
+	assert.Equal(t, "Upload media", section.MediaUpload.Title)
+	require.Len(t, section.MediaItems, 1)
+	assert.Equal(t, renderer.MediaKindVideo, section.MediaItems[0].Kind)
+	assert.Equal(t, renderer.MediaVisibilityPublic, section.MediaItems[0].Visibility)
+	assert.Equal(t, renderer.MediaUsageGallery, section.MediaItems[0].Usage)
+	require.NotNil(t, section.MediaLabels)
+	assert.Equal(t, "No media yet", section.MediaLabels.Empty)
+	require.NotNil(t, section.MediaActions)
+	require.NotNil(t, section.MediaActions.Upload)
+	assert.Equal(t, "/media_assets", section.MediaActions.Upload.API.Endpoint)
+}
+
 func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	engine := setupUniversalRendererRouter(t)
 


### PR DESCRIPTION
## Что изменено

Добавлен typed contract для `renderer.RendererMediaGallery` внутри `renderer.FormSection`:

- `MediaUploadConfig` -> `media_upload`;
- `MediaGalleryItem` -> `media_items`;
- `MediaGalleryLabels` -> `media_labels`;
- `MediaGalleryActions` -> `media_actions`;
- enum aliases/constants для `MediaKind`, `MediaVisibility`, `MediaUsage`;
- clone support для новых полей FormSection.

## Зачем

Settings/media section во v2 должна отдавать готовый typed renderer contract, без `extra`, без `map[string]interface{}` и без legacy парсинга PostgreSQL array на фронте.

## Проверки

- `go test ./...`

Связано с: https://github.com/theGHub1/api/issues/78