### PR TITLE
Add typed form action behavior

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -766,8 +766,9 @@ Actions используются в `card_schema.actions`, `record_page.actions`
 ```json
 {
   "id": "open",
-  "type": "route",
-  "label_key": "ui.open",
+  "type": "api",
+	"behavior": "submit",
+	"label": "Open",
   "icon": "open",
   "variant": "primary",
   "appearance": "outline",
@@ -780,11 +781,6 @@ Actions используются в `card_schema.actions`, `record_page.actions`
     "path": "/entities/:id",
     "queryParam": "record",
     "source": "id"
-  },
-  "route": {
-    "path": "/entities/:id",
-    "params": {"id": "record.id"},
-    "query": {}
   },
   "api": {
     "method": "post",
@@ -814,6 +810,16 @@ Actions используются в `card_schema.actions`, `record_page.actions`
   "test": "entity-open"
 }
 ```
+
+`behavior` описывает lifecycle формы и независим от `type` транспорта:
+
+| Behavior | Поведение UI kit |
+|---|---|
+| отсутствует | Обычное typed action без form lifecycle. |
+| `submit` | Передать только измененные поля формы через описанный API action, показать `saving_label`/`saved_label` и принять сохраненный record как исходное состояние. |
+| `reset` | Восстановить исходное состояние формы локально, без обязательного HTTP-запроса. |
+
+Например, `type: "api"` + `behavior: "submit"` сохраняет diff полей. Отдельный reset action выглядит как `{"type":"emit","behavior":"reset"}` и сбрасывает форму. UI kit не должен определять lifecycle по `id` action. Неизвестное значение `behavior` отклоняется validation renderer.
 
 Supported `action.type`:
 

--- a/renderer/action_behavior_test.go
+++ b/renderer/action_behavior_test.go
@@ -1,0 +1,57 @@
+package renderer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestActionBehaviorJSONAndClone(t *testing.T) {
+	render := Universal{Form: &FormPage{Actions: []Action{
+		{ID: "save", Type: ActionAPI, Behavior: ActionBehaviorSubmit, API: &APIAction{Method: "POST", Endpoint: "/records"}},
+		{ID: "discard", Type: ActionEmit, Behavior: ActionBehaviorReset},
+		{ID: "help", Type: ActionModal},
+	}}}
+
+	encoded, err := json.Marshal(render)
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), `"behavior":"submit"`)
+	require.Contains(t, string(encoded), `"behavior":"reset"`)
+	require.NotContains(t, string(encoded), `"id":"help","type":"modal","behavior"`)
+
+	cloned := render.Clone()
+	require.Equal(t, ActionBehaviorSubmit, cloned.Form.Actions[0].Behavior)
+	require.Equal(t, ActionBehaviorReset, cloned.Form.Actions[1].Behavior)
+	require.Empty(t, cloned.Form.Actions[2].Behavior)
+}
+
+func TestUniversalValidateActionBehavior(t *testing.T) {
+	for _, behavior := range []ActionBehavior{"", ActionBehaviorSubmit, ActionBehaviorReset} {
+		render := Universal{Form: &FormPage{Actions: []Action{{ID: "action", Type: ActionAPI, Behavior: behavior}}}}
+		require.NoError(t, render.Validate())
+	}
+
+	invalid := Action{ID: "invalid", Behavior: ActionBehavior("unsupported")}
+	tests := []struct {
+		name   string
+		render Universal
+		err    string
+	}{
+		{"list action", Universal{List: &ListPage{Actions: []Action{invalid}}}, `renderer.Universal: list page action "invalid": unsupported behavior "unsupported"`},
+		{"list card action", Universal{List: &ListPage{CardSchema: &CardSchema{Actions: []Action{invalid}}}}, `renderer.Universal: list page card schema action "invalid": unsupported behavior "unsupported"`},
+		{"nested list card action", Universal{Form: &FormPage{Sections: []FormSection{{ID: "nested", ListPage: &ListPage{CardSchema: &CardSchema{Actions: []Action{invalid}}}}}}}, `renderer.Universal: form section list page card schema action "invalid": unsupported behavior "unsupported"`},
+		{"form action", Universal{Form: &FormPage{Actions: []Action{invalid}}}, `renderer.Universal: form page action "invalid": unsupported behavior "unsupported"`},
+		{"collection action", Universal{Form: &FormPage{Sections: []FormSection{{ID: "collection", Collection: &CollectionConfig{Module: "items", Actions: []Action{invalid}}}}}}, `renderer.Universal: collection action "invalid": unsupported behavior "unsupported"`},
+		{"collection bucket action", Universal{Form: &FormPage{Sections: []FormSection{{ID: "collection", Collection: &CollectionConfig{Module: "items", Buckets: []CollectionBucket{{ID: "bucket", Actions: []Action{invalid}}}}}}}}, `renderer.Universal: collection bucket action "invalid": unsupported behavior "unsupported"`},
+		{"media action", Universal{Form: &FormPage{Sections: []FormSection{{ID: "media", MediaActions: &MediaGalleryActions{Upload: &invalid}}}}}, `renderer.Universal: media upload action "invalid": unsupported behavior "unsupported"`},
+		{"record action", Universal{Record: &RecordPage{Actions: []Action{invalid}}}, `renderer.Universal: record page action "invalid": unsupported behavior "unsupported"`},
+		{"resource grid action", Universal{ResourceGrid: &ResourceGridPage{Create: &invalid}}, `renderer.Universal: resource grid create action "invalid": unsupported behavior "unsupported"`},
+		{"resource grid card action", Universal{ResourceGrid: &ResourceGridPage{Card: &CardSchema{Actions: []Action{invalid}}}}, `renderer.Universal: resource grid card action "invalid": unsupported behavior "unsupported"`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.EqualError(t, test.render.Validate(), test.err)
+		})
+	}
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -74,7 +74,15 @@ func (r Universal) Validate() error {
 		return fmt.Errorf("renderer.Universal: List and ResourceGrid are mutually exclusive for one list route")
 	}
 	if r.Form != nil {
+		if err := validateActions("form page", r.Form.Actions); err != nil {
+			return err
+		}
 		for _, section := range r.Form.Sections {
+			if section.ListPage != nil {
+				if err := validateListPage("form section list page", section.ListPage); err != nil {
+					return err
+				}
+			}
 			if section.Renderer == RendererFieldMatrix && section.Matrix == nil {
 				return fmt.Errorf("renderer.Universal: field matrix section %q must define matrix", section.ID)
 			}
@@ -87,12 +95,18 @@ func (r Universal) Validate() error {
 				}
 			}
 			if section.Collection == nil {
+				if err := validateMediaActions(section.MediaActions); err != nil {
+					return err
+				}
 				continue
 			}
 			if section.Collection.Module == "" {
 				return fmt.Errorf("renderer.Universal: collection section %q must define module", section.ID)
 			}
 			for _, bucket := range section.Collection.Buckets {
+				if err := validateActions("collection bucket", bucket.Actions); err != nil {
+					return err
+				}
 				if bucket.Predicate == nil {
 					continue
 				}
@@ -106,7 +120,88 @@ func (r Universal) Validate() error {
 					return fmt.Errorf("renderer.Universal: collection bucket %q predicate must not define both value and values", bucket.ID)
 				}
 			}
+			if err := validateActions("collection", section.Collection.Actions); err != nil {
+				return err
+			}
+			if err := validateMediaActions(section.MediaActions); err != nil {
+				return err
+			}
 		}
+	}
+	if r.List != nil {
+		if err := validateListPage("list page", r.List); err != nil {
+			return err
+		}
+	}
+	if r.Record != nil {
+		if err := validateActions("record page", r.Record.Actions); err != nil {
+			return err
+		}
+	}
+	if r.ResourceGrid != nil {
+		if err := validateAction("resource grid create", r.ResourceGrid.Create); err != nil {
+			return err
+		}
+		if err := validateAction("resource grid delete", r.ResourceGrid.Delete); err != nil {
+			return err
+		}
+		if err := validateAction("resource grid update", r.ResourceGrid.Update); err != nil {
+			return err
+		}
+		if r.ResourceGrid.Card != nil {
+			if err := validateActions("resource grid card", r.ResourceGrid.Card.Actions); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateListPage(scope string, page *ListPage) error {
+	if page == nil {
+		return nil
+	}
+	if err := validateActions(scope, page.Actions); err != nil {
+		return err
+	}
+	if page.CardSchema != nil {
+		if err := validateActions(scope+" card schema", page.CardSchema.Actions); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateActions(scope string, actions []Action) error {
+	for i := range actions {
+		if err := validateAction(scope, &actions[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateMediaActions(actions *MediaGalleryActions) error {
+	if actions == nil {
+		return nil
+	}
+	for scope, action := range map[string]*Action{
+		"media upload": actions.Upload, "media link": actions.Link, "media reorder": actions.Reorder,
+		"media recenter": actions.Recenter, "media crop": actions.Crop, "media remove": actions.Remove,
+	} {
+		if err := validateAction(scope, action); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAction(scope string, action *Action) error {
+	if action == nil {
+		return nil
+	}
+	if err := action.Validate(); err != nil {
+		return fmt.Errorf("renderer.Universal: %s action %q: %w", scope, action.ID, err)
 	}
 	return nil
 }
@@ -712,6 +807,7 @@ type ResourceGridActionsConfig struct {
 type Action struct {
 	ID               string           `json:"id,omitempty"`
 	Type             ActionType       `json:"type,omitempty"`
+	Behavior         ActionBehavior   `json:"behavior,omitempty"`
 	Label            string           `json:"label,omitempty"`
 	LabelKey         string           `json:"label_key,omitempty"`
 	AriaLabel        string           `json:"aria_label,omitempty"`
@@ -741,6 +837,22 @@ type Action struct {
 	AriaLabelKey     string           `json:"aria_label_key,omitempty"`
 	TitleKey         string           `json:"title_key,omitempty"`
 	Test             string           `json:"test,omitempty"`
+}
+
+type ActionBehavior string
+
+const (
+	ActionBehaviorReset  ActionBehavior = "reset"
+	ActionBehaviorSubmit ActionBehavior = "submit"
+)
+
+func (action Action) Validate() error {
+	switch action.Behavior {
+	case "", ActionBehaviorReset, ActionBehaviorSubmit:
+		return nil
+	default:
+		return fmt.Errorf("unsupported behavior %q", action.Behavior)
+	}
 }
 
 type RouteAction struct {


### PR DESCRIPTION
## Изменения
- В `renderer.Action` добавлено typed поле `behavior` со значениями `submit` и `reset`.
- Validation отклоняет неизвестные behavior во всех поддерживаемых контейнерах actions.
- `behavior` независим от transport-поля `type`; lifecycle не определяется по `Action.ID`.
- Обновлен Universal Renderer contract и добавлены тесты JSON, clone и validation.

## Проверки
- `go test ./...`