### PR TITLE
Добавить typed columns для FormSection

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -204,6 +204,25 @@ Closed enums должны использовать typed constants из package 
 | `renderer` | Renderer identity/version, добавляется request-generator. |
 | `form_page` | Typed metadata универсальной form/edit страницы из `BaseModule.Render.Form`. |
 
+### Form Section Columns
+
+`form_page.sections[].columns` задает количество колонок для обычной секции
+формы и ее дочерних fields. Это layout секции, а не свойство отдельного поля
+или визуальной поверхности `block`.
+
+Допустимы typed значения `1`, `2`, `3`, `4` из
+`renderer.FieldMatrixColumnCount`. Значение `0` не сериализуется и означает
+renderer default. Generator отклоняет другие значения при `Universal.Validate()`.
+
+```go
+renderer.FormSection{
+    ID:      "payments",
+    Block:   &renderer.Block{Type: renderer.BlockPanel},
+    Fields:  []string{"accepted_payment", "commission_rate"},
+    Columns: renderer.FieldMatrixColumnsOne,
+}
+```
+
 ### Field Matrix
 
 `field.matrix` задает раскладку уже описанных typed полей формы. Matrix не

--- a/renderer/field_matrix_test.go
+++ b/renderer/field_matrix_test.go
@@ -1,9 +1,11 @@
 package renderer
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFieldMatrixValidate(t *testing.T) {
@@ -91,6 +93,33 @@ func TestUniversalValidateFieldMatrixRendererBinding(t *testing.T) {
 			assert.Equal(t, test.valid, err == nil, err)
 		})
 	}
+}
+
+func TestUniversalValidateFormSectionColumns(t *testing.T) {
+	for _, columns := range []FieldMatrixColumnCount{0, FieldMatrixColumnsOne, FieldMatrixColumnsTwo, FieldMatrixColumnsThree, FieldMatrixColumnsFour} {
+		t.Run("valid", func(t *testing.T) {
+			err := (Universal{Form: &FormPage{Sections: []FormSection{{ID: "preferences", Columns: columns}}}}).Validate()
+			require.NoError(t, err)
+		})
+	}
+
+	err := (Universal{Form: &FormPage{Sections: []FormSection{{ID: "preferences", Columns: 5}}}}).Validate()
+	require.EqualError(t, err, `renderer.Universal: form section "preferences" has unsupported columns`)
+}
+
+func TestFormSectionColumnsJSONAndClone(t *testing.T) {
+	original := Universal{Form: &FormPage{Sections: []FormSection{{
+		ID:      "payments",
+		Fields:  []string{"accepted_payment", "commission_rate"},
+		Columns: FieldMatrixColumnsOne,
+	}}}}
+
+	encoded, err := json.Marshal(original.Form.Sections[0])
+	require.NoError(t, err)
+	require.JSONEq(t, `{"id":"payments","fields":["accepted_payment","commission_rate"],"columns":1}`, string(encoded))
+
+	cloned := original.Clone()
+	require.Equal(t, FieldMatrixColumnsOne, cloned.Form.Sections[0].Columns)
 }
 
 func TestFieldMatrixClone(t *testing.T) {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -78,6 +78,9 @@ func (r Universal) Validate() error {
 			return err
 		}
 		for _, section := range r.Form.Sections {
+			if err := validateFormSectionColumns(section); err != nil {
+				return err
+			}
 			if section.ListPage != nil {
 				if err := validateListPage("form section list page", section.ListPage); err != nil {
 					return err
@@ -398,25 +401,26 @@ type FormPage struct {
 }
 
 type FormSection struct {
-	ID           string               `json:"id,omitempty"`
-	Title        string               `json:"title,omitempty"`
-	PanelTitle   string               `json:"panel_title,omitempty"`
-	Subtitle     string               `json:"subtitle,omitempty"`
-	Renderer     RendererKey          `json:"renderer,omitempty"`
-	Group        string               `json:"group,omitempty"`
-	GroupTitle   string               `json:"group_title,omitempty"`
-	Icon         string               `json:"icon,omitempty"`
-	Action       string               `json:"action,omitempty"`
-	Mode         string               `json:"mode,omitempty"`
-	Block        *Block               `json:"block,omitempty"`
-	Fields       []string             `json:"fields,omitempty"`
-	Matrix       *FieldMatrix         `json:"matrix,omitempty"`
-	ListPage     *ListPage            `json:"list_page,omitempty"`
-	Collection   *CollectionConfig    `json:"collection,omitempty"`
-	MediaUpload  *MediaUploadConfig   `json:"media_upload,omitempty"`
-	MediaItems   []MediaGalleryItem   `json:"media_items,omitempty"`
-	MediaLabels  *MediaGalleryLabels  `json:"media_labels,omitempty"`
-	MediaActions *MediaGalleryActions `json:"media_actions,omitempty"`
+	ID           string                 `json:"id,omitempty"`
+	Title        string                 `json:"title,omitempty"`
+	PanelTitle   string                 `json:"panel_title,omitempty"`
+	Subtitle     string                 `json:"subtitle,omitempty"`
+	Renderer     RendererKey            `json:"renderer,omitempty"`
+	Group        string                 `json:"group,omitempty"`
+	GroupTitle   string                 `json:"group_title,omitempty"`
+	Icon         string                 `json:"icon,omitempty"`
+	Action       string                 `json:"action,omitempty"`
+	Mode         string                 `json:"mode,omitempty"`
+	Block        *Block                 `json:"block,omitempty"`
+	Fields       []string               `json:"fields,omitempty"`
+	Columns      FieldMatrixColumnCount `json:"columns,omitempty"`
+	Matrix       *FieldMatrix           `json:"matrix,omitempty"`
+	ListPage     *ListPage              `json:"list_page,omitempty"`
+	Collection   *CollectionConfig      `json:"collection,omitempty"`
+	MediaUpload  *MediaUploadConfig     `json:"media_upload,omitempty"`
+	MediaItems   []MediaGalleryItem     `json:"media_items,omitempty"`
+	MediaLabels  *MediaGalleryLabels    `json:"media_labels,omitempty"`
+	MediaActions *MediaGalleryActions   `json:"media_actions,omitempty"`
 }
 
 type FieldMatrixType string
@@ -460,6 +464,15 @@ type FieldMatrixRow struct {
 type FieldMatrixCell struct {
 	Field string `json:"field,omitempty"`
 	Text  string `json:"text,omitempty"`
+}
+
+func validateFormSectionColumns(section FormSection) error {
+	switch section.Columns {
+	case 0, FieldMatrixColumnsOne, FieldMatrixColumnsTwo, FieldMatrixColumnsThree, FieldMatrixColumnsFour:
+		return nil
+	default:
+		return fmt.Errorf("renderer.Universal: form section %q has unsupported columns", section.ID)
+	}
 }
 
 func (matrix *FieldMatrix) Validate(sectionID string) error {


### PR DESCRIPTION
## Изменения

- `renderer.FormSection` получает typed `Columns FieldMatrixColumnCount`;
- canonical JSON: `form_page.sections[].columns`;
- `0` означает renderer default и не сериализуется, допустимы `1..4`;
- `Universal.Validate()` отклоняет остальные значения;
- scalar поле копируется существующим `Clone()` без отдельной ветки;
- спецификация дополнена назначением и примером.

## Проверка

- unit tests serialization, validation и clone;
- `go test ./...`.