### PR TITLE
Generalize UniversalRenderer collection contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,61 @@ renderer.Action{
 
 Важно: `visible_if` и `hidden_if` управляют только отображением. Серверное действие обязательно должно проверять доступ через `Permission`, `Where`, `BeforeAction` или `DataCheckRule`.
 
+### Collection manager metadata
+
+`renderer.CollectionConfig` описывает универсальную коллекцию записей модуля в контексте текущей target-записи. Контракт не содержит owner foreign key, profile-specific полей, price-specific полей или endpoint-ов.
+
+```go
+Render: renderer.Universal{
+    Form: &renderer.FormPage{
+        Sections: []renderer.FormSection{
+            {
+                ID:       "services",
+                Renderer: renderer.RendererCollectionManager,
+                Collection: &renderer.CollectionConfig{
+                    Module:     "model_additional_services",
+                    EditFields: []string{"price", "note", "available"},
+                    Item: &renderer.CollectionItem{
+                        LabelField: "title",
+                        MetaFields: []string{"price", "note"},
+                    },
+                    Buckets: []renderer.CollectionBucket{
+                        {
+                            ID:      "included",
+                            Title:   "ui.included",
+                            BlockID: "collection.included",
+                            Predicate: &renderer.CollectionPredicate{
+                                Field:    "price",
+                                Operator: renderer.CollectionPredicateEquals,
+                                Value:    &renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 0},
+                            },
+                            Defaults: []renderer.CollectionFieldDefaultValue{
+                                {Field: "price", Value: renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 0}},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
+```
+
+Связь с target-модулем описывается в backend module, а не в renderer metadata:
+
+```go
+Relations: []module.ModuleRelation{
+    {
+        Name:         "target",
+        TargetModule: "profiles",
+        SourceField:  table.Services.ProfileID,
+        TargetField:  table.Profiles.ID,
+    },
+}
+```
+
+Frontend строит стандартные list/defrec/action endpoints из `collection.module`, а типы, labels, options, валидацию и права для `edit_fields` берет из `defrec` этого модуля.
+
 ### Resource grid metadata
 
 Для страниц типа “управление сущностями” модуль описывает typed `BaseModule.Render.ResourceGrid`. `ExtraFunc` и `extra.resource_grid_page` остаются legacy compatibility, но не являются canonical способом для новых модулей.

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -802,6 +802,107 @@ Supported operators:
 
 Conditions отвечают только за отображение. Любое действие, скрытое или выключенное UI-условием, должно иметь server-side проверку в endpoint/action.
 
+## Collection Manager
+
+`collection.manager` описывает универсальную коллекцию записей одного модуля в контексте текущей target-записи. Контракт не содержит бизнес-понятий владельца, профиля, цены или специальных endpoint-ов.
+
+Разделение ответственности:
+
+- `actor` определяется только auth token текущего запроса;
+- `target` является текущей записью страницы, например открытый record/form;
+- `module relation` задается в producer module через `BaseModule.Relations`, а не в renderer metadata;
+- client не передает owner foreign key в body create/update/delete actions;
+- server-side policy и relation filtering остаются ответственностью backend/generator integration.
+
+Минимальная коллекция без дополнительных редактируемых полей:
+
+```json
+{
+  "renderer": "collection.manager",
+  "collection": {
+    "module": "tags",
+    "target": {
+      "module": "profiles",
+      "id": {"type": "number", "number": 123}
+    },
+    "item": {
+      "label_field": "title"
+    },
+    "buckets": [
+      {
+        "id": "all",
+        "title": "All",
+        "block_id": "collection.default"
+      }
+    ]
+  }
+}
+```
+
+Коллекция с несколькими редактируемыми полями и bucket predicate/defaults:
+
+```json
+{
+  "renderer": "collection.manager",
+  "collection": {
+    "module": "services",
+    "edit_fields": ["price", "note", "available"],
+    "item": {
+      "label_field": "title",
+      "meta_fields": ["price", "note"]
+    },
+    "buckets": [
+      {
+        "id": "included",
+        "title": "Included",
+        "block_id": "collection.included",
+        "edit_fields": ["note"],
+        "predicate": {
+          "field": "price",
+          "operator": "eq",
+          "value": {"type": "number", "number": 0}
+        },
+        "defaults": [
+          {"field": "price", "value": {"type": "number", "number": 0}},
+          {"field": "available", "value": {"type": "bool", "bool": true}}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Канонические поля:
+
+| Path | Назначение |
+|------|------------|
+| `collection.module` | Имя модуля request-generator. Client строит стандартные list/defrec/action endpoints из имени модуля. |
+| `collection.target` | Typed context текущей target-записи. |
+| `collection.target.module` | Модуль target-записи. |
+| `collection.target.id` | TypedValue идентификатора target-записи. |
+| `collection.item.label_field` | Поле модуля коллекции для основного текста элемента. |
+| `collection.item.meta_fields` | Дополнительные поля элемента. |
+| `collection.edit_fields` | Идентификаторы редактируемых полей. Типы, labels, options, validation и permissions берутся из `defrec` модуля коллекции. |
+| `collection.buckets[].block_id` | Stable id универсального блока/варианта оформления bucket. |
+| `collection.buckets[].predicate` | Typed predicate по произвольному полю. |
+| `collection.buckets[].defaults` | Typed default values для bucket. |
+| `collection.buckets[].edit_fields` | Optional override списка редактируемых полей внутри конкретного bucket. |
+
+`collection` не должен содержать `list_endpoint`, `defrec_endpoint`, `profile_field`, `price_field`, `price_prefix`, `price_enabled`, `default_price`, `tone` или другие business-specific поля.
+
+Go relation declaration:
+
+```go
+Relations: []module.ModuleRelation{
+    {
+        Name:         "target",
+        TargetModule: "profiles",
+        SourceField:  table.Services.ProfileID,
+        TargetField:  table.Profiles.ID,
+    },
+}
+```
+
 ## Resource Grid Page
 
 `resource_grid_page` описывает рабочую страницу управления сущностями. В Go API это `renderer.Universal.ResourceGrid`.

--- a/generator.go
+++ b/generator.go
@@ -169,6 +169,9 @@ func (generator *Generator) Run() {
 			}
 			panic(fmt.Sprintf("invalid renderer config in module %s: %v", module.Name, err))
 		}
+		if err := generator.validateCollectionRelations(module); err != nil {
+			panic(fmt.Sprintf("invalid collection config in module %s: %v", module.Name, err))
+		}
 
 		featuresModule := Features{
 			ModuleName:       module.Label,
@@ -345,6 +348,42 @@ func (generator *Generator) Run() {
 			c.Data(http.StatusOK, "application/json; charset=utf-8", specJSON)
 		})
 	}
+}
+
+func (generator *Generator) validateCollectionRelations(owner *BaseModule) error {
+	if owner.Render.Form == nil {
+		return nil
+	}
+	moduleByName := make(map[string]*BaseModule, len(generator.Modules))
+	for _, candidate := range generator.Modules {
+		moduleByName[candidate.Name] = candidate
+	}
+	for _, section := range owner.Render.Form.Sections {
+		if section.Collection == nil {
+			continue
+		}
+		collectionModule, ok := moduleByName[section.Collection.Module]
+		if !ok {
+			return fmt.Errorf("collection section %q references unknown module %q", section.ID, section.Collection.Module)
+		}
+		if section.Collection.Target == nil || section.Collection.Target.Module == "" {
+			continue
+		}
+		if _, ok := moduleByName[section.Collection.Target.Module]; !ok {
+			return fmt.Errorf("collection section %q references unknown target module %q", section.ID, section.Collection.Target.Module)
+		}
+		relationFound := false
+		for _, relation := range collectionModule.Relations {
+			if relation.TargetModule == section.Collection.Target.Module {
+				relationFound = true
+				break
+			}
+		}
+		if !relationFound {
+			return fmt.Errorf("collection module %q must declare relation to target module %q", section.Collection.Module, section.Collection.Target.Module)
+		}
+	}
+	return nil
 }
 
 func (generator *Generator) actionList(module *BaseModule, action actions.ListModuleAction) func(c *gin.Context) {

--- a/module.go
+++ b/module.go
@@ -32,6 +32,13 @@ type NavigationTarget struct {
 
 type RenderFunc func(c *gin.Context, base renderer.Universal) (renderer.Universal, error)
 
+type ModuleRelation struct {
+	Name         string    `json:"name,omitempty"`
+	TargetModule string    `json:"target_module,omitempty"`
+	SourceField  pg.Column `json:"-"`
+	TargetField  pg.Column `json:"-"`
+}
+
 type BaseModule struct {
 	Name           string                     `json:"name"`
 	Label          string                     `json:"label"`
@@ -50,6 +57,7 @@ type BaseModule struct {
 	Navigation     []NavigationEntry          `json:"navigation,omitempty"`
 	Render         renderer.Universal         `json:"-"`
 	RenderFunc     RenderFunc                 `json:"-"`
+	Relations      []ModuleRelation           `json:"-"`
 }
 
 func (module *BaseModule) RenderFor(c *gin.Context) (renderer.Universal, error) {

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -319,8 +319,55 @@ func cloneCollectionConfig(v *CollectionConfig) *CollectionConfig {
 		return nil
 	}
 	cp := *v
-	cp.Collections = cloneSlice(v.Collections)
+	cp.Target = cloneCollectionTarget(v.Target)
+	cp.Item = cloneCollectionItem(v.Item)
+	cp.Buckets = cloneCollectionBuckets(v.Buckets)
+	cp.EditFields = cloneSlice(v.EditFields)
 	cp.Modal = cloneCollectionModal(v.Modal)
+	cp.Actions = cloneActions(v.Actions)
+	return &cp
+}
+
+func cloneCollectionTarget(v *CollectionTarget) *CollectionTarget {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.ID = clonePtr(v.ID)
+	return &cp
+}
+
+func cloneCollectionItem(v *CollectionItem) *CollectionItem {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.MetaFields = cloneSlice(v.MetaFields)
+	return &cp
+}
+
+func cloneCollectionBuckets(values []CollectionBucket) []CollectionBucket {
+	if values == nil {
+		return nil
+	}
+	out := make([]CollectionBucket, len(values))
+	for i, v := range values {
+		out[i] = v
+		out[i].Predicate = cloneCollectionPredicate(v.Predicate)
+		out[i].Defaults = cloneSlice(v.Defaults)
+		out[i].EditFields = cloneSlice(v.EditFields)
+		out[i].Actions = cloneActions(v.Actions)
+	}
+	return out
+}
+
+func cloneCollectionPredicate(v *CollectionPredicate) *CollectionPredicate {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.Value = clonePtr(v.Value)
+	cp.Values = cloneSlice(v.Values)
 	return &cp
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -70,6 +70,30 @@ func (r Universal) Validate() error {
 	if r.List != nil && r.ResourceGrid != nil {
 		return fmt.Errorf("renderer.Universal: List and ResourceGrid are mutually exclusive for one list route")
 	}
+	if r.Form != nil {
+		for _, section := range r.Form.Sections {
+			if section.Collection == nil {
+				continue
+			}
+			if section.Collection.Module == "" {
+				return fmt.Errorf("renderer.Universal: collection section %q must define module", section.ID)
+			}
+			for _, bucket := range section.Collection.Buckets {
+				if bucket.Predicate == nil {
+					continue
+				}
+				if bucket.Predicate.Field == "" {
+					return fmt.Errorf("renderer.Universal: collection bucket %q predicate must define field", bucket.ID)
+				}
+				if bucket.Predicate.Operator == "" {
+					return fmt.Errorf("renderer.Universal: collection bucket %q predicate must define operator", bucket.ID)
+				}
+				if len(bucket.Predicate.Values) > 0 && bucket.Predicate.Value != nil {
+					return fmt.Errorf("renderer.Universal: collection bucket %q predicate must not define both value and values", bucket.ID)
+				}
+			}
+		}
+	}
 	return nil
 }
 
@@ -312,46 +336,87 @@ type MediaGalleryActions struct {
 }
 
 type CollectionConfig struct {
-	Resource       string             `json:"resource,omitempty"`
-	ListEndpoint   string             `json:"list_endpoint,omitempty"`
-	DefrecEndpoint string             `json:"defrec_endpoint,omitempty"`
-	ProfileField   string             `json:"profile_field,omitempty"`
-	ValueField     string             `json:"value_field,omitempty"`
-	PriceField     string             `json:"price_field,omitempty"`
-	PricePrefix    string             `json:"price_prefix,omitempty"`
-	Size           int                `json:"size,omitempty"`
-	LoadingLabel   string             `json:"loading_label,omitempty"`
-	Collections    []CollectionBucket `json:"collections,omitempty"`
-	Modal          *CollectionModal   `json:"modal,omitempty"`
+	Module       string             `json:"module,omitempty"`
+	Target       *CollectionTarget  `json:"target,omitempty"`
+	Item         *CollectionItem    `json:"item,omitempty"`
+	Size         int                `json:"size,omitempty"`
+	LoadingLabel string             `json:"loading_label,omitempty"`
+	Buckets      []CollectionBucket `json:"buckets,omitempty"`
+	EditFields   []string           `json:"edit_fields,omitempty"`
+	Modal        *CollectionModal   `json:"modal,omitempty"`
+	Actions      []Action           `json:"actions,omitempty"`
+}
+
+type CollectionTarget struct {
+	Module string      `json:"module,omitempty"`
+	ID     *TypedValue `json:"id,omitempty"`
+}
+
+type CollectionItem struct {
+	LabelField       string   `json:"label_field,omitempty"`
+	MetaFields       []string `json:"meta_fields,omitempty"`
+	DescriptionField string   `json:"description_field,omitempty"`
+	MediaField       string   `json:"media_field,omitempty"`
+	StatusField      string   `json:"status_field,omitempty"`
 }
 
 type CollectionBucket struct {
-	ID            string                  `json:"id,omitempty"`
-	Title         string                  `json:"title,omitempty"`
-	CountLabel    string                  `json:"count_label,omitempty"`
-	AddLabel      string                  `json:"add_label,omitempty"`
-	ClearLabel    string                  `json:"clear_label,omitempty"`
-	ModalTitle    string                  `json:"modal_title,omitempty"`
-	ModalSubtitle string                  `json:"modal_subtitle,omitempty"`
-	ConfirmLabel  string                  `json:"confirm_label,omitempty"`
-	Tone          string                  `json:"tone,omitempty"`
-	PriceEnabled  bool                    `json:"price_enabled"`
-	DefaultPrice  int                     `json:"default_price"`
-	PricePrefix   string                  `json:"price_prefix,omitempty"`
-	EditFields    []CollectionEditField   `json:"edit_fields,omitempty"`
-	Filter        *CollectionBucketFilter `json:"filter,omitempty"`
+	ID            string                        `json:"id,omitempty"`
+	Title         string                        `json:"title,omitempty"`
+	CountLabel    string                        `json:"count_label,omitempty"`
+	AddLabel      string                        `json:"add_label,omitempty"`
+	ClearLabel    string                        `json:"clear_label,omitempty"`
+	ModalTitle    string                        `json:"modal_title,omitempty"`
+	ModalSubtitle string                        `json:"modal_subtitle,omitempty"`
+	ConfirmLabel  string                        `json:"confirm_label,omitempty"`
+	BlockID       string                        `json:"block_id,omitempty"`
+	Predicate     *CollectionPredicate          `json:"predicate,omitempty"`
+	Defaults      []CollectionFieldDefaultValue `json:"defaults,omitempty"`
+	EditFields    []string                      `json:"edit_fields,omitempty"`
+	Actions       []Action                      `json:"actions,omitempty"`
 }
 
-type CollectionEditField struct {
-	ID      string `json:"id,omitempty"`
-	Type    string `json:"type,omitempty"`
-	Variant string `json:"variant,omitempty"`
-	Prefix  string `json:"prefix,omitempty"`
-	Min     int    `json:"min"`
+type CollectionPredicateOperator string
+
+const (
+	CollectionPredicateEquals      CollectionPredicateOperator = "eq"
+	CollectionPredicateNotEquals   CollectionPredicateOperator = "ne"
+	CollectionPredicateIn          CollectionPredicateOperator = "in"
+	CollectionPredicateNotIn       CollectionPredicateOperator = "not_in"
+	CollectionPredicateEmpty       CollectionPredicateOperator = "empty"
+	CollectionPredicateNotEmpty    CollectionPredicateOperator = "not_empty"
+	CollectionPredicateGreaterThan CollectionPredicateOperator = "gt"
+	CollectionPredicateLessThan    CollectionPredicateOperator = "lt"
+	CollectionPredicateGTE         CollectionPredicateOperator = "gte"
+	CollectionPredicateLTE         CollectionPredicateOperator = "lte"
+)
+
+type CollectionPredicate struct {
+	Field    string                      `json:"field,omitempty"`
+	Operator CollectionPredicateOperator `json:"operator,omitempty"`
+	Value    *TypedValue                 `json:"value,omitempty"`
+	Values   []TypedValue                `json:"values,omitempty"`
 }
 
-type CollectionBucketFilter struct {
-	Price string `json:"price,omitempty"`
+type CollectionFieldDefaultValue struct {
+	Field string     `json:"field,omitempty"`
+	Value TypedValue `json:"value"`
+}
+
+type TypedValueType string
+
+const (
+	TypedValueString TypedValueType = "string"
+	TypedValueNumber TypedValueType = "number"
+	TypedValueBool   TypedValueType = "bool"
+	TypedValueNull   TypedValueType = "null"
+)
+
+type TypedValue struct {
+	Type   TypedValueType `json:"type"`
+	String string         `json:"string,omitempty"`
+	Number float64        `json:"number,omitempty"`
+	Bool   *bool          `json:"bool,omitempty"`
 }
 
 type CollectionModal struct {

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -347,6 +347,299 @@ func TestUniversalRendererMetadata_FormSectionMediaGallery(t *testing.T) {
 	assert.Equal(t, "/media_assets", section.MediaActions.Upload.API.Endpoint)
 }
 
+func TestUniversalRendererMetadata_FormSectionCollectionContract(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	id := postgres.IntegerColumn("id")
+	table := postgres.NewTable("public", "collection_renderer_items", "", id)
+	profileID := postgres.IntegerColumn("profile_id")
+	profilesTable := postgres.NewTable("public", "profiles", "", id)
+	tagsTable := postgres.NewTable("public", "tags", "", id, profileID)
+	servicesTable := postgres.NewTable("public", "services", "", id, profileID)
+	active := true
+
+	testModule := &module.BaseModule{
+		Name:       "collection-renderer-items",
+		Path:       "/admin",
+		Table:      table,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
+		},
+		Render: renderer.Universal{
+			Form: &renderer.FormPage{
+				ID:     "collection-renderer-items-form",
+				Layout: renderer.LayoutTwoColumn,
+				Sections: []renderer.FormSection{
+					{
+						ID:       "simple_collection",
+						Renderer: renderer.RendererCollectionManager,
+						Collection: &renderer.CollectionConfig{
+							Module: "tags",
+							Target: &renderer.CollectionTarget{
+								Module: "profiles",
+								ID:     &renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 123},
+							},
+							Item: &renderer.CollectionItem{LabelField: "title"},
+							Buckets: []renderer.CollectionBucket{
+								{ID: "all", Title: "All", BlockID: "collection.default"},
+							},
+						},
+					},
+					{
+						ID:       "editable_collection",
+						Renderer: renderer.RendererCollectionManager,
+						Collection: &renderer.CollectionConfig{
+							Module:     "services",
+							EditFields: []string{"price", "note", "available"},
+							Item:       &renderer.CollectionItem{LabelField: "title", MetaFields: []string{"price", "note"}},
+							Buckets: []renderer.CollectionBucket{
+								{
+									ID:         "included",
+									Title:      "Included",
+									BlockID:    "collection.included",
+									EditFields: []string{"note"},
+									Predicate: &renderer.CollectionPredicate{
+										Field:    "price",
+										Operator: renderer.CollectionPredicateEquals,
+										Value:    &renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 0},
+									},
+									Defaults: []renderer.CollectionFieldDefaultValue{
+										{Field: "price", Value: renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 0}},
+										{Field: "available", Value: renderer.TypedValue{Type: renderer.TypedValueBool, Bool: &active}},
+									},
+								},
+								{
+									ID:      "paid",
+									Title:   "Paid",
+									BlockID: "collection.paid",
+									Predicate: &renderer.CollectionPredicate{
+										Field:    "price",
+										Operator: renderer.CollectionPredicateGreaterThan,
+										Value:    &renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 0},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Defrec: actions.DefrecModuleAction{
+			Permission: []actions.Role{actions.RoleAll},
+			Auth:       true,
+			Label:      "Defrec",
+		},
+		Actions: []actions.ModuleAction{
+			actions.AddModuleAction{
+				Columns:    []pg.Column{id},
+				Permission: []actions.Role{actions.RoleAll},
+				Auth:       true,
+				Label:      "Add",
+			},
+		},
+	}
+
+	engine := gin.New()
+	group := engine.Group("")
+	profilesModule := &module.BaseModule{Name: "profiles", Path: "/admin", Table: profilesTable, PrimaryKey: id}
+	tagsModule := &module.BaseModule{
+		Name:       "tags",
+		Path:       "/admin",
+		Table:      tagsTable,
+		PrimaryKey: id,
+		Relations:  []module.ModuleRelation{{Name: "target", TargetModule: "profiles", SourceField: profileID, TargetField: id}},
+	}
+	servicesModule := &module.BaseModule{
+		Name:       "services",
+		Path:       "/admin",
+		Table:      servicesTable,
+		PrimaryKey: id,
+		Relations:  []module.ModuleRelation{{Name: "target", TargetModule: "profiles", SourceField: profileID, TargetField: id}},
+	}
+	generator := module.NewGenerator(
+		func(_ *module.BaseModule) dbpkg.DBExecutor { return fakeRendererDB{} },
+		*group,
+		[]*module.BaseModule{testModule, profilesModule, tagsModule, servicesModule},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+	)
+	generator.Run()
+
+	w := executeRequest(engine, http.MethodGet, "/admin/collection-renderer-items/defrec/", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response struct {
+		FormPage *renderer.FormPage `json:"form_page"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NotNil(t, response.FormPage)
+	require.Len(t, response.FormPage.Sections, 2)
+
+	simple := response.FormPage.Sections[0].Collection
+	require.NotNil(t, simple)
+	assert.Equal(t, "tags", simple.Module)
+	assert.Empty(t, simple.EditFields)
+	require.NotNil(t, simple.Target)
+	assert.Equal(t, "profiles", simple.Target.Module)
+	require.NotNil(t, simple.Target.ID)
+	assert.Equal(t, renderer.TypedValueNumber, simple.Target.ID.Type)
+	assert.Equal(t, float64(123), simple.Target.ID.Number)
+	assert.Equal(t, "title", simple.Item.LabelField)
+	require.Len(t, simple.Buckets, 1)
+	assert.Equal(t, "collection.default", simple.Buckets[0].BlockID)
+
+	editable := response.FormPage.Sections[1].Collection
+	require.NotNil(t, editable)
+	assert.Equal(t, "services", editable.Module)
+	assert.Equal(t, []string{"price", "note", "available"}, editable.EditFields)
+	assert.Equal(t, []string{"price", "note"}, editable.Item.MetaFields)
+	require.Len(t, editable.Buckets, 2)
+	included := editable.Buckets[0]
+	assert.Equal(t, "collection.included", included.BlockID)
+	assert.Equal(t, []string{"note"}, included.EditFields)
+	require.NotNil(t, included.Predicate)
+	assert.Equal(t, "price", included.Predicate.Field)
+	assert.Equal(t, renderer.CollectionPredicateEquals, included.Predicate.Operator)
+	require.NotNil(t, included.Predicate.Value)
+	assert.Equal(t, float64(0), included.Predicate.Value.Number)
+	require.Len(t, included.Defaults, 2)
+	assert.Equal(t, "price", included.Defaults[0].Field)
+	assert.Equal(t, renderer.TypedValueNumber, included.Defaults[0].Value.Type)
+	assert.Equal(t, "available", included.Defaults[1].Field)
+	require.NotNil(t, included.Defaults[1].Value.Bool)
+	assert.True(t, *included.Defaults[1].Value.Bool)
+}
+
+func TestUniversalRendererMetadata_CollectionValidation(t *testing.T) {
+	err := (renderer.Universal{
+		Form: &renderer.FormPage{
+			Sections: []renderer.FormSection{
+				{ID: "collection", Renderer: renderer.RendererCollectionManager, Collection: &renderer.CollectionConfig{}},
+			},
+		},
+	}).Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `collection section "collection" must define module`)
+
+	err = (renderer.Universal{
+		Form: &renderer.FormPage{
+			Sections: []renderer.FormSection{
+				{
+					ID:       "collection",
+					Renderer: renderer.RendererCollectionManager,
+					Collection: &renderer.CollectionConfig{
+						Module: "items",
+						Buckets: []renderer.CollectionBucket{
+							{ID: "bad", Predicate: &renderer.CollectionPredicate{Operator: renderer.CollectionPredicateEquals}},
+						},
+					},
+				},
+			},
+		},
+	}).Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `collection bucket "bad" predicate must define field`)
+
+	err = (renderer.Universal{
+		Form: &renderer.FormPage{
+			Sections: []renderer.FormSection{
+				{
+					ID:       "collection",
+					Renderer: renderer.RendererCollectionManager,
+					Collection: &renderer.CollectionConfig{
+						Module: "items",
+						Buckets: []renderer.CollectionBucket{
+							{
+								ID: "bad",
+								Predicate: &renderer.CollectionPredicate{
+									Field:    "status",
+									Operator: renderer.CollectionPredicateIn,
+									Value:    &renderer.TypedValue{Type: renderer.TypedValueString, String: "active"},
+									Values:   []renderer.TypedValue{{Type: renderer.TypedValueString, String: "draft"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `collection bucket "bad" predicate must not define both value and values`)
+}
+
+func TestUniversalRendererMetadata_CollectionRelationValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	id := postgres.IntegerColumn("id")
+	profileID := postgres.IntegerColumn("profile_id")
+	pageTable := postgres.NewTable("public", "collection_page", "", id)
+	profilesTable := postgres.NewTable("public", "profiles", "", id)
+	itemsTable := postgres.NewTable("public", "items", "", id, profileID)
+
+	newGenerator := func(collectionModule *module.BaseModule, collectionName string) *module.Generator {
+		pageModule := &module.BaseModule{
+			Name:       "collection-page",
+			Path:       "/admin",
+			Table:      pageTable,
+			PrimaryKey: id,
+			Render: renderer.Universal{
+				Form: &renderer.FormPage{
+					Sections: []renderer.FormSection{
+						{
+							ID:       "items",
+							Renderer: renderer.RendererCollectionManager,
+							Collection: &renderer.CollectionConfig{
+								Module: collectionName,
+								Target: &renderer.CollectionTarget{Module: "profiles"},
+							},
+						},
+					},
+				},
+			},
+		}
+		profilesModule := &module.BaseModule{Name: "profiles", Path: "/admin", Table: profilesTable, PrimaryKey: id}
+		modules := []*module.BaseModule{pageModule, profilesModule}
+		if collectionModule != nil {
+			modules = append(modules, collectionModule)
+		}
+		engine := gin.New()
+		group := engine.Group("")
+		return module.NewGenerator(
+			func(_ *module.BaseModule) dbpkg.DBExecutor { return fakeRendererDB{} },
+			*group,
+			modules,
+			func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+				return func(c *gin.Context) { c.Next() }
+			},
+			createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+		)
+	}
+
+	assert.PanicsWithValue(t,
+		`invalid collection config in module collection-page: collection section "items" references unknown module "items"`,
+		func() { newGenerator(nil, "items").Run() },
+	)
+
+	itemsWithoutRelation := &module.BaseModule{Name: "items", Path: "/admin", Table: itemsTable, PrimaryKey: id}
+	assert.PanicsWithValue(t,
+		`invalid collection config in module collection-page: collection module "items" must declare relation to target module "profiles"`,
+		func() { newGenerator(itemsWithoutRelation, "items").Run() },
+	)
+
+	itemsWithRelation := &module.BaseModule{
+		Name:       "items",
+		Path:       "/admin",
+		Table:      itemsTable,
+		PrimaryKey: id,
+		Relations:  []module.ModuleRelation{{Name: "target", TargetModule: "profiles", SourceField: profileID, TargetField: id}},
+	}
+	assert.NotPanics(t, func() { newGenerator(itemsWithRelation, "items").Run() })
+}
+
 func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	engine := setupUniversalRendererRouter(t)
 


### PR DESCRIPTION
## Что изменено

- CollectionConfig очищен от business-specific полей: profile/price owner-binding, list_endpoint, defrec_endpoint, price_enabled, default_price, price_prefix, tone.
- В конфигурации коллекции оставлен module, target context, item field bindings, edit_fields, buckets, modal и actions.
- edit_fields теперь только список id полей; типы, labels, options, checks и permissions должны браться из defrec модуля коллекции.
- Bucket filter заменен на typed predicate по произвольному field/operator/value/values.
- Bucket defaults заменены на список typed field default values.
- Визуальное оформление bucket задается block_id, а не tone.
- Добавлен TypedValue для target id, predicates и defaults.
- Добавлен BaseModule.Relations / ModuleRelation для декларации связи collection module -> target module вне renderer metadata.
- Generator.Run валидирует, что collection.module существует, target.module существует и collection module объявляет relation к target module.
- Добавлены integration/contract tests для:
  - коллекции без edit fields;
  - коллекции с одним и несколькими edit fields;
  - bucket predicates/defaults;
  - validation ошибок collection config;
  - отказа при неизвестном collection module;
  - отказа при отсутствии relation к target module.
- Обновлены README и UniversalRenderer specification.

## Границы PR

Этот PR меняет typed contract request-generator и статическую relation validation. Миграция существующих API modules и ui-kit components не входит в задачу issue #38 и должна идти отдельными PR.

## Проверки

- go test ./...

Closes #38