### PR TITLE
Implement relation-scoped collection actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ renderer.Action{
 
 ### Collection manager metadata
 
-`renderer.CollectionConfig` описывает универсальную коллекцию записей модуля в контексте текущей target-записи. Контракт не содержит owner foreign key, profile-specific полей, price-specific полей или endpoint-ов.
+`renderer.CollectionConfig` описывает универсальную коллекцию записей самостоятельного модуля. Контракт не содержит owner foreign key, target module/id, business-specific полей или endpoint-ов.
 
 ```go
 Render: renderer.Universal{
@@ -317,11 +317,12 @@ Render: renderer.Universal{
                 ID:       "services",
                 Renderer: renderer.RendererCollectionManager,
                 Collection: &renderer.CollectionConfig{
-                    Module:     "model_additional_services",
-                    EditFields: []string{"price", "note", "available"},
+                    Module:     "related_records",
+                    Relation:   "owner",
+                    EditFields: []string{"amount", "note", "enabled"},
                     Item: &renderer.CollectionItem{
-                        LabelField: "title",
-                        MetaFields: []string{"price", "note"},
+                        LabelField: "kind",
+                        MetaFields: []string{"amount", "note"},
                     },
                     Buckets: []renderer.CollectionBucket{
                         {
@@ -329,12 +330,12 @@ Render: renderer.Universal{
                             Title:   "ui.included",
                             BlockID: "collection.included",
                             Predicate: &renderer.CollectionPredicate{
-                                Field:    "price",
+                                Field:    "amount",
                                 Operator: renderer.CollectionPredicateEquals,
                                 Value:    &renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 0},
                             },
                             Defaults: []renderer.CollectionFieldDefaultValue{
-                                {Field: "price", Value: renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 0}},
+                                {Field: "amount", Value: renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 0}},
                             },
                         },
                     },
@@ -345,20 +346,23 @@ Render: renderer.Universal{
 }
 ```
 
-Связь с target-модулем описывается в backend module, а не в renderer metadata:
+Если collection нужно ограничить текущей открытой записью, связь описывается в backend module, а renderer указывает только technical relation name:
 
 ```go
 Relations: []module.ModuleRelation{
     {
-        Name:         "target",
-        TargetModule: "profiles",
-        SourceField:  table.Services.ProfileID,
-        TargetField:  table.Profiles.ID,
+        Name:         "owner",
+        TargetModule: "records",
+        SourceField:  table.RelatedRecords.RecordID,
+        TargetField:  table.Records.ID,
+        ScopeCheck: func(c *gin.Context, scope module.RelationScope) error {
+            return checkActorCanUseRecord(c, scope.ID)
+        },
     },
 }
 ```
 
-Frontend строит стандартные list/defrec/action endpoints из `collection.module`, а типы, labels, options, валидацию и права для `edit_fields` берет из `defrec` этого модуля.
+Frontend строит стандартные list/defrec/action endpoints из `collection.module`. Если `collection.relation` задан, frontend передаёт `scope[relation]` и `scope[id]` в query. Body add/update содержит только обычные поля модуля; relation source field подставляет generator.
 
 ### Resource grid metadata
 

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -804,27 +804,23 @@ Conditions отвечают только за отображение. Любое
 
 ## Collection Manager
 
-`collection.manager` описывает универсальную коллекцию записей одного модуля в контексте текущей target-записи. Контракт не содержит бизнес-понятий владельца, профиля, цены или специальных endpoint-ов.
+`collection.manager` описывает универсальную коллекцию записей одного самостоятельного модуля. Контракт не содержит business-specific полей владельца, target module/id, цены или специальных endpoint-ов.
 
 Разделение ответственности:
 
 - `actor` определяется только auth token текущего запроса;
-- `target` является текущей записью страницы, например открытый record/form;
 - `module relation` задается в producer module через `BaseModule.Relations`, а не в renderer metadata;
-- client не передает owner foreign key в body create/update/delete actions;
-- server-side policy и relation filtering остаются ответственностью backend/generator integration.
+- если коллекция scoped, renderer передает только stable relation name через `collection.relation`;
+- client передает `scope[relation]` и `scope[id]` в query, но не передает owner foreign key в body create/update/delete actions;
+- server-side permission, `ScopeCheck` и relation filtering остаются ответственностью backend/generator integration.
 
-Минимальная коллекция без дополнительных редактируемых полей:
+Минимальная коллекция без relation scope:
 
 ```json
 {
   "renderer": "collection.manager",
   "collection": {
     "module": "tags",
-    "target": {
-      "module": "profiles",
-      "id": {"type": "number", "number": 123}
-    },
     "item": {
       "label_field": "title"
     },
@@ -839,17 +835,18 @@ Conditions отвечают только за отображение. Любое
 }
 ```
 
-Коллекция с несколькими редактируемыми полями и bucket predicate/defaults:
+Коллекция с relation scope, несколькими редактируемыми полями и bucket predicate/defaults:
 
 ```json
 {
   "renderer": "collection.manager",
   "collection": {
-    "module": "services",
-    "edit_fields": ["price", "note", "available"],
+    "module": "related_records",
+    "relation": "owner",
+    "edit_fields": ["amount", "note", "enabled"],
     "item": {
-      "label_field": "title",
-      "meta_fields": ["price", "note"]
+      "label_field": "kind",
+      "meta_fields": ["amount", "note"]
     },
     "buckets": [
       {
@@ -858,13 +855,13 @@ Conditions отвечают только за отображение. Любое
         "block_id": "collection.included",
         "edit_fields": ["note"],
         "predicate": {
-          "field": "price",
+          "field": "amount",
           "operator": "eq",
           "value": {"type": "number", "number": 0}
         },
         "defaults": [
-          {"field": "price", "value": {"type": "number", "number": 0}},
-          {"field": "available", "value": {"type": "bool", "bool": true}}
+          {"field": "amount", "value": {"type": "number", "number": 0}},
+          {"field": "enabled", "value": {"type": "bool", "bool": true}}
         ]
       }
     ]
@@ -877,9 +874,7 @@ Conditions отвечают только за отображение. Любое
 | Path | Назначение |
 |------|------------|
 | `collection.module` | Имя модуля request-generator. Client строит стандартные list/defrec/action endpoints из имени модуля. |
-| `collection.target` | Typed context текущей target-записи. |
-| `collection.target.module` | Модуль target-записи. |
-| `collection.target.id` | TypedValue идентификатора target-записи. |
+| `collection.relation` | Optional stable technical name relation из `BaseModule.Relations`. Если задан, client передает `scope[relation]` и `scope[id]` в query стандартных actions. |
 | `collection.item.label_field` | Поле модуля коллекции для основного текста элемента. |
 | `collection.item.meta_fields` | Дополнительные поля элемента. |
 | `collection.edit_fields` | Идентификаторы редактируемых полей. Типы, labels, options, validation и permissions берутся из `defrec` модуля коллекции. |
@@ -888,20 +883,40 @@ Conditions отвечают только за отображение. Любое
 | `collection.buckets[].defaults` | Typed default values для bucket. |
 | `collection.buckets[].edit_fields` | Optional override списка редактируемых полей внутри конкретного bucket. |
 
-`collection` не должен содержать `list_endpoint`, `defrec_endpoint`, `profile_field`, `price_field`, `price_prefix`, `price_enabled`, `default_price`, `tone` или другие business-specific поля.
+`collection` не должен содержать `target`, `list_endpoint`, `defrec_endpoint`, `profile_field`, `price_field`, `price_prefix`, `price_enabled`, `default_price`, `tone` или другие business-specific поля.
 
 Go relation declaration:
 
 ```go
 Relations: []module.ModuleRelation{
     {
-        Name:         "target",
-        TargetModule: "profiles",
-        SourceField:  table.Services.ProfileID,
-        TargetField:  table.Profiles.ID,
+        Name:         "owner",
+        TargetModule: "records",
+        SourceField:  table.RelatedRecords.RecordID,
+        TargetField:  table.Records.ID,
+        ScopeCheck: func(c *gin.Context, scope module.RelationScope) error {
+            return checkActorCanUseRecord(c, scope.ID)
+        },
     },
 }
 ```
+
+Scoped transport:
+
+```http
+GET /api/related_records?scope[relation]=owner&scope[id]=123&size=200
+PUT /api/related_records?scope[relation]=owner&scope[id]=123
+POST /api/related_records/id/88?scope[relation]=owner&scope[id]=123
+DELETE /api/related_records/delete/id/88?scope[relation]=owner&scope[id]=123
+```
+
+Generator behavior:
+
+- без `scope[...]` стандартные actions работают как раньше;
+- с `scope[...]` generator находит relation по имени, вызывает `ScopeCheck`, добавляет relation filter в `list`;
+- при `add` generator сам подставляет `SourceField = scope[id]`;
+- при `add/update` body с relation source field отклоняется;
+- при `update/delete` generator добавляет relation constraint к `WHERE`, поэтому запись из другого scope не изменяется и не удаляется.
 
 ## Resource Grid Page
 

--- a/generator.go
+++ b/generator.go
@@ -366,21 +366,18 @@ func (generator *Generator) validateCollectionRelations(owner *BaseModule) error
 		if !ok {
 			return fmt.Errorf("collection section %q references unknown module %q", section.ID, section.Collection.Module)
 		}
-		if section.Collection.Target == nil || section.Collection.Target.Module == "" {
+		if section.Collection.Relation == "" {
 			continue
 		}
-		if _, ok := moduleByName[section.Collection.Target.Module]; !ok {
-			return fmt.Errorf("collection section %q references unknown target module %q", section.ID, section.Collection.Target.Module)
+		relation, ok := findModuleRelation(collectionModule, section.Collection.Relation)
+		if !ok {
+			return fmt.Errorf("collection module %q must declare relation %q", section.Collection.Module, section.Collection.Relation)
 		}
-		relationFound := false
-		for _, relation := range collectionModule.Relations {
-			if relation.TargetModule == section.Collection.Target.Module {
-				relationFound = true
-				break
-			}
+		if relation.TargetModule != owner.Name {
+			return fmt.Errorf("collection module %q relation %q must target module %q", section.Collection.Module, section.Collection.Relation, owner.Name)
 		}
-		if !relationFound {
-			return fmt.Errorf("collection module %q must declare relation to target module %q", section.Collection.Module, section.Collection.Target.Module)
+		if relation.ScopeCheck == nil {
+			return fmt.Errorf("collection module %q relation %q must declare ScopeCheck", section.Collection.Module, section.Collection.Relation)
 		}
 	}
 	return nil
@@ -450,6 +447,12 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 				where = actionWhere
 			}
 		}
+		scope, status, err := generator.resolveRelationScope(c, module)
+		if err != nil {
+			response.ErrorResponse(l, c, status, err.Error(), nil)
+			return
+		}
+		where = appendRelationScopeWhere(module, where, scope)
 
 		joins := action.Join
 		if roleJoins := actions.ResolveRoleJoin(module.RoleJoin, role); roleJoins != nil {
@@ -768,6 +771,19 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 			})
 			return
 		}
+		scope, status, err := generator.resolveRelationScope(c, module)
+		if err != nil {
+			response.ErrorResponse(l, c, status, GeneratorErrorAdd, []string{err.Error()})
+			return
+		}
+		if err := rejectScopedSourceField(input, scope); err != nil {
+			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
+			return
+		}
+		if _, err := injectRelationScopeInput(c, input, nil, nil, module, scope); err != nil {
+			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
+			return
+		}
 
 		// Apply DefaultFunc for fields absent from the request body.
 		for _, field := range module.Fields {
@@ -806,6 +822,11 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 			if !containsColumn(columns, realField.Column) && realField.DefaultFunc != nil {
 				mapInput[realField.ColumnName()] = realField.DefaultFunc(c)
 			}
+		}
+		realFields, err = injectRelationScopeInput(c, input, mapInput, realFields, module, scope)
+		if err != nil {
+			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
+			return
 		}
 		output, err := generator.db(module).Add(l, module.Table, module.PrimaryKey, realFields, mapInput, tc)
 		if err != nil {
@@ -1179,6 +1200,15 @@ func (generator *Generator) actionUpdate(module *BaseModule, action actions.Upda
 			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorUpdate, nil)
 			return
 		}
+		scope, status, err := generator.resolveRelationScope(c, module)
+		if err != nil {
+			response.ErrorResponse(l, c, status, GeneratorErrorUpdate, []string{err.Error()})
+			return
+		}
+		if err := rejectScopedSourceField(input, scope); err != nil {
+			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorUpdate, []string{err.Error()})
+			return
+		}
 
 		errs := generator.checkRequest(c, input, module, action, fields.ScenarioUpdate, lang)
 		if len(errs) > 0 {
@@ -1217,6 +1247,7 @@ func (generator *Generator) actionUpdate(module *BaseModule, action actions.Upda
 				where = pg.AND(where, actionWhere)
 			}
 		}
+		where = appendRelationScopeWhere(module, where, scope)
 
 		_, err = generator.db(module).Update(l, module.Table, module.PrimaryKey, realFields, mapInput, where, tc)
 		if err != nil {
@@ -1329,6 +1360,12 @@ func (generator *Generator) actionDelete(module *BaseModule, action actions.Dele
 				where = pg.AND(where, actionWhere)
 			}
 		}
+		scope, status, err := generator.resolveRelationScope(c, module)
+		if err != nil {
+			response.ErrorResponse(l, c, status, GeneratorErrorDelete, []string{err.Error()})
+			return
+		}
+		where = appendRelationScopeWhere(module, where, scope)
 
 		err = generator.db(module).Delete(l, module.Table, where, tc)
 		if err != nil {

--- a/module.go
+++ b/module.go
@@ -32,11 +32,17 @@ type NavigationTarget struct {
 
 type RenderFunc func(c *gin.Context, base renderer.Universal) (renderer.Universal, error)
 
+type RelationScope struct {
+	Relation string
+	ID       interface{}
+}
+
 type ModuleRelation struct {
-	Name         string    `json:"name,omitempty"`
-	TargetModule string    `json:"target_module,omitempty"`
-	SourceField  pg.Column `json:"-"`
-	TargetField  pg.Column `json:"-"`
+	Name         string                                          `json:"name,omitempty"`
+	TargetModule string                                          `json:"target_module,omitempty"`
+	SourceField  pg.Column                                       `json:"-"`
+	TargetField  pg.Column                                       `json:"-"`
+	ScopeCheck   func(c *gin.Context, scope RelationScope) error `json:"-"`
 }
 
 type BaseModule struct {

--- a/relation_scope.go
+++ b/relation_scope.go
@@ -1,0 +1,185 @@
+package module
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/darkrain/request-generator/fields"
+	"github.com/gin-gonic/gin"
+	pg "github.com/go-jet/jet/v2/postgres"
+)
+
+type resolvedRelationScope struct {
+	relation ModuleRelation
+	scope    RelationScope
+}
+
+func (generator *Generator) resolveRelationScope(c *gin.Context, module *BaseModule) (*resolvedRelationScope, int, error) {
+	query := c.QueryMap("scope")
+	relationName := strings.TrimSpace(query["relation"])
+	scopeID := strings.TrimSpace(query["id"])
+	if relationName == "" && scopeID == "" {
+		return nil, 0, nil
+	}
+	if relationName == "" || scopeID == "" {
+		return nil, http.StatusBadRequest, errors.New("scope[relation] and scope[id] are required together")
+	}
+
+	relation, ok := findModuleRelation(module, relationName)
+	if !ok {
+		return nil, http.StatusBadRequest, fmt.Errorf("unknown relation scope %q", relationName)
+	}
+	if relation.ScopeCheck == nil {
+		return nil, http.StatusBadRequest, fmt.Errorf("relation scope %q is not enabled", relationName)
+	}
+	canonicalID, err := generator.canonicalRelationScopeID(c, relation, scopeID)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	scope := RelationScope{
+		Relation: relationName,
+		ID:       canonicalID,
+	}
+	if err = relation.ScopeCheck(c, scope); err != nil {
+		return nil, http.StatusForbidden, err
+	}
+
+	return &resolvedRelationScope{
+		relation: relation,
+		scope:    scope,
+	}, 0, nil
+}
+
+func findModuleRelation(module *BaseModule, name string) (ModuleRelation, bool) {
+	for _, relation := range module.Relations {
+		if relation.Name == name {
+			return relation, true
+		}
+	}
+	return ModuleRelation{}, false
+}
+
+func (generator *Generator) canonicalRelationScopeID(c *gin.Context, relation ModuleRelation, raw string) (interface{}, error) {
+	targetModule := generator.findModule(relation.TargetModule)
+	if targetModule == nil {
+		return nil, fmt.Errorf("relation scope target module %q is not registered", relation.TargetModule)
+	}
+	targetField := targetModule.GetFieldByColumn(relation.TargetField)
+	if targetField == nil {
+		return nil, fmt.Errorf("relation target field %q is not declared in module fields", relation.TargetField.Name())
+	}
+	if targetField.Convert != nil {
+		return targetField.Convert(c, raw)
+	}
+
+	switch targetField.Type {
+	case fields.ModuleFieldTypeInt:
+		parsed, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid relation scope id %q for int field %q", raw, targetField.ColumnName())
+		}
+		return parsed, nil
+	case fields.ModuleFieldTypeFloat:
+		parsed, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid relation scope id %q for float field %q", raw, targetField.ColumnName())
+		}
+		return parsed, nil
+	case fields.ModuleFieldTypeString:
+		return raw, nil
+	default:
+		return nil, fmt.Errorf("relation scope id field %q has unsupported type %q", targetField.ColumnName(), targetField.Type)
+	}
+}
+
+func (generator *Generator) findModule(name string) *BaseModule {
+	for _, candidate := range generator.Modules {
+		if candidate.Name == name {
+			return candidate
+		}
+	}
+	return nil
+}
+
+func relationScopeWhere(module *BaseModule, scope *resolvedRelationScope) pg.BoolExpression {
+	if scope == nil {
+		return nil
+	}
+	tableRef := scope.relation.SourceField.TableName()
+	if tableRef == "" {
+		tableRef = module.Table.Alias()
+	}
+	if tableRef == "" {
+		tableRef = module.Table.TableName()
+	}
+	return pg.RawBool(
+		fmt.Sprintf(`%s."%s" = #scope_id`, tableRef, scope.relation.SourceField.Name()),
+		pg.RawArgs{"#scope_id": scope.scope.ID},
+	)
+}
+
+func rejectScopedSourceField(input map[string]interface{}, scope *resolvedRelationScope) error {
+	if scope == nil {
+		return nil
+	}
+	if _, ok := input[scope.relation.SourceField.Name()]; ok {
+		return fmt.Errorf("field %q is controlled by relation scope", scope.relation.SourceField.Name())
+	}
+	return nil
+}
+
+func appendRelationScopeWhere(module *BaseModule, where pg.BoolExpression, scope *resolvedRelationScope) pg.BoolExpression {
+	scopeWhere := relationScopeWhere(module, scope)
+	if scopeWhere == nil {
+		return where
+	}
+	if where == nil {
+		return scopeWhere
+	}
+	return pg.AND(where, scopeWhere)
+}
+
+func injectRelationScopeInput(
+	c *gin.Context,
+	input map[string]interface{},
+	mapInput map[string]interface{},
+	realFields []fields.ModuleField,
+	module *BaseModule,
+	scope *resolvedRelationScope,
+) ([]fields.ModuleField, error) {
+	if scope == nil {
+		return realFields, nil
+	}
+
+	field := module.GetFieldByColumn(scope.relation.SourceField)
+	if field == nil {
+		return nil, fmt.Errorf("relation source field %q is not declared in module fields", scope.relation.SourceField.Name())
+	}
+
+	// scope.ID has already been converted by the target field before ScopeCheck.
+	// A source-field converter accepts a transport value and is not required to
+	// be idempotent, so applying it again would corrupt typed relation IDs.
+	value := scope.scope.ID
+
+	input[field.ColumnName()] = value
+	if mapInput != nil {
+		mapInput[field.ColumnName()] = value
+	}
+	if !containsModuleField(realFields, field.Column) {
+		realFields = append(realFields, *field)
+	}
+	return realFields, nil
+}
+
+func containsModuleField(items []fields.ModuleField, target pg.Column) bool {
+	for _, item := range items {
+		if fields.ContainsColumn([]pg.Column{item.Column}, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -319,21 +319,11 @@ func cloneCollectionConfig(v *CollectionConfig) *CollectionConfig {
 		return nil
 	}
 	cp := *v
-	cp.Target = cloneCollectionTarget(v.Target)
 	cp.Item = cloneCollectionItem(v.Item)
 	cp.Buckets = cloneCollectionBuckets(v.Buckets)
 	cp.EditFields = cloneSlice(v.EditFields)
 	cp.Modal = cloneCollectionModal(v.Modal)
 	cp.Actions = cloneActions(v.Actions)
-	return &cp
-}
-
-func cloneCollectionTarget(v *CollectionTarget) *CollectionTarget {
-	if v == nil {
-		return nil
-	}
-	cp := *v
-	cp.ID = clonePtr(v.ID)
 	return &cp
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -337,7 +337,7 @@ type MediaGalleryActions struct {
 
 type CollectionConfig struct {
 	Module       string             `json:"module,omitempty"`
-	Target       *CollectionTarget  `json:"target,omitempty"`
+	Relation     string             `json:"relation,omitempty"`
 	Item         *CollectionItem    `json:"item,omitempty"`
 	Size         int                `json:"size,omitempty"`
 	LoadingLabel string             `json:"loading_label,omitempty"`
@@ -345,11 +345,6 @@ type CollectionConfig struct {
 	EditFields   []string           `json:"edit_fields,omitempty"`
 	Modal        *CollectionModal   `json:"modal,omitempty"`
 	Actions      []Action           `json:"actions,omitempty"`
-}
-
-type CollectionTarget struct {
-	Module string      `json:"module,omitempty"`
-	ID     *TypedValue `json:"id,omitempty"`
 }
 
 type CollectionItem struct {

--- a/tests/integration/relation_scope_actions_test.go
+++ b/tests/integration/relation_scope_actions_test.go
@@ -1,0 +1,246 @@
+package integration
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"testing"
+
+	module "github.com/darkrain/request-generator"
+	"github.com/darkrain/request-generator/actions"
+	dbpkg "github.com/darkrain/request-generator/db"
+	"github.com/darkrain/request-generator/fields"
+	"github.com/darkrain/request-generator/icontext"
+	"github.com/gin-gonic/gin"
+	pg "github.com/go-jet/jet/v2/postgres"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type scopedActionDB struct {
+	table      pg.Table
+	lastInput  map[string]interface{}
+	whereArgs  []interface{}
+	listCalled bool
+}
+
+type scopeFieldConverters struct {
+	source func(*gin.Context, interface{}) (interface{}, error)
+	target func(*gin.Context, interface{}) (interface{}, error)
+}
+
+func (db *scopedActionDB) List(
+	_ *log.Entry,
+	table pg.Table,
+	_ pg.Column,
+	_ []fields.ModuleField,
+	_ []fields.ModuleField,
+	_ int64,
+	_ int64,
+	_ []pg.Column,
+	_ string,
+	_ map[string]string,
+	where pg.BoolExpression,
+	_ []actions.ModuleActionJoin,
+	_ *actions.SortOption,
+	_ *dbpkg.TranslationContext,
+) ([]interface{}, int64, error) {
+	db.listCalled = true
+	db.captureWhere(table, where)
+	return []interface{}{}, 0, nil
+}
+
+func (db *scopedActionDB) View(_ *log.Entry, table pg.Table, _ pg.Column, _ []fields.ModuleField, where pg.BoolExpression, _ []actions.ModuleActionJoin, _ *dbpkg.TranslationContext) (interface{}, error) {
+	db.captureWhere(table, where)
+	return map[string]interface{}{"id": 88, "owner_id": 123, "title": "changed"}, nil
+}
+
+func (db *scopedActionDB) Add(_ *log.Entry, _ pg.Table, _ pg.Column, _ []fields.ModuleField, input map[string]interface{}, _ *dbpkg.TranslationContext) (interface{}, error) {
+	db.lastInput = input
+	return input, nil
+}
+
+func (db *scopedActionDB) Update(_ *log.Entry, table pg.Table, _ pg.Column, _ []fields.ModuleField, input map[string]interface{}, where pg.BoolExpression, _ *dbpkg.TranslationContext) (interface{}, error) {
+	db.lastInput = input
+	db.captureWhere(table, where)
+	return nil, nil
+}
+
+func (db *scopedActionDB) Delete(_ *log.Entry, table pg.Table, where pg.BoolExpression, _ *dbpkg.TranslationContext) error {
+	db.captureWhere(table, where)
+	return nil
+}
+
+func (db *scopedActionDB) RawRequest(_ *log.Entry, _ string, _ ...interface{}) (*sql.Rows, error) {
+	return nil, nil
+}
+
+func (db *scopedActionDB) RawDB() *sql.DB {
+	return nil
+}
+
+func (db *scopedActionDB) captureWhere(table pg.Table, where pg.BoolExpression) {
+	if where == nil {
+		db.whereArgs = nil
+		return
+	}
+	_, args := pg.SELECT(pg.Raw("1")).FROM(table).WHERE(where).Sql()
+	db.whereArgs = args
+}
+
+func setupRelationScopeActionsRouter(t *testing.T, scopeCheck func(*gin.Context, module.RelationScope) error, converters ...scopeFieldConverters) (*gin.Engine, *scopedActionDB) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	var converter scopeFieldConverters
+	if len(converters) > 0 {
+		converter = converters[0]
+	}
+
+	id := pg.IntegerColumn("id")
+	ownerID := pg.IntegerColumn("owner_id")
+	title := pg.StringColumn("title")
+	ownerTable := pg.NewTable("public", "owners", "", id)
+	itemsTable := pg.NewTable("public", "scoped_items", "", id, ownerID, title)
+	db := &scopedActionDB{table: itemsTable}
+
+	itemsModule := &module.BaseModule{
+		Name:       "scoped-items",
+		Path:       "/admin",
+		Table:      itemsTable,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
+			{Column: ownerID, Title: "Owner", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber, Convert: converter.source},
+			{Column: title, Title: "Title", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeText},
+		},
+		Relations: []module.ModuleRelation{{
+			Name:         "owner",
+			TargetModule: "owners",
+			SourceField:  ownerID,
+			TargetField:  id,
+			ScopeCheck:   scopeCheck,
+		}},
+		Actions: []actions.ModuleAction{
+			actions.ListModuleAction{Columns: []pg.Column{id, ownerID, title}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
+			actions.AddModuleAction{Columns: []pg.Column{title}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
+			actions.UpdateModuleAction{Columns: []pg.Column{title}, By: []pg.Column{id}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
+			actions.DeleteModuleAction{By: []pg.Column{id}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
+		},
+	}
+	ownersModule := &module.BaseModule{
+		Name:       "owners",
+		Path:       "/admin",
+		Table:      ownerTable,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber, Convert: converter.target},
+		},
+	}
+
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(
+		func(_ *module.BaseModule) dbpkg.DBExecutor { return db },
+		*group,
+		[]*module.BaseModule{itemsModule, ownersModule},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+	)
+	generator.Run()
+	return engine, db
+}
+
+func TestRelationScopeActions_ListAddUpdateDelete(t *testing.T) {
+	var checkedScopes []module.RelationScope
+	engine, db := setupRelationScopeActionsRouter(t, func(_ *gin.Context, scope module.RelationScope) error {
+		checkedScopes = append(checkedScopes, scope)
+		return nil
+	})
+
+	w := executeRequest(engine, http.MethodGet, "/admin/scoped-items?scope[relation]=owner&scope[id]=123", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, db.listCalled)
+	assert.Contains(t, db.whereArgs, int64(123))
+
+	w = executeJSONRequest(engine, http.MethodPut, "/admin/scoped-items?scope[relation]=owner&scope[id]=123", map[string]interface{}{"title": "new"})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "new", db.lastInput["title"])
+	assert.Equal(t, int64(123), db.lastInput["owner_id"])
+
+	w = executeJSONRequest(engine, http.MethodPost, "/admin/scoped-items/id/88?scope[relation]=owner&scope[id]=123", map[string]interface{}{"title": "changed"})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "changed", db.lastInput["title"])
+	assert.NotContains(t, db.lastInput, "owner_id")
+	assert.Contains(t, db.whereArgs, "88")
+	assert.Contains(t, db.whereArgs, int64(123))
+
+	w = executeRequest(engine, http.MethodDelete, "/admin/scoped-items/delete/id/88?scope[relation]=owner&scope[id]=123", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, db.whereArgs, "88")
+	assert.Contains(t, db.whereArgs, int64(123))
+
+	require.Len(t, checkedScopes, 4)
+	for _, scope := range checkedScopes {
+		assert.Equal(t, module.RelationScope{Relation: "owner", ID: int64(123)}, scope)
+	}
+}
+
+func TestRelationScopeActions_RejectSourceFieldAndDeniedScope(t *testing.T) {
+	engine, _ := setupRelationScopeActionsRouter(t, func(_ *gin.Context, _ module.RelationScope) error {
+		return nil
+	})
+
+	w := executeJSONRequest(engine, http.MethodPut, "/admin/scoped-items?scope[relation]=owner&scope[id]=123", map[string]interface{}{"title": "new", "owner_id": 999})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	deniedEngine, _ := setupRelationScopeActionsRouter(t, func(_ *gin.Context, _ module.RelationScope) error {
+		return errors.New("scope access denied")
+	})
+	w = executeRequest(deniedEngine, http.MethodGet, "/admin/scoped-items?scope[relation]=owner&scope[id]=123", nil)
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestRelationScopeActions_UnscopedBehaviorUnchanged(t *testing.T) {
+	engine, db := setupRelationScopeActionsRouter(t, func(_ *gin.Context, _ module.RelationScope) error {
+		return errors.New("should not be called")
+	})
+
+	w := executeRequest(engine, http.MethodGet, "/admin/scoped-items", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Nil(t, db.whereArgs)
+
+	w = executeJSONRequest(engine, http.MethodPut, "/admin/scoped-items", map[string]interface{}{"title": "new"})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "new", db.lastInput["title"])
+	assert.NotContains(t, db.lastInput, "owner_id")
+}
+
+func TestRelationScopeActions_AddDoesNotReconvertCanonicalScopeID(t *testing.T) {
+	type canonicalID struct{ value string }
+
+	engine, db := setupRelationScopeActionsRouter(t, func(_ *gin.Context, scope module.RelationScope) error {
+		assert.Equal(t, canonicalID{value: "owner-123"}, scope.ID)
+		return nil
+	}, scopeFieldConverters{
+		source: func(_ *gin.Context, value interface{}) (interface{}, error) {
+			if _, ok := value.(string); !ok {
+				return nil, errors.New("source converter accepts only transport strings")
+			}
+			return value, nil
+		},
+		target: func(_ *gin.Context, value interface{}) (interface{}, error) {
+			raw, ok := value.(string)
+			if !ok {
+				return nil, errors.New("target converter accepts only transport strings")
+			}
+			return canonicalID{value: raw}, nil
+		},
+	})
+
+	w := executeJSONRequest(engine, http.MethodPut, "/admin/scoped-items?scope[relation]=owner&scope[id]=owner-123", map[string]interface{}{"title": "new"})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, canonicalID{value: "owner-123"}, db.lastInput["owner_id"])
+}

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -375,12 +375,9 @@ func TestUniversalRendererMetadata_FormSectionCollectionContract(t *testing.T) {
 						ID:       "simple_collection",
 						Renderer: renderer.RendererCollectionManager,
 						Collection: &renderer.CollectionConfig{
-							Module: "tags",
-							Target: &renderer.CollectionTarget{
-								Module: "profiles",
-								ID:     &renderer.TypedValue{Type: renderer.TypedValueNumber, Number: 123},
-							},
-							Item: &renderer.CollectionItem{LabelField: "title"},
+							Module:   "tags",
+							Relation: "owner",
+							Item:     &renderer.CollectionItem{LabelField: "title"},
 							Buckets: []renderer.CollectionBucket{
 								{ID: "all", Title: "All", BlockID: "collection.default"},
 							},
@@ -442,25 +439,30 @@ func TestUniversalRendererMetadata_FormSectionCollectionContract(t *testing.T) {
 
 	engine := gin.New()
 	group := engine.Group("")
-	profilesModule := &module.BaseModule{Name: "profiles", Path: "/admin", Table: profilesTable, PrimaryKey: id}
+	_ = profilesTable
 	tagsModule := &module.BaseModule{
 		Name:       "tags",
 		Path:       "/admin",
 		Table:      tagsTable,
 		PrimaryKey: id,
-		Relations:  []module.ModuleRelation{{Name: "target", TargetModule: "profiles", SourceField: profileID, TargetField: id}},
+		Relations: []module.ModuleRelation{{
+			Name:         "owner",
+			TargetModule: "collection-renderer-items",
+			SourceField:  profileID,
+			TargetField:  id,
+			ScopeCheck:   func(_ *gin.Context, _ module.RelationScope) error { return nil },
+		}},
 	}
 	servicesModule := &module.BaseModule{
 		Name:       "services",
 		Path:       "/admin",
 		Table:      servicesTable,
 		PrimaryKey: id,
-		Relations:  []module.ModuleRelation{{Name: "target", TargetModule: "profiles", SourceField: profileID, TargetField: id}},
 	}
 	generator := module.NewGenerator(
 		func(_ *module.BaseModule) dbpkg.DBExecutor { return fakeRendererDB{} },
 		*group,
-		[]*module.BaseModule{testModule, profilesModule, tagsModule, servicesModule},
+		[]*module.BaseModule{testModule, tagsModule, servicesModule},
 		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
 			return func(c *gin.Context) { c.Next() }
 		},
@@ -482,11 +484,7 @@ func TestUniversalRendererMetadata_FormSectionCollectionContract(t *testing.T) {
 	require.NotNil(t, simple)
 	assert.Equal(t, "tags", simple.Module)
 	assert.Empty(t, simple.EditFields)
-	require.NotNil(t, simple.Target)
-	assert.Equal(t, "profiles", simple.Target.Module)
-	require.NotNil(t, simple.Target.ID)
-	assert.Equal(t, renderer.TypedValueNumber, simple.Target.ID.Type)
-	assert.Equal(t, float64(123), simple.Target.ID.Number)
+	assert.Equal(t, "owner", simple.Relation)
 	assert.Equal(t, "title", simple.Item.LabelField)
 	require.Len(t, simple.Buckets, 1)
 	assert.Equal(t, "collection.default", simple.Buckets[0].BlockID)
@@ -577,10 +575,9 @@ func TestUniversalRendererMetadata_CollectionRelationValidation(t *testing.T) {
 	id := postgres.IntegerColumn("id")
 	profileID := postgres.IntegerColumn("profile_id")
 	pageTable := postgres.NewTable("public", "collection_page", "", id)
-	profilesTable := postgres.NewTable("public", "profiles", "", id)
 	itemsTable := postgres.NewTable("public", "items", "", id, profileID)
 
-	newGenerator := func(collectionModule *module.BaseModule, collectionName string) *module.Generator {
+	newGenerator := func(collectionModule *module.BaseModule, collectionName string, relation string) *module.Generator {
 		pageModule := &module.BaseModule{
 			Name:       "collection-page",
 			Path:       "/admin",
@@ -593,16 +590,15 @@ func TestUniversalRendererMetadata_CollectionRelationValidation(t *testing.T) {
 							ID:       "items",
 							Renderer: renderer.RendererCollectionManager,
 							Collection: &renderer.CollectionConfig{
-								Module: collectionName,
-								Target: &renderer.CollectionTarget{Module: "profiles"},
+								Module:   collectionName,
+								Relation: relation,
 							},
 						},
 					},
 				},
 			},
 		}
-		profilesModule := &module.BaseModule{Name: "profiles", Path: "/admin", Table: profilesTable, PrimaryKey: id}
-		modules := []*module.BaseModule{pageModule, profilesModule}
+		modules := []*module.BaseModule{pageModule}
 		if collectionModule != nil {
 			modules = append(modules, collectionModule)
 		}
@@ -621,13 +617,43 @@ func TestUniversalRendererMetadata_CollectionRelationValidation(t *testing.T) {
 
 	assert.PanicsWithValue(t,
 		`invalid collection config in module collection-page: collection section "items" references unknown module "items"`,
-		func() { newGenerator(nil, "items").Run() },
+		func() { newGenerator(nil, "items", "owner").Run() },
 	)
 
 	itemsWithoutRelation := &module.BaseModule{Name: "items", Path: "/admin", Table: itemsTable, PrimaryKey: id}
 	assert.PanicsWithValue(t,
-		`invalid collection config in module collection-page: collection module "items" must declare relation to target module "profiles"`,
-		func() { newGenerator(itemsWithoutRelation, "items").Run() },
+		`invalid collection config in module collection-page: collection module "items" must declare relation "owner"`,
+		func() { newGenerator(itemsWithoutRelation, "items", "owner").Run() },
+	)
+
+	itemsWithRelationToWrongTarget := &module.BaseModule{
+		Name:       "items",
+		Path:       "/admin",
+		Table:      itemsTable,
+		PrimaryKey: id,
+		Relations: []module.ModuleRelation{{
+			Name:         "owner",
+			TargetModule: "profiles",
+			SourceField:  profileID,
+			TargetField:  id,
+			ScopeCheck:   func(_ *gin.Context, _ module.RelationScope) error { return nil },
+		}},
+	}
+	assert.PanicsWithValue(t,
+		`invalid collection config in module collection-page: collection module "items" relation "owner" must target module "collection-page"`,
+		func() { newGenerator(itemsWithRelationToWrongTarget, "items", "owner").Run() },
+	)
+
+	itemsWithoutScopeCheck := &module.BaseModule{
+		Name:       "items",
+		Path:       "/admin",
+		Table:      itemsTable,
+		PrimaryKey: id,
+		Relations:  []module.ModuleRelation{{Name: "owner", TargetModule: "collection-page", SourceField: profileID, TargetField: id}},
+	}
+	assert.PanicsWithValue(t,
+		`invalid collection config in module collection-page: collection module "items" relation "owner" must declare ScopeCheck`,
+		func() { newGenerator(itemsWithoutScopeCheck, "items", "owner").Run() },
 	)
 
 	itemsWithRelation := &module.BaseModule{
@@ -635,9 +661,18 @@ func TestUniversalRendererMetadata_CollectionRelationValidation(t *testing.T) {
 		Path:       "/admin",
 		Table:      itemsTable,
 		PrimaryKey: id,
-		Relations:  []module.ModuleRelation{{Name: "target", TargetModule: "profiles", SourceField: profileID, TargetField: id}},
+		Relations: []module.ModuleRelation{{
+			Name:         "owner",
+			TargetModule: "collection-page",
+			SourceField:  profileID,
+			TargetField:  id,
+			ScopeCheck:   func(_ *gin.Context, _ module.RelationScope) error { return nil },
+		}},
 	}
-	assert.NotPanics(t, func() { newGenerator(itemsWithRelation, "items").Run() })
+	assert.NotPanics(t, func() { newGenerator(itemsWithRelation, "items", "owner").Run() })
+
+	unscopedItems := &module.BaseModule{Name: "items", Path: "/admin", Table: itemsTable, PrimaryKey: id}
+	assert.NotPanics(t, func() { newGenerator(unscopedItems, "items", "").Run() })
 }
 
 func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {

--- a/tests/relation_scope_db_test.go
+++ b/tests/relation_scope_db_test.go
@@ -1,0 +1,120 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	module "github.com/darkrain/request-generator"
+	"github.com/darkrain/request-generator/actions"
+	"github.com/darkrain/request-generator/db"
+	"github.com/darkrain/request-generator/fields"
+	"github.com/darkrain/request-generator/icontext"
+	"github.com/gin-gonic/gin"
+	"github.com/go-jet/jet/v2/postgres"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelationScopeList_CanonicalizesIntegerIDAndQualifiesSourceColumn(t *testing.T) {
+	cleanTable(t)
+	_, err := sqlDB.Exec(`INSERT INTO test_items (name, email, age, role) VALUES
+		('One', 'one@example.test', 30, 'user'),
+		('Two', 'two@example.test', 40, 'user')`)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`INSERT INTO test_tags (item_id, tag) VALUES (1, 'alpha'), (2, 'beta')`)
+	require.NoError(t, err)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	group := engine.Group("")
+
+	id := postgres.IntegerColumn("id")
+	ownersTable := postgres.NewTable("public", "owners", "", id)
+	tagID := postgres.IntegerColumn("id")
+	tagItemID := postgres.IntegerColumn("item_id")
+	tagCol := postgres.StringColumn("tag")
+	tagsTable := postgres.NewTable("public", "test_tags", "tags", tagID, tagItemID, tagCol)
+
+	var checkedScope module.RelationScope
+	itemsModule := &module.BaseModule{
+		Name:       "items",
+		Path:       "/api",
+		Table:      tbl,
+		PrimaryKey: tbl.ID,
+		Fields: []fields.ModuleField{
+			{Column: tbl.ID, Title: "ID", Type: fields.ModuleFieldTypeInt},
+			{Column: tbl.Name, Title: "Name", Type: fields.ModuleFieldTypeString},
+			{Column: tbl.Email, Title: "Email", Type: fields.ModuleFieldTypeString},
+			{Column: tbl.Age, Title: "Age", Type: fields.ModuleFieldTypeInt},
+			{Column: tbl.Role, Title: "Role", Type: fields.ModuleFieldTypeString},
+		},
+		Relations: []module.ModuleRelation{{
+			Name:         "owner",
+			TargetModule: "owners",
+			SourceField:  tbl.ID,
+			TargetField:  id,
+			ScopeCheck: func(_ *gin.Context, scope module.RelationScope) error {
+				checkedScope = scope
+				return nil
+			},
+		}},
+		Actions: []actions.ModuleAction{
+			actions.ListModuleAction{
+				Columns:    []postgres.Column{tbl.ID, tbl.Name, tbl.Email, tbl.Age, tbl.Role},
+				Join:       []actions.ModuleActionJoin{actions.NewJoin(tagsTable, actions.JoinTypeLeft, postgres.RawBool(`test_items."id" = tags."item_id"`, nil), []postgres.Column{tagCol}, "tags")},
+				Permission: []actions.Role{actions.RoleAll},
+				Auth:       true,
+			},
+		},
+	}
+	ownersModule := &module.BaseModule{
+		Name:       "owners",
+		Path:       "/api",
+		Table:      ownersTable,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt},
+		},
+	}
+
+	generator := module.NewGenerator(
+		func(_ *module.BaseModule) db.DBExecutor { return testDB },
+		*group,
+		[]*module.BaseModule{itemsModule, ownersModule},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		func(_ actions.ModuleAction) gin.HandlerFunc {
+			return func(c *gin.Context) {
+				ctx := icontext.SetUser(c.Request.Context(), &icontext.UserInfo{ID: 1, Role: "admin"})
+				c.Request = c.Request.WithContext(ctx)
+				c.Next()
+			}
+		},
+	)
+	generator.Run()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/items?scope[relation]=owner&scope[id]=1", nil)
+	engine.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, module.RelationScope{Relation: "owner", ID: int64(1)}, checkedScope)
+
+	var response struct {
+		Count int64                    `json:"count"`
+		Rows  []map[string]interface{} `json:"rows"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, int64(1), response.Count)
+	require.Len(t, response.Rows, 1)
+	assert.Equal(t, float64(1), response.Rows[0]["id"])
+
+	checkedScope = module.RelationScope{}
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/items?scope[relation]=owner&scope[id]=bad", nil)
+	engine.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, module.RelationScope{}, checkedScope)
+}


### PR DESCRIPTION
## Что сделано

- Заменил `collection.target` на optional `collection.relation` в Universal Renderer metadata.
- Добавил `RelationScope` и `ModuleRelation.ScopeCheck` для проверки actor -> scope record.
- Добавил обработку `scope[relation]` и `scope[id]` в стандартные `list/add/update/delete`.
- Для scoped `list` добавляется relation filter, для scoped `add` source FK подставляется сервером, для scoped `update/delete` relation constraint добавляется в WHERE.
- Body с relation source field в scoped add/update отклоняется.
- Обновил README и Universal Renderer contract.

## Проверки

- `go test ./...`

Closes darkrain/request-generator#40