### PR TITLE
Remove universal preferences renderer contract

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -961,11 +961,12 @@ Stable renderer names:
 | `universal.display` | Display section metadata: `components`, `components[].fields`, layout fields. |
 | `universal.filters` | `filters`, `levels`, `primary`, `secondary`, `more`, `nested`, `reset`. |
 | `universal.pagination` | `mode`, pagination response fields. |
-| `universal.preferences` | `preferences` config directly in section. |
 | `media.gallery` | Media fields/config in section metadata. |
 | `collection.manager` | `collection` config directly in section. |
 
 Unknown renderer names must degrade to a generic block or produce a visible unsupported-renderer state. Producer services should not introduce custom renderer names unless the target frontend registers them.
+
+Renderer registry должен описывать универсальные UI primitives. Business-specific renderer names не допускаются в core contract. Например, настройки уведомлений не должны оформляться как `universal.preferences` с полями `global_channels`, `type_prefs`, `quiet_hours` и `connections`; такие экраны должны раскладываться на обычные sections, fields, matrices/lists и typed actions.
 
 Renderer behavior changes are versioned through this specification process, not through per-renderer object versions.
 

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -276,7 +276,6 @@ func cloneFormSections(values []FormSection) []FormSection {
 		out[i].Fields = cloneSlice(v.Fields)
 		out[i].ListPage = cloneListPage(v.ListPage)
 		out[i].Collection = cloneCollectionConfig(v.Collection)
-		out[i].Preferences = clonePreferencesConfig(v.Preferences)
 		out[i].MediaUpload = clonePtr(v.MediaUpload)
 		out[i].MediaItems = cloneSlice(v.MediaItems)
 		out[i].MediaLabels = clonePtr(v.MediaLabels)
@@ -330,17 +329,6 @@ func cloneCollectionModal(v *CollectionModal) *CollectionModal {
 		return nil
 	}
 	cp := *v
-	return &cp
-}
-
-func clonePreferencesConfig(v *PreferencesConfig) *PreferencesConfig {
-	if v == nil {
-		return nil
-	}
-	cp := *v
-	cp.Channels = cloneSlice(v.Channels)
-	cp.Blocks = cloneSlice(v.Blocks)
-	cp.ConnectionPrompts = cloneSlice(v.ConnectionPrompts)
 	return &cp
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -263,7 +263,6 @@ type FormSection struct {
 	Fields       []string             `json:"fields,omitempty"`
 	ListPage     *ListPage            `json:"list_page,omitempty"`
 	Collection   *CollectionConfig    `json:"collection,omitempty"`
-	Preferences  *PreferencesConfig   `json:"preferences,omitempty"`
 	MediaUpload  *MediaUploadConfig   `json:"media_upload,omitempty"`
 	MediaItems   []MediaGalleryItem   `json:"media_items,omitempty"`
 	MediaLabels  *MediaGalleryLabels  `json:"media_labels,omitempty"`
@@ -364,32 +363,6 @@ type CollectionModal struct {
 	TakenLabel          string `json:"taken_label,omitempty"`
 	CancelLabel         string `json:"cancel_label,omitempty"`
 	ConfirmLoadingLabel string `json:"confirm_loading_label,omitempty"`
-}
-
-type PreferencesConfig struct {
-	Resource          string                        `json:"resource,omitempty"`
-	ListEndpoint      string                        `json:"list_endpoint,omitempty"`
-	SaveEndpoint      string                        `json:"save_endpoint,omitempty"`
-	Channels          []string                      `json:"channels,omitempty"`
-	Blocks            []PreferencesBlock            `json:"blocks,omitempty"`
-	ConnectionPrompts []PreferencesConnectionPrompt `json:"connection_prompts,omitempty"`
-}
-
-type PreferencesBlock struct {
-	ID       string `json:"id,omitempty"`
-	Title    string `json:"title,omitempty"`
-	Subtitle string `json:"subtitle,omitempty"`
-}
-
-type PreferencesConnectionPrompt struct {
-	ID               string           `json:"id,omitempty"`
-	Channel          string           `json:"channel,omitempty"`
-	Icon             string           `json:"icon,omitempty"`
-	Tone             string           `json:"tone,omitempty"`
-	Text             string           `json:"text,omitempty"`
-	ActionLabel      string           `json:"action_label,omitempty"`
-	ActionVariant    ActionVariant    `json:"action_variant,omitempty"`
-	ActionAppearance ActionAppearance `json:"action_appearance,omitempty"`
 }
 
 type Block struct {

--- a/renderer/tokens.go
+++ b/renderer/tokens.go
@@ -199,14 +199,13 @@ const (
 type RendererKey string
 
 const (
-	RendererUniversalDisplay     RendererKey = "universal.display"
-	RendererUniversalSection     RendererKey = "universal.section"
-	RendererUniversalPreferences RendererKey = "universal.preferences"
-	RendererUniversalFilters     RendererKey = "universal.filters"
-	RendererUniversalPagination  RendererKey = "universal.pagination"
-	RendererMediaGallery         RendererKey = "media.gallery"
-	RendererCollectionManager    RendererKey = "collection.manager"
-	RendererAvatar               RendererKey = "avatar"
+	RendererUniversalDisplay    RendererKey = "universal.display"
+	RendererUniversalSection    RendererKey = "universal.section"
+	RendererUniversalFilters    RendererKey = "universal.filters"
+	RendererUniversalPagination RendererKey = "universal.pagination"
+	RendererMediaGallery        RendererKey = "media.gallery"
+	RendererCollectionManager   RendererKey = "collection.manager"
+	RendererAvatar              RendererKey = "avatar"
 )
 
 type RecordSectionRenderer = RendererKey


### PR DESCRIPTION
## Что изменено

- Удален RendererUniversalPreferences.
- Удалены PreferencesConfig, PreferencesBlock, PreferencesConnectionPrompt из core renderer contract.
- Удалено clonePreferencesConfig.
- Спецификация UniversalRenderer больше не перечисляет universal.preferences как stable renderer.
- В документации явно указано, что business-specific renderers не должны попадать в core contract; настройки уведомлений нужно раскладывать на обычные sections, fields, matrices/lists и typed actions.

## Зачем

universal.preferences оказался business-specific contract для notification_preferences. Это заставляет ui-kit знать про global_channels, type_prefs, quiet_hours и connections, что противоречит UniversalRenderer подходу.

## Проверки

- go test ./...