### PR TITLE
Preserve zero values in typed renderer metadata

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -1,6 +1,9 @@
 package renderer
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type Universal struct {
 	List         *ListPage         `json:"list_page,omitempty"`
@@ -412,6 +415,28 @@ type TypedValue struct {
 	String string         `json:"string,omitempty"`
 	Number float64        `json:"number,omitempty"`
 	Bool   *bool          `json:"bool,omitempty"`
+}
+
+// MarshalJSON keeps a typed zero value on the wire. A plain omitempty tag on
+// Number makes number: 0 indistinguishable from an omitted value to clients.
+func (v TypedValue) MarshalJSON() ([]byte, error) {
+	type typedValueJSON struct {
+		Type   TypedValueType `json:"type"`
+		String *string        `json:"string,omitempty"`
+		Number *float64       `json:"number,omitempty"`
+		Bool   *bool          `json:"bool,omitempty"`
+	}
+
+	payload := typedValueJSON{Type: v.Type}
+	switch v.Type {
+	case TypedValueString:
+		payload.String = &v.String
+	case TypedValueNumber:
+		payload.Number = &v.Number
+	case TypedValueBool:
+		payload.Bool = v.Bool
+	}
+	return json.Marshal(payload)
 }
 
 type CollectionModal struct {

--- a/renderer/typed_value_test.go
+++ b/renderer/typed_value_test.go
@@ -1,0 +1,21 @@
+package renderer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypedValueMarshalJSONPreservesTypedZero(t *testing.T) {
+	payload, err := json.Marshal(TypedValue{Type: TypedValueNumber, Number: 0})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"type":"number","number":0}`, string(payload))
+}
+
+func TestTypedValueMarshalJSONPreservesFalse(t *testing.T) {
+	value := false
+	payload, err := json.Marshal(TypedValue{Type: TypedValueBool, Bool: &value})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"type":"bool","bool":false}`, string(payload))
+}


### PR DESCRIPTION
## Проблема
`TypedValue{Type: number, Number: 0}` сериализовался как `{ "type": "number" }` из-за `omitempty`. Клиент не мог отличить `0` от отсутствующего значения: в частности, коллекция услуг не могла отобрать включённые услуги по `price = 0`.

## Изменение
- добавлена типозависимая JSON-сериализация `TypedValue`;
- `number: 0`, `string: ""` и `bool: false` сохраняются, когда соответствуют `type`;
- добавлены unit-тесты для `0` и `false`.

## Проверка
`go test ./renderer`.