### PR TITLE
Add block configuration to collection buckets

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -368,6 +368,7 @@ type CollectionBucket struct {
 	ModalSubtitle string                        `json:"modal_subtitle,omitempty"`
 	ConfirmLabel  string                        `json:"confirm_label,omitempty"`
 	BlockID       string                        `json:"block_id,omitempty"`
+	Block         *Block                        `json:"block,omitempty"`
 	Predicate     *CollectionPredicate          `json:"predicate,omitempty"`
 	Defaults      []CollectionFieldDefaultValue `json:"defaults,omitempty"`
 	EditFields    []string                      `json:"edit_fields,omitempty"`

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -410,6 +410,10 @@ func TestUniversalRendererMetadata_FormSectionCollectionContract(t *testing.T) {
 									ID:      "paid",
 									Title:   "Paid",
 									BlockID: "collection.paid",
+									Block: &renderer.Block{
+										Type:    renderer.BlockType("GlassesPanel"),
+										Variant: renderer.BlockVariant("compact-info"),
+									},
 									Predicate: &renderer.CollectionPredicate{
 										Field:    "price",
 										Operator: renderer.CollectionPredicateGreaterThan,
@@ -509,6 +513,10 @@ func TestUniversalRendererMetadata_FormSectionCollectionContract(t *testing.T) {
 	assert.Equal(t, "available", included.Defaults[1].Field)
 	require.NotNil(t, included.Defaults[1].Value.Bool)
 	assert.True(t, *included.Defaults[1].Value.Bool)
+	paid := editable.Buckets[1]
+	require.NotNil(t, paid.Block)
+	assert.Equal(t, renderer.BlockType("GlassesPanel"), paid.Block.Type)
+	assert.Equal(t, renderer.BlockVariant("compact-info"), paid.Block.Variant)
 }
 
 func TestUniversalRendererMetadata_CollectionValidation(t *testing.T) {


### PR DESCRIPTION
## Summary
- add typed `CollectionBucket.Block` using the existing universal `Block` contract
- verify block configuration survives the defrec response

## Verification
- `go test ./renderer ./tests/integration`