### PR TITLE
Добавить typed renderer keys для option controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@ Frontend должен получать готовую схему и рендер
 
 В `defrec.fields[field]` и `view.item[field]` эти blocks приходят как `presentation` и `media`. Labels в media/action metadata переводятся request-generator по текущему языку. В `view` `media.item.src` может быть автоматически заполнен из `item[field].value`, если producer не указал `src`.
 
-Для typed controls выбора используйте renderer key вместе с обычными `Options`.
-`ModuleFieldOptions.Icon` передается в list filters, `defrec` и `view`, а
-`Label` локализуется генератором.
+Для typed controls выбора в `defrec` и `view` используйте renderer key вместе
+с обычными `Options`. `ModuleFieldOptions.Icon` передается в list filters,
+`defrec` и `view`, а `Label` локализуется генератором. List filter не получает
+`Presentation`: он использует базовый control по `form_type`. Специализированный
+filter control потребует отдельного typed contract.
 
 ```go
 {

--- a/README.md
+++ b/README.md
@@ -156,6 +156,37 @@ Frontend должен получать готовую схему и рендер
 
 В `defrec.fields[field]` и `view.item[field]` эти blocks приходят как `presentation` и `media`. Labels в media/action metadata переводятся request-generator по текущему языку. В `view` `media.item.src` может быть автоматически заполнен из `item[field].value`, если producer не указал `src`.
 
+Для typed controls выбора используйте renderer key вместе с обычными `Options`.
+`ModuleFieldOptions.Icon` передается в list filters, `defrec` и `view`, а
+`Label` локализуется генератором.
+
+```go
+{
+    Column:   table.Items.Categories,
+    Title:    "items.fields.categories",
+    Type:     fields.ModuleFieldTypeArray,
+    FormType: fields.ModuleFieldFormTypeMultiselect,
+    Presentation: &renderer.FieldPresentation{
+        Renderer: renderer.RendererChipSelect,
+    },
+    Options: []fields.ModuleFieldOptions{
+        {Value: "example", Label: "items.options.example", Icon: "tag"},
+    },
+},
+{
+    Column:   table.Items.Status,
+    Title:    "items.fields.status",
+    Type:     fields.ModuleFieldTypeString,
+    FormType: fields.ModuleFieldFormTypeSelect,
+    Presentation: &renderer.FieldPresentation{
+        Renderer: renderer.RendererPrimaryRadio,
+    },
+    Options: []fields.ModuleFieldOptions{
+        {Value: "active", Label: "items.options.active", Icon: "check"},
+    },
+},
+```
+
 ### FieldMatrix list
 
 `field.matrix` раскладывает уже описанные typed поля формы. Для `list` не
@@ -958,8 +989,8 @@ allModules := []*module.BaseModule{
 - Системные поля задаются через `DefaultFunc`, а не принимаются от клиента.
 - Все options приходят из `Options`, `OptionsFunc` или `options_url`.
 - Все поля формы имеют `Title` как ключ перевода.
-- Для новых UI-полей заполнен `Extra.Defrec`.
-- Для detail/list отображения заполнен `Extra.View`, если raw value неудобен.
+- Новые UI-возможности описаны typed metadata (`Presentation`, `Media` и т.п.), а не ad-hoc `Extra`.
+- `Extra.Defrec` и `Extra.View` используются только для legacy-совместимости.
 - UniversalRenderer page metadata описана через typed `BaseModule.Render`, а не через legacy `ExtraFunc`.
 - Действия, зависящие от состояния записи, описаны через `visible_if`/`hidden_if`.
 - Все ограничения из `visible_if` продублированы серверной проверкой.

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -422,8 +422,9 @@ Typed field metadata нужна для одиночных полей, где б�
 
 ### Option Controls
 
-Для вариантов выбора producer использует базовые `form_type`, `options` и
-`presentation.renderer`. UI kit выбирает control только по renderer key:
+Для вариантов выбора в `defrec` и `view` producer использует базовые
+`form_type`, `options` и `presentation.renderer`. UI kit выбирает control
+поля только по renderer key:
 
 | Renderer key | Назначение |
 |---|---|
@@ -444,7 +445,14 @@ Typed field metadata нужна для одиночных полей, где б�
 
 `label` задается producer-ом как translation key и локализуется
 request-generator до выдачи JSON. `icon` является стабильным именем иконки и
-не локализуется. Этот contract одинаков для list filters, `defrec` и `view`.
+не локализуется.
+
+В list filters generator передает `form_type` и стандартные options
+(`value`, локализованный `label`, `icon`), но не передает
+`presentation.renderer`. Поэтому list filter использует свой базовый control
+по `form_type`. Если для filter понадобится специализированный control, он
+должен получить отдельный typed contract (`FilterPresentation`), а не
+неявно переиспользовать field presentation.
 
 ```go
 {

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -420,6 +420,59 @@ Typed field metadata нужна для одиночных полей, где б�
 | `presentation.size` | Media size token: `thumb`, `card`, `hero`. |
 | `presentation.ratio` | Media ratio token: `square`, `portrait`, `landscape`, `wide`. |
 
+### Option Controls
+
+Для вариантов выбора producer использует базовые `form_type`, `options` и
+`presentation.renderer`. UI kit выбирает control только по renderer key:
+
+| Renderer key | Назначение |
+|---|---|
+| `chip_select` | Множественный выбор через chips. Используется с `form_type: multiselect`. |
+| `primary_radio` | Выбор одного основного варианта. Используется со scalar `form_type`, например `select`. |
+
+Каждый option может содержать `icon`. Значение и label остаются стандартными:
+
+```json
+{
+  "form_type": "multiselect",
+  "presentation": { "renderer": "chip_select" },
+  "options": [
+    { "value": "example", "label": "Example", "icon": "tag" }
+  ]
+}
+```
+
+`label` задается producer-ом как translation key и локализуется
+request-generator до выдачи JSON. `icon` является стабильным именем иконки и
+не локализуется. Этот contract одинаков для list filters, `defrec` и `view`.
+
+```go
+{
+    Column:   table.Items.Categories,
+    Title:    "items.fields.categories",
+    Type:     fields.ModuleFieldTypeArray,
+    FormType: fields.ModuleFieldFormTypeMultiselect,
+    Presentation: &renderer.FieldPresentation{
+        Renderer: renderer.RendererChipSelect,
+    },
+    Options: []fields.ModuleFieldOptions{
+        {Value: "example", Label: "items.options.example", Icon: "tag"},
+    },
+},
+{
+    Column:   table.Items.Status,
+    Title:    "items.fields.status",
+    Type:     fields.ModuleFieldTypeString,
+    FormType: fields.ModuleFieldFormTypeSelect,
+    Presentation: &renderer.FieldPresentation{
+        Renderer: renderer.RendererPrimaryRadio,
+    },
+    Options: []fields.ModuleFieldOptions{
+        {Value: "active", Label: "items.options.active", Icon: "check"},
+    },
+},
+```
+
 ### Field Media
 
 `media` описывает одиночное media-поле через существующие универсальные media-структуры. Это не gallery section и не application-specific avatar contract. Это один media item, optional upload config, labels и actions.

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -209,6 +209,7 @@ func (f ModuleFilterField) ColumnName() string {
 type ModuleFieldOptions struct {
 	Value  interface{}       `json:"value"`
 	Label  string            `json:"label"`
+	Icon   string            `json:"icon,omitempty"`
 	Labels map[string]string `json:"-"`
 }
 

--- a/generator.go
+++ b/generator.go
@@ -567,6 +567,7 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 					translatedOpts[i] = fields.ModuleFieldOptions{
 						Value: opt.Value,
 						Label: generator.Translate(lang, opt.Label),
+						Icon:  opt.Icon,
 					}
 				}
 				ef.Title = generator.Translate(lang, ef.Title)

--- a/renderer/tokens.go
+++ b/renderer/tokens.go
@@ -207,6 +207,8 @@ const (
 	RendererCollectionManager   RendererKey = "collection.manager"
 	RendererFieldMatrix         RendererKey = "field.matrix"
 	RendererAvatar              RendererKey = "avatar"
+	RendererChipSelect          RendererKey = "chip_select"
+	RendererPrimaryRadio        RendererKey = "primary_radio"
 )
 
 type RecordSectionRenderer = RendererKey

--- a/tests/integration/typed_option_renderer_response_test.go
+++ b/tests/integration/typed_option_renderer_response_test.go
@@ -1,0 +1,131 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	module "github.com/darkrain/request-generator"
+	"github.com/darkrain/request-generator/actions"
+	dbpkg "github.com/darkrain/request-generator/db"
+	"github.com/darkrain/request-generator/fields"
+	"github.com/darkrain/request-generator/icontext"
+	"github.com/darkrain/request-generator/locale"
+	"github.com/darkrain/request-generator/renderer"
+	"github.com/gin-gonic/gin"
+	pg "github.com/go-jet/jet/v2/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	id := pg.IntegerColumn("id")
+	status := pg.StringColumn("status")
+	categories := pg.StringColumn("categories")
+	table := pg.NewTable("public", "typed_option_items", "", id, status, categories)
+	testModule := &module.BaseModule{
+		Name:       "typed-option-items",
+		Path:       "/admin",
+		Table:      table,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "items.fields.id", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeOnlyView},
+			{
+				Column:       status,
+				Title:        "items.fields.status",
+				Type:         fields.ModuleFieldTypeString,
+				FormType:     fields.ModuleFieldFormTypeSelect,
+				Presentation: &renderer.FieldPresentation{Renderer: renderer.RendererPrimaryRadio},
+				Options: []fields.ModuleFieldOptions{
+					{Value: "active", Label: "items.options.active", Icon: "check"},
+				},
+			},
+			{
+				Column:       categories,
+				Title:        "items.fields.categories",
+				Type:         fields.ModuleFieldTypeArray,
+				FormType:     fields.ModuleFieldFormTypeMultiselect,
+				Presentation: &renderer.FieldPresentation{Renderer: renderer.RendererChipSelect},
+				Options: []fields.ModuleFieldOptions{
+					{Value: "example", Label: "items.options.example", Icon: "tag"},
+				},
+			},
+		},
+		Render: renderer.Universal{
+			List:   &renderer.ListPage{ID: "typed-option-items"},
+			Form:   &renderer.FormPage{ID: "typed-option-items-form"},
+			Record: &renderer.RecordPage{ID: "typed-option-items-record"},
+		},
+		Actions: []actions.ModuleAction{
+			actions.ListModuleAction{Columns: []pg.Column{id, status, categories}, Filter: []pg.Column{status}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
+			actions.AddModuleAction{Columns: []pg.Column{status, categories}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
+			actions.ViewModuleAction{Columns: []pg.Column{id, status, categories}, By: []pg.Column{id}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
+		},
+	}
+
+	translationsPath := filepath.Join(t.TempDir(), "en.json")
+	require.NoError(t, os.WriteFile(translationsPath, []byte(`{"items":{"fields":{"id":"ID","status":"Status","categories":"Categories"},"options":{"active":"Active","example":"Example"}}}`), 0o600))
+
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(
+		func(_ *module.BaseModule) dbpkg.DBExecutor { return fakeRendererDB{} },
+		*group,
+		[]*module.BaseModule{testModule},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+	)
+	generator.Locales = []locale.Lang{locale.EN}
+	require.NoError(t, generator.LoadTranslationsFile(locale.EN, translationsPath))
+	generator.Run()
+
+	assertOptions := func(t *testing.T, options []fields.ModuleFieldOptions, label, icon string) {
+		t.Helper()
+		require.Len(t, options, 1)
+		require.Equal(t, label, options[0].Label)
+		require.Equal(t, icon, options[0].Icon)
+	}
+
+	w := executeRequest(engine, http.MethodGet, "/admin/typed-option-items?addFilters=true&lang=en", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var listResponse struct {
+		Filters map[string]struct {
+			Options []fields.ModuleFieldOptions `json:"options"`
+		} `json:"filters"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listResponse))
+	assertOptions(t, listResponse.Filters["status"].Options, "Active", "check")
+
+	w = executeRequest(engine, http.MethodGet, "/admin/typed-option-items/defrec/?lang=en", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var defrecResponse struct {
+		Fields map[string]struct {
+			Presentation *renderer.FieldPresentation `json:"presentation"`
+			Options      []fields.ModuleFieldOptions `json:"options"`
+		} `json:"fields"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &defrecResponse))
+	require.Equal(t, renderer.RendererPrimaryRadio, defrecResponse.Fields["status"].Presentation.Renderer)
+	assertOptions(t, defrecResponse.Fields["status"].Options, "Active", "check")
+	require.Equal(t, renderer.RendererChipSelect, defrecResponse.Fields["categories"].Presentation.Renderer)
+	assertOptions(t, defrecResponse.Fields["categories"].Options, "Example", "tag")
+
+	w = executeRequest(engine, http.MethodGet, "/admin/typed-option-items/view/id/1?lang=en", nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var viewResponse struct {
+		Item map[string]struct {
+			Presentation *renderer.FieldPresentation `json:"presentation"`
+			Options      []fields.ModuleFieldOptions `json:"options"`
+		} `json:"item"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &viewResponse))
+	require.Equal(t, renderer.RendererPrimaryRadio, viewResponse.Item["status"].Presentation.Renderer)
+	assertOptions(t, viewResponse.Item["status"].Options, "Active", "check")
+	require.Equal(t, renderer.RendererChipSelect, viewResponse.Item["categories"].Presentation.Renderer)
+	assertOptions(t, viewResponse.Item["categories"].Options, "Example", "tag")
+}


### PR DESCRIPTION
## Изменения

- добавлены универсальные renderer keys `chip_select` и `primary_radio`;
- `fields.ModuleFieldOptions` расширен typed полем `icon`;
- `Icon` сохраняется при локализации и clone-path `ExtraFilters`;
- интеграционный тест проверяет JSON для list filters, `defrec` и `view`: renderer key, локализованный label и icon;
- README и спецификация UniversalRenderer дополнены нейтральными Go/JSON примерами.

## Проверка

- `go test ./...`