### PR TITLE
Add typed field media presentation contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ BaseModule
   │     ├── Type/FormType
   │     ├── Options/OptionsFunc
   │     ├── Check/DefaultFunc/Convert
-  │     └── Extra
-  │           ├── Defrec  -> форма и universal field props
-  │           └── View    -> отображение в списках/detail/card view
+  │     ├── Presentation  -> typed metadata визуального представления поля
+  │     ├── Media         -> typed metadata одиночного media-поля
+  │     └── Extra         -> legacy escape hatch
   │
   ├── ListModuleAction
   │     ├── Filter/Search/Sort/SortDefault
@@ -65,7 +65,7 @@ BaseModule
   │     └── ExtraFunc -> legacy/dynamic app-specific metadata
   │
   ├── ViewModuleAction
-  │     └── Extra -> custom view/detail metadata
+  │     └── Extra -> legacy custom view/detail metadata
   │
   ├── DefrecModuleAction
   │     └── schema for add/edit forms
@@ -92,7 +92,8 @@ BaseModule
 - ключи переводов;
 - ключи иконок;
 - typed metadata для UniversalRenderer через `BaseModule.Render`;
-- legacy/application-specific metadata через `extra`, если typed contract еще не покрывает сценарий.
+- typed metadata одиночных полей через `ModuleField.Presentation` и специализированные typed blocks вроде `ModuleField.Media`;
+- legacy/application-specific metadata через `extra` только для старого кода. Новые возможности UniversalRenderer нужно добавлять в typed contract.
 
 Frontend должен получать готовую схему и рендерить ее своими универсальными компонентами. Frontend не должен угадывать, что поле `status` нужно показать badge, что `category_ids` является multiselect, а `owner_id` нужно скрыть от определенной роли.
 
@@ -100,8 +101,8 @@ Frontend должен получать готовую схему и рендер
 
 | Что нужно описать | Где описывать |
 |---|---|
-| Поле формы add/edit | `ModuleField.Extra.Defrec` |
-| Поле detail/list/card view | `ModuleField.Extra.View` |
+| Поле формы add/edit | Базово `ModuleField`; расширения через typed поля `Presentation`, `Media` и т.п. |
+| Поле detail/list/card view | Базово `ModuleField`; расширения через typed поля `Presentation`, `Media` и т.п. |
 | Полный список с фильтрами и карточками | `BaseModule.Render.List` |
 | Универсальная form/edit page | `BaseModule.Render.Form` |
 | Страница просмотра записи | `BaseModule.Render.Record` |
@@ -113,9 +114,51 @@ Frontend должен получать готовую схему и рендер
 | Права на строки | `Where`, `RoleWhere`, `BeforeAction`, `DataCheckRule` |
 | Options из базы | `OptionsFunc` или `Extra.Defrec.options_url` |
 
+Подробная спецификация UniversalRenderer: [docs/universal-renderer-contract.md](docs/universal-renderer-contract.md).
+
+### Typed field metadata
+
+Для новых UI-возможностей нельзя заставлять frontend угадывать поведение по имени поля и нельзя добавлять ad-hoc `extra`. Если поле требует явного renderer contract, используйте typed поля `ModuleField`.
+
+Пример одиночного media-поля:
+
+```go
+{
+    Column:   table.Profiles.Avatar,
+    Title:    "profiles.fields.avatar",
+    Type:     fields.ModuleFieldTypeString,
+    FormType: fields.ModuleFieldFormTypeText,
+    Presentation: &renderer.FieldPresentation{
+        Renderer: renderer.RendererAvatar,
+        Variant:  "avatar",
+        Size:     renderer.MediaSizeThumb,
+        Ratio:    renderer.MediaRatioSquare,
+    },
+    Media: &renderer.FieldMediaConfig{
+        Item: &renderer.MediaGalleryItem{
+            Kind:       renderer.MediaKindPhoto,
+            Visibility: renderer.MediaVisibilityPublic,
+            Usage:      renderer.MediaUsageAvatar,
+        },
+        Upload: &renderer.MediaUploadConfig{
+            Title:        "settings.profile.avatar_title",
+            LoadingTitle: "settings.profile.uploading",
+            Accept:       "image/jpeg,image/png,image/webp",
+            Multiple:     false,
+        },
+        Actions: &renderer.MediaGalleryActions{
+            Upload: &renderer.Action{ID: "upload", Label: "settings.profile.upload_new", Type: renderer.ActionEmit},
+            Remove: &renderer.Action{ID: "remove", Label: "settings.profile.remove_avatar", Type: renderer.ActionEmit},
+        },
+    },
+}
+```
+
+В `defrec.fields[field]` и `view.item[field]` эти blocks приходят как `presentation` и `media`. Labels в media/action metadata переводятся request-generator по текущему языку. В `view` `media.item.src` может быть автоматически заполнен из `item[field].value`, если producer не указал `src`.
+
 ### Extra.Defrec
 
-`Extra.Defrec` описывает, каким контролом клиентское приложение должно редактировать поле.
+`Extra.Defrec` является legacy-механизмом. Его можно использовать только для существующих модулей или временной совместимости, пока нужный UI contract еще не типизирован.
 
 ```go
 {

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -28,6 +28,7 @@ flowchart TD
     B --> X["legacy response.extra"]
 
     C --> F["field.extra"]
+    C --> Y["field.presentation / field.media"]
     D --> F
 
     T --> G["list_page"]
@@ -39,6 +40,8 @@ flowchart TD
     F --> L["form metadata"]
     F --> M["list metadata"]
     F --> N["view metadata"]
+    Y --> Q
+    Y --> R
 
     G --> O["List renderer"]
     H --> P["Resource grid renderer"]
@@ -53,7 +56,7 @@ flowchart TD
 
 ## Где Лежит Metadata
 
-UniversalRenderer читает canonical metadata только из typed top-level response fields. `response.extra` остается legacy/deprecated escape hatch для старых модулей и application-specific compatibility, но не является частью UniversalRenderer metadata.
+UniversalRenderer читает canonical metadata из typed response fields. `response.extra` и `field.extra` остаются legacy/deprecated escape hatch для старых модулей и application-specific compatibility. Новые UI-возможности должны добавляться в typed contract генератора, а не в ad-hoc `extra`.
 
 Каждый response с typed page metadata должен содержать renderer identity:
 
@@ -178,11 +181,9 @@ Closed enums должны использовать typed constants из package 
       "required": true,
       "options": [],
       "section": "main",
-      "extra": {
-        "visual_kind": "select",
-        "section": "main",
-        "group": "general",
-        "order": 20
+      "presentation": {
+        "renderer": "universal.section",
+        "variant": "default"
       }
     }
   }
@@ -197,7 +198,9 @@ Closed enums должны использовать typed constants из package 
 | `fields[field].required` | Required marker для UI. |
 | `fields[field].options` | Static options. |
 | `fields[field].section` | Базовая секция поля. |
-| `fields[field].extra` | UI metadata формы. |
+| `fields[field].presentation` | Typed metadata визуального представления одиночного поля. |
+| `fields[field].media` | Typed media metadata одиночного поля, если поле является media value. |
+| `fields[field].extra` | Legacy metadata формы. Не использовать для новых UniversalRenderer capabilities. |
 | `renderer` | Renderer identity/version, добавляется request-generator. |
 | `form_page` | Typed metadata универсальной form/edit страницы из `BaseModule.Render.Form`. |
 
@@ -218,8 +221,9 @@ Closed enums должны использовать typed constants из package 
       "value": "active",
       "edit": true,
       "options": [],
-      "extra": {
-        "display": {"type": "badge"}
+      "presentation": {
+        "renderer": "universal.display",
+        "variant": "badge"
       }
     }
   }
@@ -233,7 +237,9 @@ Closed enums должны использовать typed constants из package 
 | `item[field].value` | Значение поля. |
 | `item[field].edit` | Можно ли редактировать поле в UI. |
 | `item[field].options` | Options для значения. |
-| `item[field].extra` | Metadata отображения поля. |
+| `item[field].presentation` | Typed metadata визуального представления одиночного поля. |
+| `item[field].media` | Typed media metadata одиночного поля, если поле является media value. |
+| `item[field].extra` | Legacy metadata отображения поля. Не использовать для новых UniversalRenderer capabilities. |
 | `renderer` | Renderer identity/version, добавляется request-generator. |
 | `record_page` | Typed metadata страницы просмотра из `BaseModule.Render.Record`. |
 
@@ -316,7 +322,150 @@ Renderer discovery происходит через `/api/config`: frontend мо�
 
 ## Field Metadata
 
-Поле может иметь metadata в трех контекстах:
+Поле может иметь typed metadata, которая приходит вместе с самим field object в `defrec.fields[field]` и `view.item[field]`.
+
+Typed field metadata нужна для одиночных полей, где базовых `type/form_type/options/checks` недостаточно, но вводить module-specific frontend код нельзя. Пример: поле с одним media value. Frontend не должен проверять `field.id == "avatar"` или другой application-specific ключ. API должен явно сказать, что значение поля является media item и каким renderer presentation его показывать.
+
+### Field Presentation
+
+`presentation` описывает только визуальное представление поля. Оно не описывает данные и не содержит бизнес-смысл.
+
+```json
+{
+  "presentation": {
+    "renderer": "avatar",
+    "variant": "avatar",
+    "style": "avatar",
+    "size": "thumb",
+    "ratio": "square"
+  }
+}
+```
+
+Поля:
+
+| Path | Назначение |
+|------|------------|
+| `presentation.renderer` | Renderer/component key, например `avatar`, `universal.display`, `universal.section`. |
+| `presentation.variant` | Вариант компонента внутри renderer. |
+| `presentation.style` | Optional style token, если renderer поддерживает несколько визуальных стилей. |
+| `presentation.size` | Media size token: `thumb`, `card`, `hero`. |
+| `presentation.ratio` | Media ratio token: `square`, `portrait`, `landscape`, `wide`. |
+
+### Field Media
+
+`media` описывает одиночное media-поле через существующие универсальные media-структуры. Это не gallery section и не application-specific avatar contract. Это один media item, optional upload config, labels и actions.
+
+```json
+{
+  "media": {
+    "item": {
+      "kind": "photo",
+      "usage": "avatar",
+      "visibility": "public",
+      "src": "ipfs://..."
+    },
+    "upload": {
+      "title": "Ваш аватар",
+      "subtitle": "Загрузите фото. Мы поможем вам правильно обрезать его по кругу.",
+      "loading_title": "Загрузка…",
+      "accept": "image/jpeg,image/png,image/webp",
+      "multiple": false
+    },
+    "labels": {
+      "empty": "Аватар не загружен",
+      "remove": "Удалить"
+    },
+    "actions": {
+      "upload": {
+        "id": "upload",
+        "type": "emit",
+        "label": "Загрузить",
+        "icon": "upload"
+      },
+      "recenter": {
+        "id": "recenter",
+        "type": "emit",
+        "label": "Центрировать",
+        "icon": "crosshair"
+      },
+      "crop": {
+        "id": "crop",
+        "type": "emit",
+        "label": "Обрезать",
+        "icon": "crop"
+      },
+      "remove": {
+        "id": "remove",
+        "type": "emit",
+        "label": "Удалить",
+        "icon": "trash",
+        "variant": "danger"
+      }
+    }
+  }
+}
+```
+
+Поля:
+
+| Path | Назначение |
+|------|------------|
+| `media.item` | `MediaGalleryItem` для одиночного значения. |
+| `media.item.kind` | Тип media: `photo`, `video`, `file`. |
+| `media.item.usage` | Назначение media: `gallery`, `avatar`, `poster`. |
+| `media.item.src` | URI значения. В `view` request-generator может подставить сюда `item[field].value`, если producer не указал `src` явно. |
+| `media.upload` | `MediaUploadConfig`: ограничения upload UI и localized labels. |
+| `media.labels` | `MediaGalleryLabels`, переиспользуется для одиночного media field. |
+| `media.actions` | `MediaGalleryActions`: стандартные действия `upload`, `link`, `reorder`, `recenter`, `crop`, `remove`. |
+
+Producer задает labels как translation keys. Request-generator возвращает во внешнем JSON уже локализованные labels согласно `lang`/`Accept-Language`.
+
+### Go API
+
+```go
+{
+    Column:   table.Profiles.Avatar,
+    Title:    "profiles.fields.avatar",
+    Type:     fields.ModuleFieldTypeString,
+    FormType: fields.ModuleFieldFormTypeText,
+    Presentation: &renderer.FieldPresentation{
+        Renderer: renderer.RendererAvatar,
+        Variant:  "avatar",
+        Style:    "avatar",
+        Size:     renderer.MediaSizeThumb,
+        Ratio:    renderer.MediaRatioSquare,
+    },
+    Media: &renderer.FieldMediaConfig{
+        Item: &renderer.MediaGalleryItem{
+            Kind:       renderer.MediaKindPhoto,
+            Visibility: renderer.MediaVisibilityPublic,
+            Usage:      renderer.MediaUsageAvatar,
+        },
+        Upload: &renderer.MediaUploadConfig{
+            Title:        "settings.profile.avatar_title",
+            Subtitle:     "settings.profile.avatar_desc",
+            LoadingTitle: "settings.profile.uploading",
+            Accept:       "image/jpeg,image/png,image/webp",
+            Multiple:     false,
+        },
+        Labels: &renderer.MediaGalleryLabels{
+            Empty:  "settings.profile.avatar_empty",
+            Remove: "settings.profile.remove_avatar",
+        },
+        Actions: &renderer.MediaGalleryActions{
+            Upload:   &renderer.Action{ID: "upload", Label: "settings.profile.upload_new", Type: renderer.ActionEmit},
+            Recenter: &renderer.Action{ID: "recenter", Label: "settings.profile.recenter", Type: renderer.ActionEmit},
+            Crop:     &renderer.Action{ID: "crop", Label: "settings.profile.crop", Type: renderer.ActionEmit},
+            Remove:   &renderer.Action{ID: "remove", Label: "settings.profile.remove_avatar", Type: renderer.ActionEmit, Variant: renderer.ActionVariantDanger},
+        },
+    },
+}
+```
+
+### Legacy Extra
+
+`extra` пока остается в трех контекстах для старых модулей:
 
 | Контекст | Где задается producer-side | Где приходит frontend |
 |----------|-----------------------------|-----------------------|
@@ -324,7 +473,9 @@ Renderer discovery происходит через `/api/config`: frontend мо�
 | List | `ModuleField.Extra.List` | `list.heads[field].extra`, `list.filters[field].extra` |
 | View | `ModuleField.Extra.View` | `view.item[field].extra` |
 
-Канонический shape:
+Для нового UniversalRenderer metadata `extra` использовать нельзя. Если нужной структуры нет, надо добавить typed поле в `renderer` package, тест response contract и обновить эту спецификацию.
+
+Legacy shape:
 
 ```json
 {

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/darkrain/request-generator/locale"
+	"github.com/darkrain/request-generator/renderer"
 	"github.com/gin-gonic/gin"
 	pg "github.com/go-jet/jet/v2/postgres"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -112,6 +113,8 @@ type ModuleField struct {
 	FormType         ModuleFieldFormType                             `json:"form_type,omitempty"`
 	Example          string                                          `json:"example,omitempty"`
 	AllLabel         string                                          `json:"all_label,omitempty"`
+	Presentation     *renderer.FieldPresentation                     `json:"presentation,omitempty"`
+	Media            *renderer.FieldMediaConfig                      `json:"media,omitempty"`
 	Extra            *FieldExtra                                     `json:"-"`
 	Options          []ModuleFieldOptions                            `json:"options,omitempty"`
 	OptionsURL       string                                          `json:"options_url,omitempty"`

--- a/generator.go
+++ b/generator.go
@@ -109,6 +109,53 @@ func (generator *Generator) FeaturesMiddleware() gin.HandlerFunc {
 	}
 }
 
+func (generator *Generator) localizeFieldPresentation(_ locale.Lang, v *renderer.FieldPresentation) *renderer.FieldPresentation {
+	return renderer.CloneFieldPresentation(v)
+}
+
+func (generator *Generator) localizeFieldMedia(lang locale.Lang, v *renderer.FieldMediaConfig, value interface{}) *renderer.FieldMediaConfig {
+	cp := renderer.CloneFieldMediaConfig(v)
+	if cp == nil {
+		return nil
+	}
+	if cp.Item != nil && cp.Item.Src == "" {
+		if src, ok := value.(string); ok {
+			cp.Item.Src = src
+		}
+	}
+	if cp.Upload != nil {
+		cp.Upload.Title = generator.Translate(lang, cp.Upload.Title)
+		cp.Upload.Subtitle = generator.Translate(lang, cp.Upload.Subtitle)
+		cp.Upload.LoadingTitle = generator.Translate(lang, cp.Upload.LoadingTitle)
+	}
+	if cp.Labels != nil {
+		cp.Labels.Public = generator.Translate(lang, cp.Labels.Public)
+		cp.Labels.Private = generator.Translate(lang, cp.Labels.Private)
+		cp.Labels.Empty = generator.Translate(lang, cp.Labels.Empty)
+		cp.Labels.CoverBadge = generator.Translate(lang, cp.Labels.CoverBadge)
+		cp.Labels.Remove = generator.Translate(lang, cp.Labels.Remove)
+		cp.Labels.Reorder = generator.Translate(lang, cp.Labels.Reorder)
+		cp.Labels.FirstIsCover = generator.Translate(lang, cp.Labels.FirstIsCover)
+		cp.Labels.PrivateHint = generator.Translate(lang, cp.Labels.PrivateHint)
+	}
+	if cp.Actions != nil {
+		generator.localizeRendererAction(lang, cp.Actions.Upload)
+		generator.localizeRendererAction(lang, cp.Actions.Link)
+		generator.localizeRendererAction(lang, cp.Actions.Reorder)
+		generator.localizeRendererAction(lang, cp.Actions.Recenter)
+		generator.localizeRendererAction(lang, cp.Actions.Crop)
+		generator.localizeRendererAction(lang, cp.Actions.Remove)
+	}
+	return cp
+}
+
+func (generator *Generator) localizeRendererAction(lang locale.Lang, action *renderer.Action) {
+	if action == nil {
+		return
+	}
+	action.Label = generator.Translate(lang, action.Label)
+}
+
 func (generator *Generator) Run() {
 
 	featuresGroup := generator.group.Group("/api")
@@ -812,6 +859,8 @@ func (generator *Generator) actionDefrec(module *BaseModule) func(c *gin.Context
 			field.Title = generator.Translate(lang, field.Title)
 			field.Options = optionItems
 			field.Check = checkItems
+			field.Presentation = generator.localizeFieldPresentation(lang, field.Presentation)
+			field.Media = generator.localizeFieldMedia(lang, field.Media, nil)
 
 			if field.RoleSection != nil {
 				if s, ok := field.RoleSection[role]; ok {
@@ -968,6 +1017,12 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 
 			if field.Extra != nil && field.Extra.View != nil {
 				fieldItem["extra"] = field.Extra.View
+			}
+			if field.Presentation != nil {
+				fieldItem["presentation"] = generator.localizeFieldPresentation(lang, field.Presentation)
+			}
+			if field.Media != nil {
+				fieldItem["media"] = generator.localizeFieldMedia(lang, field.Media, value)
 			}
 
 			// Collect options

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -285,6 +285,22 @@ func cloneFormSections(values []FormSection) []FormSection {
 	return out
 }
 
+func CloneFieldPresentation(v *FieldPresentation) *FieldPresentation {
+	return clonePtr(v)
+}
+
+func CloneFieldMediaConfig(v *FieldMediaConfig) *FieldMediaConfig {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.Item = clonePtr(v.Item)
+	cp.Upload = clonePtr(v.Upload)
+	cp.Labels = clonePtr(v.Labels)
+	cp.Actions = cloneMediaGalleryActions(v.Actions)
+	return &cp
+}
+
 func cloneMediaGalleryActions(v *MediaGalleryActions) *MediaGalleryActions {
 	if v == nil {
 		return nil
@@ -293,6 +309,8 @@ func cloneMediaGalleryActions(v *MediaGalleryActions) *MediaGalleryActions {
 	cp.Upload = cloneAction(v.Upload)
 	cp.Link = cloneAction(v.Link)
 	cp.Reorder = cloneAction(v.Reorder)
+	cp.Recenter = cloneAction(v.Recenter)
+	cp.Crop = cloneAction(v.Crop)
 	cp.Remove = cloneAction(v.Remove)
 	return &cp
 }

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -179,6 +179,21 @@ type Media struct {
 	Fallback     string      `json:"fallback,omitempty"`
 }
 
+type FieldPresentation struct {
+	Renderer RendererKey `json:"renderer,omitempty"`
+	Variant  string      `json:"variant,omitempty"`
+	Style    string      `json:"style,omitempty"`
+	Size     MediaSize   `json:"size,omitempty"`
+	Ratio    MediaRatio  `json:"ratio,omitempty"`
+}
+
+type FieldMediaConfig struct {
+	Item    *MediaGalleryItem    `json:"item,omitempty"`
+	Upload  *MediaUploadConfig   `json:"upload,omitempty"`
+	Labels  *MediaGalleryLabels  `json:"labels,omitempty"`
+	Actions *MediaGalleryActions `json:"actions,omitempty"`
+}
+
 type TextBinding struct {
 	Field    string `json:"field,omitempty"`
 	Template string `json:"template,omitempty"`
@@ -289,10 +304,12 @@ type MediaGalleryLabels struct {
 }
 
 type MediaGalleryActions struct {
-	Upload  *Action `json:"upload,omitempty"`
-	Link    *Action `json:"link,omitempty"`
-	Reorder *Action `json:"reorder,omitempty"`
-	Remove  *Action `json:"remove,omitempty"`
+	Upload   *Action `json:"upload,omitempty"`
+	Link     *Action `json:"link,omitempty"`
+	Reorder  *Action `json:"reorder,omitempty"`
+	Recenter *Action `json:"recenter,omitempty"`
+	Crop     *Action `json:"crop,omitempty"`
+	Remove   *Action `json:"remove,omitempty"`
 }
 
 type CollectionConfig struct {

--- a/response/defrec.go
+++ b/response/defrec.go
@@ -29,6 +29,12 @@ func NewDefrecResponse(extra interface{}, fields []f.ModuleField) DefrecResponse
 		if field.Extra != nil && field.Extra.Defrec != nil {
 			item["extra"] = field.Extra.Defrec
 		}
+		if field.Presentation != nil {
+			item["presentation"] = field.Presentation
+		}
+		if field.Media != nil {
+			item["media"] = field.Media
+		}
 		if field.Section != "" {
 			item["section"] = field.Section
 		}

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -43,7 +43,7 @@ func (fakeRendererDB) List(
 }
 
 func (fakeRendererDB) View(_ *log.Entry, _ pg.Table, _ pg.Column, _ []fields.ModuleField, _ pg.BoolExpression, _ []actions.ModuleActionJoin, _ *dbpkg.TranslationContext) (interface{}, error) {
-	return map[string]interface{}{"id": 1, "status": "active"}, nil
+	return map[string]interface{}{"id": 1, "status": "active", "avatar": "ipfs://avatar"}, nil
 }
 
 func (fakeRendererDB) Add(_ *log.Entry, _ pg.Table, _ pg.Column, _ []fields.ModuleField, _ map[string]interface{}, _ *dbpkg.TranslationContext) (interface{}, error) {
@@ -72,7 +72,8 @@ func setupUniversalRendererRouter(t *testing.T) *gin.Engine {
 
 	id := postgres.IntegerColumn("id")
 	status := postgres.StringColumn("status")
-	table := postgres.NewTable("public", "renderer_items", "", id, status)
+	avatar := postgres.StringColumn("avatar")
+	table := postgres.NewTable("public", "renderer_items", "", id, status, avatar)
 
 	testModule := &module.BaseModule{
 		Name:       "renderer-items",
@@ -82,6 +83,39 @@ func setupUniversalRendererRouter(t *testing.T) *gin.Engine {
 		Fields: []fields.ModuleField{
 			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
 			{Column: status, Title: "Status", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeSelect},
+			{
+				Column:   avatar,
+				Title:    "Avatar",
+				Type:     fields.ModuleFieldTypeString,
+				FormType: fields.ModuleFieldFormTypeText,
+				Presentation: &renderer.FieldPresentation{
+					Renderer: renderer.RendererAvatar,
+					Variant:  "avatar",
+					Size:     renderer.MediaSizeThumb,
+					Ratio:    renderer.MediaRatioSquare,
+				},
+				Media: &renderer.FieldMediaConfig{
+					Item: &renderer.MediaGalleryItem{
+						Kind:       renderer.MediaKindPhoto,
+						Visibility: renderer.MediaVisibilityPublic,
+						Usage:      renderer.MediaUsageAvatar,
+					},
+					Upload: &renderer.MediaUploadConfig{
+						Title:        "Upload avatar",
+						LoadingTitle: "Uploading avatar",
+						Accept:       "image/jpeg,image/png,image/webp",
+					},
+					Labels: &renderer.MediaGalleryLabels{
+						Empty:  "No avatar",
+						Remove: "Remove avatar",
+					},
+					Actions: &renderer.MediaGalleryActions{
+						Upload: &renderer.Action{ID: "upload", Label: "Upload", Type: renderer.ActionEmit, Icon: "upload"},
+						Crop:   &renderer.Action{ID: "crop", Label: "Crop", Type: renderer.ActionEmit, Icon: "crop"},
+						Remove: &renderer.Action{ID: "remove", Label: "Remove", Type: renderer.ActionAPI, API: &renderer.APIAction{Method: "POST", Endpoint: "/profiles/avatar/remove"}},
+					},
+				},
+			},
 		},
 		Render: renderer.Universal{
 			List: &renderer.ListPage{
@@ -108,13 +142,13 @@ func setupUniversalRendererRouter(t *testing.T) *gin.Engine {
 				Label:      "List",
 			},
 			actions.AddModuleAction{
-				Columns:    []pg.Column{status},
+				Columns:    []pg.Column{status, avatar},
 				Permission: []actions.Role{actions.RoleAll},
 				Auth:       true,
 				Label:      "Add",
 			},
 			actions.ViewModuleAction{
-				Columns:    []pg.Column{id, status},
+				Columns:    []pg.Column{id, status, avatar},
 				By:         []pg.Column{id},
 				Permission: []actions.Role{actions.RoleAll},
 				Auth:       true,
@@ -168,6 +202,10 @@ func TestUniversalRendererMetadata_DefrecResponse(t *testing.T) {
 	var response struct {
 		Renderer *renderer.Identity `json:"renderer"`
 		FormPage *renderer.FormPage `json:"form_page"`
+		Fields   map[string]struct {
+			Presentation *renderer.FieldPresentation `json:"presentation"`
+			Media        *renderer.FieldMediaConfig  `json:"media"`
+		} `json:"fields"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 
@@ -177,6 +215,20 @@ func TestUniversalRendererMetadata_DefrecResponse(t *testing.T) {
 	require.NotNil(t, response.FormPage)
 	assert.Equal(t, "renderer-items-form", response.FormPage.ID)
 	assert.Equal(t, renderer.LayoutTwoColumn, response.FormPage.Layout)
+	avatarField := response.Fields["avatar"]
+	require.NotNil(t, avatarField.Presentation)
+	assert.Equal(t, renderer.RendererAvatar, avatarField.Presentation.Renderer)
+	assert.Equal(t, "avatar", avatarField.Presentation.Variant)
+	require.NotNil(t, avatarField.Media)
+	require.NotNil(t, avatarField.Media.Item)
+	assert.Equal(t, renderer.MediaUsageAvatar, avatarField.Media.Item.Usage)
+	require.NotNil(t, avatarField.Media.Upload)
+	assert.Equal(t, "Upload avatar", avatarField.Media.Upload.Title)
+	require.NotNil(t, avatarField.Media.Actions)
+	require.NotNil(t, avatarField.Media.Actions.Crop)
+	assert.Equal(t, "Crop", avatarField.Media.Actions.Crop.Label)
+	require.NotNil(t, avatarField.Media.Actions.Remove)
+	assert.Equal(t, "/profiles/avatar/remove", avatarField.Media.Actions.Remove.API.Endpoint)
 }
 
 func TestUniversalRendererMetadata_FormSectionMediaGallery(t *testing.T) {
@@ -304,6 +356,11 @@ func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	var response struct {
 		Renderer   *renderer.Identity   `json:"renderer"`
 		RecordPage *renderer.RecordPage `json:"record_page"`
+		Item       map[string]struct {
+			Value        interface{}                 `json:"value"`
+			Presentation *renderer.FieldPresentation `json:"presentation"`
+			Media        *renderer.FieldMediaConfig  `json:"media"`
+		} `json:"item"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 
@@ -312,6 +369,16 @@ func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	assert.Equal(t, renderer.Version, response.Renderer.Version)
 	require.NotNil(t, response.RecordPage)
 	assert.Equal(t, renderer.LayoutThreeColumn, response.RecordPage.Layout.Type)
+	avatarField := response.Item["avatar"]
+	assert.Equal(t, "ipfs://avatar", avatarField.Value)
+	require.NotNil(t, avatarField.Presentation)
+	assert.Equal(t, renderer.RendererAvatar, avatarField.Presentation.Renderer)
+	require.NotNil(t, avatarField.Media)
+	require.NotNil(t, avatarField.Media.Item)
+	assert.Equal(t, renderer.MediaUsageAvatar, avatarField.Media.Item.Usage)
+	assert.Equal(t, "ipfs://avatar", avatarField.Media.Item.Src)
+	require.NotNil(t, avatarField.Media.Actions)
+	assert.Equal(t, "Remove", avatarField.Media.Actions.Remove.Label)
 }
 
 func TestUniversalRendererMetadata_ViewFormPageResponse(t *testing.T) {


### PR DESCRIPTION
## Что изменено

- Добавлен typed metadata contract для одиночных form/view fields: FieldPresentation и FieldMediaConfig.
- ModuleField теперь может отдавать presentation и media без extra и map[string]interface{}.
- defrec и view сериализуют эти typed поля.
- Генератор локализует media upload labels, media labels и action labels перед ответом.
- В view media.item.src автоматически заполняется из значения поля, если src не задан явно.
- Добавлены стандартные media actions recenter/crop.
- Удален ошибочный business-specific renderer universal.preferences и PreferencesConfig из core renderer contract.
- Добавлены integration tests для defrec и view JSON contract.
- Обновлены README и docs/universal-renderer-contract.md: описано зачем нужен typed field contract, как использовать presentation/media, где остается legacy extra, и почему business-specific renderers не должны попадать в core contract.

## Зачем

Это нужно для одиночных media-полей вроде avatar: frontend получает явный renderer contract и не угадывает поведение по имени поля. Дополнительно PR убирает лишний universal.preferences, который должен быть заменен обычными typed primitives.

## Проверки

- go test ./...