### PR TITLE
Add typed FieldMatrix renderer contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,32 @@ Frontend должен получать готовую схему и рендер
 
 В `defrec.fields[field]` и `view.item[field]` эти blocks приходят как `presentation` и `media`. Labels в media/action metadata переводятся request-generator по текущему языку. В `view` `media.item.src` может быть автоматически заполнен из `item[field].value`, если producer не указал `src`.
 
+### FieldMatrix list
+
+`field.matrix` раскладывает уже описанные typed поля формы. Для `list` не
+нужны rows или cells: producer задает только порядок полей и число колонок.
+Само поле сохраняет стандартные `type`, `form_type`, value, options и checks.
+
+```go
+renderer.FormSection{
+    ID:       "preferences",
+    Renderer: renderer.RendererFieldMatrix,
+    Matrix: &renderer.FieldMatrix{
+        Type:      renderer.FieldMatrixTypeList,
+        Underline: "settings",
+        List: &renderer.FieldMatrixList{
+            Fields:  []string{"email_enabled", "push_enabled", "quiet_hours"},
+            Columns: renderer.FieldMatrixColumnsTwo,
+        },
+    },
+}
+```
+
+`Columns` - closed typed enum от `FieldMatrixColumnsOne` до
+`FieldMatrixColumnsFour`. Для table используется отдельная typed структура с
+heads, rows и cells; полный contract и правила локализации приведены в
+[docs/universal-renderer-contract.md](docs/universal-renderer-contract.md).
+
 ### Extra.Defrec
 
 `Extra.Defrec` является legacy-механизмом. Его можно использовать только для существующих модулей или временной совместимости, пока нужный UI contract еще не типизирован.

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -204,6 +204,74 @@ Closed enums должны использовать typed constants из package 
 | `renderer` | Renderer identity/version, добавляется request-generator. |
 | `form_page` | Typed metadata универсальной form/edit страницы из `BaseModule.Render.Form`. |
 
+### Field Matrix
+
+`field.matrix` задает раскладку уже описанных typed полей формы. Matrix не
+дублирует значение, `type`, `form_type`, options, checks или presentation:
+renderer получает их из стандартных `fields` либо `item` response.
+
+```go
+renderer.FormSection{
+    ID:       "rates",
+    Renderer: renderer.RendererFieldMatrix,
+    Matrix: &renderer.FieldMatrix{
+        Type:      renderer.FieldMatrixTypeTable,
+        Underline: "rates",
+        Table: &renderer.FieldMatrixTable{
+            Heads: []string{
+                "settings.rates.duration",
+                "settings.rates.incall",
+                "settings.rates.outcall",
+            },
+            Rows: []renderer.FieldMatrixRow{
+                {
+                    Label: "settings.rates.1h",
+                    Cells: []renderer.FieldMatrixCell{
+                        {Field: "incall_1h_price"},
+                        {Field: "outcall_1h_price"},
+                    },
+                },
+            },
+        },
+    },
+}
+```
+
+`table` содержит `heads` и `rows`. У каждой ячейки должен быть ровно один
+источник: `field` (ссылка на поле модуля) или `text` (статический текст).
+Непустой `row.label` занимает первую ячейку строки, поэтому в этом случае
+количество `cells` на единицу меньше числа заголовков. Без `row.label` оно
+должно совпадать с числом заголовков.
+
+`list` содержит только упорядоченные `fields` и typed `columns` от одного до
+четырех. Каждый field выводится как самостоятельный item без описания строк,
+ячеек или колонок в producer metadata.
+
+```go
+renderer.FormSection{
+    ID:       "preferences",
+    Renderer: renderer.RendererFieldMatrix,
+    Matrix: &renderer.FieldMatrix{
+        Type:      renderer.FieldMatrixTypeList,
+        Underline: "settings",
+        List: &renderer.FieldMatrixList{
+            Fields:  []string{"email_enabled", "push_enabled", "quiet_hours"},
+            Columns: renderer.FieldMatrixColumnsTwo,
+        },
+    },
+}
+```
+
+`heads[]`, `rows[].label` и `cells[].text` producer задает translation
+keys. Перед ответом request-generator локализует их для выбранного `lang`; UI
+kit не получает ключи и не выполняет перевод. `underline` является opaque
+application-defined visual identifier: generator не знает его палитру и не
+валидирует как CSS value.
+
+Generator проверяет closed `type`, применимость `list`/`table`, допустимое
+число колонок list, структуру table и существование каждого referenced field
+в модуле.
+
 ### View/Record Response
 
 ```json

--- a/field_matrix_validation_test.go
+++ b/field_matrix_validation_test.go
@@ -1,0 +1,97 @@
+package module
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/darkrain/request-generator/fields"
+	"github.com/darkrain/request-generator/locale"
+	"github.com/darkrain/request-generator/renderer"
+	"github.com/gin-gonic/gin"
+	"github.com/go-jet/jet/v2/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderForRejectsUnknownFieldMatrixReference(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	id := postgres.IntegerColumn("id")
+	table := postgres.NewTable("public", "matrix_items", "", id)
+	base := &BaseModule{
+		Name:       "matrix-items",
+		Table:      table,
+		PrimaryKey: id,
+		Fields:     []fields.ModuleField{{Column: id, Type: fields.ModuleFieldTypeInt}},
+		Render: renderer.Universal{Form: &renderer.FormPage{Sections: []renderer.FormSection{{
+			ID:       "rates",
+			Renderer: renderer.RendererFieldMatrix,
+			Matrix: &renderer.FieldMatrix{
+				Type: renderer.FieldMatrixTypeList,
+				List: &renderer.FieldMatrixList{Fields: []string{"missing"}, Columns: renderer.FieldMatrixColumnsOne},
+			},
+		}}}},
+		RenderFunc: func(_ *gin.Context, render renderer.Universal) (renderer.Universal, error) { return render, nil },
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/", nil)
+	_, err := base.RenderFor(c)
+	require.EqualError(t, err, `renderer.Universal: matrix section "rates" references unknown field "missing"`)
+}
+
+func TestRunRejectsUnknownStaticFieldMatrixReference(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	id := postgres.IntegerColumn("id")
+	table := postgres.NewTable("public", "matrix_items", "", id)
+	base := &BaseModule{
+		Name:       "matrix-items",
+		Table:      table,
+		PrimaryKey: id,
+		Fields:     []fields.ModuleField{{Column: id, Type: fields.ModuleFieldTypeInt}},
+		Render: renderer.Universal{Form: &renderer.FormPage{Sections: []renderer.FormSection{{
+			ID:       "rates",
+			Renderer: renderer.RendererFieldMatrix,
+			Matrix: &renderer.FieldMatrix{
+				Type: renderer.FieldMatrixTypeList,
+				List: &renderer.FieldMatrixList{Fields: []string{"missing"}, Columns: renderer.FieldMatrixColumnsOne},
+			},
+		}}}},
+	}
+	engine := gin.New()
+	group := engine.Group("")
+	generator := NewGenerator(nil, *group, []*BaseModule{base}, nil, nil)
+
+	require.PanicsWithValue(t,
+		`invalid field matrix config in module matrix-items: renderer.Universal: matrix section "rates" references unknown field "missing"`,
+		func() { generator.Run() },
+	)
+}
+
+func TestLocalizeRendererFieldMatrix(t *testing.T) {
+	generator := &Generator{translations: map[locale.Lang]map[string]string{
+		locale.EN: {
+			"matrix.duration": "Duration",
+			"matrix.incall":   "In-call",
+			"matrix.1h":       "1 hour",
+			"matrix.none":     "Not available",
+		},
+	}}
+	render := generator.localizeRenderer(locale.EN, renderer.Universal{Form: &renderer.FormPage{Sections: []renderer.FormSection{{
+		ID:       "rates",
+		Renderer: renderer.RendererFieldMatrix,
+		Matrix: &renderer.FieldMatrix{
+			Type: renderer.FieldMatrixTypeTable,
+			Table: &renderer.FieldMatrixTable{
+				Heads: []string{"matrix.duration", "matrix.incall", "matrix.outcall"},
+				Rows:  []renderer.FieldMatrixRow{{Label: "matrix.1h", Cells: []renderer.FieldMatrixCell{{Text: "matrix.none"}, {Field: "incall_1h_price"}}}},
+			},
+		},
+	}}}})
+
+	matrix := render.Form.Sections[0].Matrix.Table
+	require.Equal(t, "Duration", matrix.Heads[0])
+	require.Equal(t, "In-call", matrix.Heads[1])
+	require.Equal(t, "1 hour", matrix.Rows[0].Label)
+	require.Equal(t, "Not available", matrix.Rows[0].Cells[0].Text)
+	require.Equal(t, "incall_1h_price", matrix.Rows[0].Cells[1].Field)
+}

--- a/generator.go
+++ b/generator.go
@@ -156,6 +156,32 @@ func (generator *Generator) localizeRendererAction(lang locale.Lang, action *ren
 	action.Label = generator.Translate(lang, action.Label)
 }
 
+func (generator *Generator) localizeRenderer(lang locale.Lang, render renderer.Universal) renderer.Universal {
+	if render.Form == nil {
+		return render
+	}
+	for sectionIndex := range render.Form.Sections {
+		matrix := render.Form.Sections[sectionIndex].Matrix
+		if matrix == nil {
+			continue
+		}
+		if matrix.Table == nil {
+			continue
+		}
+		for headIndex := range matrix.Table.Heads {
+			matrix.Table.Heads[headIndex] = generator.Translate(lang, matrix.Table.Heads[headIndex])
+		}
+		for rowIndex := range matrix.Table.Rows {
+			row := &matrix.Table.Rows[rowIndex]
+			row.Label = generator.Translate(lang, row.Label)
+			for cellIndex := range row.Cells {
+				row.Cells[cellIndex].Text = generator.Translate(lang, row.Cells[cellIndex].Text)
+			}
+		}
+	}
+	return render
+}
+
 func (generator *Generator) Run() {
 
 	featuresGroup := generator.group.Group("/api")
@@ -168,6 +194,9 @@ func (generator *Generator) Run() {
 				panic(fmt.Sprintf("invalid base renderer config in module %s: %v", module.Name, err))
 			}
 			panic(fmt.Sprintf("invalid renderer config in module %s: %v", module.Name, err))
+		}
+		if err := module.validateFieldMatrices(module.Render); err != nil {
+			panic(fmt.Sprintf("invalid field matrix config in module %s: %v", module.Name, err))
 		}
 		if err := generator.validateCollectionRelations(module); err != nil {
 			panic(fmt.Sprintf("invalid collection config in module %s: %v", module.Name, err))
@@ -629,6 +658,7 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		render = generator.localizeRenderer(lang, render)
 
 		if len(heads) == 0 {
 			heads = make(map[string]interface{})
@@ -945,6 +975,7 @@ func (generator *Generator) actionDefrec(module *BaseModule) func(c *gin.Context
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		render = generator.localizeRenderer(lang, render)
 		defrecResponse := response.NewDefrecResponse(extra, output)
 		defrecResponse.AttachRender(render)
 		response.Response(l, c, defrecResponse)
@@ -1121,6 +1152,7 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		render = generator.localizeRenderer(lang, render)
 
 		output := struct {
 			Renderer   *renderer.Identity     `json:"renderer,omitempty"`

--- a/module.go
+++ b/module.go
@@ -1,6 +1,8 @@
 package module
 
 import (
+	"fmt"
+
 	"github.com/darkrain/request-generator/actions"
 	"github.com/darkrain/request-generator/fields"
 	"github.com/darkrain/request-generator/renderer"
@@ -68,17 +70,52 @@ type BaseModule struct {
 
 func (module *BaseModule) RenderFor(c *gin.Context) (renderer.Universal, error) {
 	render := module.Render.Clone()
-	if module.RenderFunc != nil {
-		var err error
-		render, err = module.RenderFunc(c, render)
-		if err != nil {
-			return renderer.Universal{}, err
-		}
+	if module.RenderFunc == nil {
+		return render, nil
+	}
+	var err error
+	render, err = module.RenderFunc(c, render)
+	if err != nil {
+		return renderer.Universal{}, err
 	}
 	if err := render.Validate(); err != nil {
 		return renderer.Universal{}, err
 	}
+	if err := module.validateFieldMatrices(render); err != nil {
+		return renderer.Universal{}, err
+	}
 	return render, nil
+}
+
+func (module *BaseModule) validateFieldMatrices(render renderer.Universal) error {
+	if render.Form == nil {
+		return nil
+	}
+	for _, section := range render.Form.Sections {
+		matrix := section.Matrix
+		if matrix == nil {
+			continue
+		}
+		fieldIDs := make([]string, 0)
+		switch matrix.Type {
+		case renderer.FieldMatrixTypeList:
+			fieldIDs = append(fieldIDs, matrix.List.Fields...)
+		case renderer.FieldMatrixTypeTable:
+			for _, row := range matrix.Table.Rows {
+				for _, cell := range row.Cells {
+					if cell.Field != "" {
+						fieldIDs = append(fieldIDs, cell.Field)
+					}
+				}
+			}
+		}
+		for _, fieldID := range fieldIDs {
+			if module.GetField(fieldID) == nil {
+				return fmt.Errorf("renderer.Universal: matrix section %q references unknown field %q", section.ID, fieldID)
+			}
+		}
+	}
+	return nil
 }
 
 func (module BaseModule) GetEntityName() string {

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -274,6 +274,7 @@ func cloneFormSections(values []FormSection) []FormSection {
 		out[i] = v
 		out[i].Block = cloneBlock(v.Block)
 		out[i].Fields = cloneSlice(v.Fields)
+		out[i].Matrix = cloneFieldMatrix(v.Matrix)
 		out[i].ListPage = cloneListPage(v.ListPage)
 		out[i].Collection = cloneCollectionConfig(v.Collection)
 		out[i].MediaUpload = clonePtr(v.MediaUpload)
@@ -282,6 +283,23 @@ func cloneFormSections(values []FormSection) []FormSection {
 		out[i].MediaActions = cloneMediaGalleryActions(v.MediaActions)
 	}
 	return out
+}
+
+func cloneFieldMatrix(v *FieldMatrix) *FieldMatrix {
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	if v.List != nil {
+		cp.List = &FieldMatrixList{Fields: cloneSlice(v.List.Fields), Columns: v.List.Columns}
+	}
+	if v.Table != nil {
+		cp.Table = &FieldMatrixTable{Heads: cloneSlice(v.Table.Heads), Rows: make([]FieldMatrixRow, len(v.Table.Rows))}
+		for i, row := range v.Table.Rows {
+			cp.Table.Rows[i] = FieldMatrixRow{Label: row.Label, Cells: cloneSlice(row.Cells)}
+		}
+	}
+	return &cp
 }
 
 func CloneFieldPresentation(v *FieldPresentation) *FieldPresentation {

--- a/renderer/field_matrix_test.go
+++ b/renderer/field_matrix_test.go
@@ -1,0 +1,108 @@
+package renderer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldMatrixValidate(t *testing.T) {
+	tests := []struct {
+		name   string
+		matrix *FieldMatrix
+		valid  bool
+	}{
+		{
+			name: "table",
+			matrix: &FieldMatrix{
+				Type: FieldMatrixTypeTable,
+				Table: &FieldMatrixTable{
+					Heads: []string{"matrix.duration", "matrix.incall", "matrix.outcall"},
+					Rows:  []FieldMatrixRow{{Label: "matrix.1h", Cells: []FieldMatrixCell{{Field: "incall_1h_price"}, {Field: "outcall_1h_price"}}}},
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "list",
+			matrix: &FieldMatrix{
+				Type: FieldMatrixTypeList,
+				List: &FieldMatrixList{Fields: []string{"first", "second"}, Columns: FieldMatrixColumnsTwo},
+			},
+			valid: true,
+		},
+		{
+			name: "table cell must select one value source",
+			matrix: &FieldMatrix{
+				Type: FieldMatrixTypeTable,
+				Table: &FieldMatrixTable{
+					Heads: []string{"matrix.duration"},
+					Rows:  []FieldMatrixRow{{Cells: []FieldMatrixCell{{Field: "price", Text: "matrix.price"}}}},
+				},
+			},
+		},
+		{
+			name: "list columns are closed enum",
+			matrix: &FieldMatrix{
+				Type: FieldMatrixTypeList,
+				List: &FieldMatrixList{Fields: []string{"first"}, Columns: 5},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.matrix.Validate("rates")
+			assert.Equal(t, test.valid, err == nil, err)
+		})
+	}
+}
+
+func TestUniversalValidateFieldMatrixRendererBinding(t *testing.T) {
+	tests := []struct {
+		name    string
+		section FormSection
+		valid   bool
+	}{
+		{
+			name:    "matrix renderer without matrix",
+			section: FormSection{ID: "rates", Renderer: RendererFieldMatrix},
+		},
+		{
+			name: "matrix with another renderer",
+			section: FormSection{ID: "rates", Renderer: RendererUniversalSection, Matrix: &FieldMatrix{
+				Type: FieldMatrixTypeList,
+				List: &FieldMatrixList{Fields: []string{"price"}, Columns: FieldMatrixColumnsOne},
+			}},
+		},
+		{
+			name: "matrix renderer with matrix",
+			section: FormSection{ID: "rates", Renderer: RendererFieldMatrix, Matrix: &FieldMatrix{
+				Type: FieldMatrixTypeList,
+				List: &FieldMatrixList{Fields: []string{"price"}, Columns: FieldMatrixColumnsOne},
+			}},
+			valid: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (Universal{Form: &FormPage{Sections: []FormSection{test.section}}}).Validate()
+			assert.Equal(t, test.valid, err == nil, err)
+		})
+	}
+}
+
+func TestFieldMatrixClone(t *testing.T) {
+	original := Universal{Form: &FormPage{Sections: []FormSection{{
+		ID: "rates",
+		Matrix: &FieldMatrix{
+			Type:  FieldMatrixTypeTable,
+			Table: &FieldMatrixTable{Heads: []string{"matrix.duration"}, Rows: []FieldMatrixRow{{Cells: []FieldMatrixCell{{Field: "price"}}}}},
+		},
+	}}}}
+	form := original.Clone().Form
+
+	form.Sections[0].Matrix.Table.Heads[0] = "changed"
+	assert.Equal(t, "matrix.duration", original.Form.Sections[0].Matrix.Table.Heads[0])
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -75,6 +75,17 @@ func (r Universal) Validate() error {
 	}
 	if r.Form != nil {
 		for _, section := range r.Form.Sections {
+			if section.Renderer == RendererFieldMatrix && section.Matrix == nil {
+				return fmt.Errorf("renderer.Universal: field matrix section %q must define matrix", section.ID)
+			}
+			if section.Renderer != RendererFieldMatrix && section.Matrix != nil {
+				return fmt.Errorf("renderer.Universal: section %q matrix requires renderer %q", section.ID, RendererFieldMatrix)
+			}
+			if section.Matrix != nil {
+				if err := section.Matrix.Validate(section.ID); err != nil {
+					return err
+				}
+			}
 			if section.Collection == nil {
 				continue
 			}
@@ -288,12 +299,100 @@ type FormSection struct {
 	Mode         string               `json:"mode,omitempty"`
 	Block        *Block               `json:"block,omitempty"`
 	Fields       []string             `json:"fields,omitempty"`
+	Matrix       *FieldMatrix         `json:"matrix,omitempty"`
 	ListPage     *ListPage            `json:"list_page,omitempty"`
 	Collection   *CollectionConfig    `json:"collection,omitempty"`
 	MediaUpload  *MediaUploadConfig   `json:"media_upload,omitempty"`
 	MediaItems   []MediaGalleryItem   `json:"media_items,omitempty"`
 	MediaLabels  *MediaGalleryLabels  `json:"media_labels,omitempty"`
 	MediaActions *MediaGalleryActions `json:"media_actions,omitempty"`
+}
+
+type FieldMatrixType string
+
+const (
+	FieldMatrixTypeTable FieldMatrixType = "table"
+	FieldMatrixTypeList  FieldMatrixType = "list"
+)
+
+type FieldMatrixColumnCount uint8
+
+const (
+	FieldMatrixColumnsOne   FieldMatrixColumnCount = 1
+	FieldMatrixColumnsTwo   FieldMatrixColumnCount = 2
+	FieldMatrixColumnsThree FieldMatrixColumnCount = 3
+	FieldMatrixColumnsFour  FieldMatrixColumnCount = 4
+)
+
+type FieldMatrix struct {
+	Type      FieldMatrixType   `json:"type,omitempty"`
+	Underline string            `json:"underline,omitempty"`
+	List      *FieldMatrixList  `json:"list,omitempty"`
+	Table     *FieldMatrixTable `json:"table,omitempty"`
+}
+
+type FieldMatrixList struct {
+	Fields  []string               `json:"fields,omitempty"`
+	Columns FieldMatrixColumnCount `json:"columns,omitempty"`
+}
+
+type FieldMatrixTable struct {
+	Heads []string         `json:"heads,omitempty"`
+	Rows  []FieldMatrixRow `json:"rows,omitempty"`
+}
+
+type FieldMatrixRow struct {
+	Label string            `json:"label,omitempty"`
+	Cells []FieldMatrixCell `json:"cells,omitempty"`
+}
+
+type FieldMatrixCell struct {
+	Field string `json:"field,omitempty"`
+	Text  string `json:"text,omitempty"`
+}
+
+func (matrix *FieldMatrix) Validate(sectionID string) error {
+	if matrix == nil {
+		return nil
+	}
+	switch matrix.Type {
+	case FieldMatrixTypeTable:
+		if matrix.Table == nil || matrix.List != nil {
+			return fmt.Errorf("renderer.Universal: matrix section %q table type must define only table", sectionID)
+		}
+		if len(matrix.Table.Heads) == 0 || len(matrix.Table.Rows) == 0 {
+			return fmt.Errorf("renderer.Universal: matrix section %q table must define heads and rows", sectionID)
+		}
+		for rowIndex, row := range matrix.Table.Rows {
+			expectedCells := len(matrix.Table.Heads)
+			if row.Label != "" {
+				expectedCells--
+			}
+			if len(row.Cells) != expectedCells {
+				return fmt.Errorf("renderer.Universal: matrix section %q row %d cells must match heads", sectionID, rowIndex)
+			}
+			for cellIndex, cell := range row.Cells {
+				if (cell.Field == "") == (cell.Text == "") {
+					return fmt.Errorf("renderer.Universal: matrix section %q row %d cell %d must define exactly one of field or text", sectionID, rowIndex, cellIndex)
+				}
+			}
+		}
+	case FieldMatrixTypeList:
+		if matrix.List == nil || matrix.Table != nil {
+			return fmt.Errorf("renderer.Universal: matrix section %q list type must define only list", sectionID)
+		}
+		if len(matrix.List.Fields) == 0 {
+			return fmt.Errorf("renderer.Universal: matrix section %q list must define fields", sectionID)
+		}
+		switch matrix.List.Columns {
+		case FieldMatrixColumnsOne, FieldMatrixColumnsTwo, FieldMatrixColumnsThree, FieldMatrixColumnsFour:
+		default:
+			return fmt.Errorf("renderer.Universal: matrix section %q list has unsupported columns", sectionID)
+		}
+	default:
+		return fmt.Errorf("renderer.Universal: matrix section %q has unsupported matrix type %q", sectionID, matrix.Type)
+	}
+	return nil
 }
 
 type MediaUploadConfig struct {

--- a/renderer/tokens.go
+++ b/renderer/tokens.go
@@ -205,6 +205,7 @@ const (
 	RendererUniversalPagination RendererKey = "universal.pagination"
 	RendererMediaGallery        RendererKey = "media.gallery"
 	RendererCollectionManager   RendererKey = "collection.manager"
+	RendererFieldMatrix         RendererKey = "field.matrix"
 	RendererAvatar              RendererKey = "avatar"
 )
 

--- a/tests/integration/field_matrix_response_test.go
+++ b/tests/integration/field_matrix_response_test.go
@@ -1,0 +1,90 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	module "github.com/darkrain/request-generator"
+	"github.com/darkrain/request-generator/actions"
+	dbpkg "github.com/darkrain/request-generator/db"
+	"github.com/darkrain/request-generator/fields"
+	"github.com/darkrain/request-generator/icontext"
+	"github.com/darkrain/request-generator/locale"
+	"github.com/darkrain/request-generator/renderer"
+	"github.com/gin-gonic/gin"
+	pg "github.com/go-jet/jet/v2/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldMatrixViewResponseLocalizesPublicContract(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	id := pg.IntegerColumn("id")
+	price := pg.IntegerColumn("price")
+	table := pg.NewTable("public", "matrix_items", "", id, price)
+	testModule := &module.BaseModule{
+		Name:       "matrix-items",
+		Path:       "/admin",
+		Table:      table,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "matrix.id", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeOnlyView},
+			{Column: price, Title: "matrix.price", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
+		},
+		Render: renderer.Universal{Form: &renderer.FormPage{Sections: []renderer.FormSection{{
+			ID:       "rates",
+			Renderer: renderer.RendererFieldMatrix,
+			Matrix: &renderer.FieldMatrix{
+				Type: renderer.FieldMatrixTypeTable,
+				Table: &renderer.FieldMatrixTable{
+					Heads: []string{"matrix.duration", "matrix.price", "matrix.note"},
+					Rows: []renderer.FieldMatrixRow{{
+						Label: "matrix.1h",
+						Cells: []renderer.FieldMatrixCell{{Field: "price"}, {Text: "matrix.none"}},
+					}},
+				},
+			},
+		}}}},
+		Actions: []actions.ModuleAction{actions.ViewModuleAction{
+			Columns:    []pg.Column{id, price},
+			By:         []pg.Column{id},
+			Permission: []actions.Role{actions.RoleAll},
+			Auth:       true,
+			PageType:   renderer.PageTypeForm,
+		}},
+	}
+
+	translationsPath := filepath.Join(t.TempDir(), "en.json")
+	require.NoError(t, os.WriteFile(translationsPath, []byte(`{"matrix":{"id":"ID","price":"Price","duration":"Duration","note":"Note","1h":"1 hour","none":"Not available"}}`), 0o600))
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(
+		func(_ *module.BaseModule) dbpkg.DBExecutor { return fakeRendererDB{} },
+		*group,
+		[]*module.BaseModule{testModule},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+	)
+	generator.Locales = []locale.Lang{locale.EN}
+	require.NoError(t, generator.LoadTranslationsFile(locale.EN, translationsPath))
+	generator.Run()
+
+	w := executeRequest(engine, http.MethodGet, "/admin/matrix-items/view/id/1?lang=en", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var response struct {
+		FormPage *renderer.FormPage `json:"form_page"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NotNil(t, response.FormPage)
+	require.Len(t, response.FormPage.Sections, 1)
+	matrix := response.FormPage.Sections[0].Matrix
+	require.NotNil(t, matrix)
+	require.Equal(t, []string{"Duration", "Price", "Note"}, matrix.Table.Heads)
+	require.Equal(t, "1 hour", matrix.Table.Rows[0].Label)
+	require.Equal(t, "price", matrix.Table.Rows[0].Cells[0].Field)
+	require.Equal(t, "Not available", matrix.Table.Rows[0].Cells[1].Text)
+}


### PR DESCRIPTION
## Изменения

- добавляет renderer `field.matrix`;
- поддерживает `table` с typed heads, rows и cells, а также `list` с closed enum колонок;
- валидирует структуру матрицы и ссылки на поля модуля;
- локализует заголовки, labels строк и текстовые ячейки по request lang;
- добавляет deep clone и документацию UniversalRenderer.

## Проверка

`go test ./...`