### PR TITLE
Добавить typed cropper-конфигурацию для image media fields

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -601,10 +601,12 @@ Producer задает labels как translation keys. Request-generator возв
 }
 ```
 
-Текстовые поля cropper producer задает translation keys; в response они уже
-локализованы. `viewport.shape` принимает только `circle`, `rounded` или
-`rectangle`; `viewport.aspect_ratio` должен быть положительным. Output требует
-положительные `width` и `height`, непустой `mime_type` и `quality` от `0` до
+Producer задает `title`, `hint`, `choose_label`, `cancel_label`,
+`confirm_label` и `close_label` как обязательные translation keys; в response
+они уже локализованы. `subtitle` optional. `viewport.shape` принимает только
+`circle`, `rounded` или `rectangle`; `viewport.aspect_ratio` должен быть
+положительным. Output требует положительные `width` и `height`, один из typed
+`mime_type` (`image/jpeg`, `image/png`, `image/webp`) и `quality` от `0` до
 `1`. Некорректный cropper generator отклоняет при запуске.
 
 ```go
@@ -625,7 +627,7 @@ Media: &renderer.FieldMediaConfig{
         Output: renderer.MediaCropperOutputConfig{
             Width:    512,
             Height:   512,
-            MIMEType: "image/jpeg",
+			MIMEType: renderer.MediaCropperOutputMIMETypeJPEG,
             Quality:  0.92,
         },
     },

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -566,8 +566,71 @@ request-generator до выдачи JSON. `icon` является стабиль
 | `media.upload` | `MediaUploadConfig`: ограничения upload UI и localized labels. |
 | `media.labels` | `MediaGalleryLabels`, переиспользуется для одиночного media field. |
 | `media.actions` | `MediaGalleryActions`: стандартные действия `upload`, `link`, `reorder`, `recenter`, `crop`, `remove`. |
+| `media.cropper` | Optional typed config универсального image cropper. |
 
 Producer задает labels как translation keys. Request-generator возвращает во внешнем JSON уже локализованные labels согласно `lang`/`Accept-Language`.
+
+### Media Cropper
+
+`media.cropper` опционально описывает обрезку любого image field. Generator не
+знает назначение изображения: `circle` является только маской viewport, а не
+признаком avatar.
+
+```json
+{
+  "cropper": {
+    "title": "Adjust image",
+    "subtitle": "Move and scale the image",
+    "hint": "Drag or pinch to zoom",
+    "choose_label": "Choose image",
+    "cancel_label": "Cancel",
+    "confirm_label": "Use image",
+    "close_label": "Close",
+    "accept": "image/jpeg,image/png,image/webp",
+    "viewport": {
+      "shape": "circle",
+      "aspect_ratio": 1
+    },
+    "output": {
+      "width": 512,
+      "height": 512,
+      "mime_type": "image/jpeg",
+      "quality": 0.92
+    }
+  }
+}
+```
+
+Текстовые поля cropper producer задает translation keys; в response они уже
+локализованы. `viewport.shape` принимает только `circle`, `rounded` или
+`rectangle`; `viewport.aspect_ratio` должен быть положительным. Output требует
+положительные `width` и `height`, непустой `mime_type` и `quality` от `0` до
+`1`. Некорректный cropper generator отклоняет при запуске.
+
+```go
+Media: &renderer.FieldMediaConfig{
+    Cropper: &renderer.MediaCropperConfig{
+        Title:        "items.cropper.title",
+        Subtitle:     "items.cropper.subtitle",
+        Hint:         "items.cropper.hint",
+        ChooseLabel:  "items.cropper.choose",
+        CancelLabel:  "ui.cancel",
+        ConfirmLabel: "items.cropper.confirm",
+        CloseLabel:   "ui.close",
+        Accept:       "image/jpeg,image/png,image/webp",
+        Viewport: renderer.MediaCropperViewportConfig{
+            Shape:       renderer.MediaCropperViewportCircle,
+            AspectRatio: 1,
+        },
+        Output: renderer.MediaCropperOutputConfig{
+            Width:    512,
+            Height:   512,
+            MIMEType: "image/jpeg",
+            Quality:  0.92,
+        },
+    },
+},
+```
 
 ### Go API
 

--- a/field_media_validation_test.go
+++ b/field_media_validation_test.go
@@ -22,8 +22,14 @@ func TestRunRejectsInvalidFieldMediaCropper(t *testing.T) {
 		Fields: []fields.ModuleField{{
 			Column: avatar,
 			Media: &renderer.FieldMediaConfig{Cropper: &renderer.MediaCropperConfig{
-				Viewport: renderer.MediaCropperViewportConfig{Shape: renderer.MediaCropperViewportCircle, AspectRatio: 1},
-				Output:   renderer.MediaCropperOutputConfig{Width: 512, Height: 512, MIMEType: "image/jpeg", Quality: 1.1},
+				Title:        "Adjust image",
+				Hint:         "Drag to crop",
+				ChooseLabel:  "Choose image",
+				CancelLabel:  "Cancel",
+				ConfirmLabel: "Use image",
+				CloseLabel:   "Close",
+				Viewport:     renderer.MediaCropperViewportConfig{Shape: renderer.MediaCropperViewportCircle, AspectRatio: 1},
+				Output:       renderer.MediaCropperOutputConfig{Width: 512, Height: 512, MIMEType: renderer.MediaCropperOutputMIMETypeJPEG, Quality: 1.1},
 			}},
 		}},
 	}

--- a/field_media_validation_test.go
+++ b/field_media_validation_test.go
@@ -1,0 +1,38 @@
+package module
+
+import (
+	"testing"
+
+	"github.com/darkrain/request-generator/fields"
+	"github.com/darkrain/request-generator/renderer"
+	"github.com/gin-gonic/gin"
+	"github.com/go-jet/jet/v2/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunRejectsInvalidFieldMediaCropper(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	id := postgres.IntegerColumn("id")
+	avatar := postgres.StringColumn("avatar")
+	table := postgres.NewTable("public", "media_items", "", id, avatar)
+	base := &BaseModule{
+		Name:       "media-items",
+		Table:      table,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{{
+			Column: avatar,
+			Media: &renderer.FieldMediaConfig{Cropper: &renderer.MediaCropperConfig{
+				Viewport: renderer.MediaCropperViewportConfig{Shape: renderer.MediaCropperViewportCircle, AspectRatio: 1},
+				Output:   renderer.MediaCropperOutputConfig{Width: 512, Height: 512, MIMEType: "image/jpeg", Quality: 1.1},
+			}},
+		}},
+	}
+	engine := gin.New()
+	group := engine.Group("")
+	generator := NewGenerator(nil, *group, []*BaseModule{base}, nil, nil)
+
+	require.PanicsWithValue(t,
+		`invalid field media config in module media-items: field "avatar": renderer.MediaCropperConfig: output quality must be between 0 and 1`,
+		func() { generator.Run() },
+	)
+}

--- a/generator.go
+++ b/generator.go
@@ -125,6 +125,9 @@ func (generator *Generator) Run() {
 		if err := module.validateFieldMatrices(module.Render); err != nil {
 			panic(fmt.Sprintf("invalid field matrix config in module %s: %v", module.Name, err))
 		}
+		if err := validateModuleFieldMedia(module); err != nil {
+			panic(fmt.Sprintf("invalid field media config in module %s: %v", module.Name, err))
+		}
 		if err := generator.validateCollectionRelations(module); err != nil {
 			panic(fmt.Sprintf("invalid collection config in module %s: %v", module.Name, err))
 		}
@@ -304,6 +307,15 @@ func (generator *Generator) Run() {
 			c.Data(http.StatusOK, "application/json; charset=utf-8", specJSON)
 		})
 	}
+}
+
+func validateModuleFieldMedia(module *BaseModule) error {
+	for _, field := range module.Fields {
+		if err := field.Media.Validate(); err != nil {
+			return fmt.Errorf("field %q: %w", field.ColumnName(), err)
+		}
+	}
+	return nil
 }
 
 func (generator *Generator) validateCollectionRelations(owner *BaseModule) error {

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -316,6 +316,7 @@ func CloneFieldMediaConfig(v *FieldMediaConfig) *FieldMediaConfig {
 	cp.Upload = clonePtr(v.Upload)
 	cp.Labels = clonePtr(v.Labels)
 	cp.Actions = cloneMediaGalleryActions(v.Actions)
+	cp.Cropper = clonePtr(v.Cropper)
 	return &cp
 }
 

--- a/renderer/localize.go
+++ b/renderer/localize.go
@@ -61,6 +61,7 @@ func LocalizeFieldMedia(value *FieldMediaConfig, resolve TextResolver) *FieldMed
 	localized.Upload = localizer.localizeMediaUpload(localized.Upload)
 	localized.Labels = localizer.localizeMediaLabels(localized.Labels)
 	localizer.localizeMediaActions(localized.Actions)
+	localizer.localizeMediaCropper(localized.Cropper)
 	return localized
 }
 
@@ -200,6 +201,13 @@ func (localizer textLocalizer) localizeMediaActions(actions *MediaGalleryActions
 		localizer.localizeRendererAction(actions.Crop)
 		localizer.localizeRendererAction(actions.Remove)
 	}
+}
+
+func (localizer textLocalizer) localizeMediaCropper(cropper *MediaCropperConfig) {
+	if cropper == nil {
+		return
+	}
+	localizer.localizeTextFields(&cropper.Title, &cropper.Subtitle, &cropper.Hint, &cropper.ChooseLabel, &cropper.CancelLabel, &cropper.ConfirmLabel, &cropper.CloseLabel)
 }
 
 func (localizer textLocalizer) localizeCollection(collection *CollectionConfig) {

--- a/renderer/media_cropper_test.go
+++ b/renderer/media_cropper_test.go
@@ -23,7 +23,7 @@ func validMediaCropper() *MediaCropperConfig {
 		Output: MediaCropperOutputConfig{
 			Width:    512,
 			Height:   512,
-			MIMEType: "image/jpeg",
+			MIMEType: MediaCropperOutputMIMETypeJPEG,
 			Quality:  0.92,
 		},
 	}
@@ -39,7 +39,9 @@ func TestMediaCropperConfigValidate(t *testing.T) {
 		{name: "unsupported shape", mutate: func(config *MediaCropperConfig) { config.Viewport.Shape = "oval" }, err: `renderer.MediaCropperConfig: unsupported viewport shape "oval"`},
 		{name: "nonpositive aspect ratio", mutate: func(config *MediaCropperConfig) { config.Viewport.AspectRatio = 0 }, err: "renderer.MediaCropperConfig: viewport aspect ratio must be positive"},
 		{name: "nonpositive dimensions", mutate: func(config *MediaCropperConfig) { config.Output.Width = 0 }, err: "renderer.MediaCropperConfig: output dimensions must be positive"},
-		{name: "missing mime type", mutate: func(config *MediaCropperConfig) { config.Output.MIMEType = " " }, err: "renderer.MediaCropperConfig: output mime type is required"},
+		{name: "missing title", mutate: func(config *MediaCropperConfig) { config.Title = " " }, err: "renderer.MediaCropperConfig: title is required"},
+		{name: "missing confirm label", mutate: func(config *MediaCropperConfig) { config.ConfirmLabel = "" }, err: "renderer.MediaCropperConfig: confirm label is required"},
+		{name: "unsupported mime type", mutate: func(config *MediaCropperConfig) { config.Output.MIMEType = "image/avif" }, err: `renderer.MediaCropperConfig: unsupported output mime type "image/avif"`},
 		{name: "invalid quality", mutate: func(config *MediaCropperConfig) { config.Output.Quality = 1.01 }, err: "renderer.MediaCropperConfig: output quality must be between 0 and 1"},
 	}
 

--- a/renderer/media_cropper_test.go
+++ b/renderer/media_cropper_test.go
@@ -1,0 +1,86 @@
+package renderer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func validMediaCropper() *MediaCropperConfig {
+	return &MediaCropperConfig{
+		Title:        "cropper.title",
+		Subtitle:     "cropper.subtitle",
+		Hint:         "cropper.hint",
+		ChooseLabel:  "cropper.choose",
+		CancelLabel:  "cropper.cancel",
+		ConfirmLabel: "cropper.confirm",
+		CloseLabel:   "cropper.close",
+		Accept:       "image/jpeg,image/png,image/webp",
+		Viewport: MediaCropperViewportConfig{
+			Shape:       MediaCropperViewportCircle,
+			AspectRatio: 1,
+		},
+		Output: MediaCropperOutputConfig{
+			Width:    512,
+			Height:   512,
+			MIMEType: "image/jpeg",
+			Quality:  0.92,
+		},
+	}
+}
+
+func TestMediaCropperConfigValidate(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*MediaCropperConfig)
+		err    string
+	}{
+		{name: "valid"},
+		{name: "unsupported shape", mutate: func(config *MediaCropperConfig) { config.Viewport.Shape = "oval" }, err: `renderer.MediaCropperConfig: unsupported viewport shape "oval"`},
+		{name: "nonpositive aspect ratio", mutate: func(config *MediaCropperConfig) { config.Viewport.AspectRatio = 0 }, err: "renderer.MediaCropperConfig: viewport aspect ratio must be positive"},
+		{name: "nonpositive dimensions", mutate: func(config *MediaCropperConfig) { config.Output.Width = 0 }, err: "renderer.MediaCropperConfig: output dimensions must be positive"},
+		{name: "missing mime type", mutate: func(config *MediaCropperConfig) { config.Output.MIMEType = " " }, err: "renderer.MediaCropperConfig: output mime type is required"},
+		{name: "invalid quality", mutate: func(config *MediaCropperConfig) { config.Output.Quality = 1.01 }, err: "renderer.MediaCropperConfig: output quality must be between 0 and 1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cropper := validMediaCropper()
+			if test.mutate != nil {
+				test.mutate(cropper)
+			}
+			if test.err == "" {
+				require.NoError(t, cropper.Validate())
+				return
+			}
+			require.EqualError(t, cropper.Validate(), test.err)
+		})
+	}
+}
+
+func TestLocalizeFieldMediaCropperClonesAndLocalizes(t *testing.T) {
+	source := &FieldMediaConfig{Cropper: validMediaCropper()}
+	translations := map[string]string{
+		"cropper.title":    "Adjust image",
+		"cropper.subtitle": "Move and scale the image",
+		"cropper.hint":     "Drag or pinch to zoom",
+		"cropper.choose":   "Choose image",
+		"cropper.cancel":   "Cancel",
+		"cropper.confirm":  "Use image",
+		"cropper.close":    "Close",
+	}
+
+	localized := LocalizeFieldMedia(source, func(value, _ string) string {
+		if translated, ok := translations[value]; ok {
+			return translated
+		}
+		return value
+	})
+
+	require.Equal(t, "Adjust image", localized.Cropper.Title)
+	require.Equal(t, "Use image", localized.Cropper.ConfirmLabel)
+	require.Equal(t, "cropper.title", source.Cropper.Title)
+	require.Equal(t, "cropper.confirm", source.Cropper.ConfirmLabel)
+	require.Equal(t, MediaCropperViewportCircle, localized.Cropper.Viewport.Shape)
+	require.Equal(t, 512, localized.Cropper.Output.Width)
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -368,10 +368,10 @@ type MediaCropperViewportConfig struct {
 }
 
 type MediaCropperOutputConfig struct {
-	Width    int     `json:"width"`
-	Height   int     `json:"height"`
-	MIMEType string  `json:"mime_type"`
-	Quality  float64 `json:"quality"`
+	Width    int                        `json:"width"`
+	Height   int                        `json:"height"`
+	MIMEType MediaCropperOutputMIMEType `json:"mime_type"`
+	Quality  float64                    `json:"quality"`
 }
 
 func (config *FieldMediaConfig) Validate() error {
@@ -393,11 +393,28 @@ func (cropper *MediaCropperConfig) Validate() error {
 	if cropper.Viewport.AspectRatio <= 0 || math.IsNaN(cropper.Viewport.AspectRatio) || math.IsInf(cropper.Viewport.AspectRatio, 0) {
 		return fmt.Errorf("renderer.MediaCropperConfig: viewport aspect ratio must be positive")
 	}
+	for _, label := range []struct {
+		name  string
+		value string
+	}{
+		{name: "title", value: cropper.Title},
+		{name: "hint", value: cropper.Hint},
+		{name: "choose label", value: cropper.ChooseLabel},
+		{name: "cancel label", value: cropper.CancelLabel},
+		{name: "confirm label", value: cropper.ConfirmLabel},
+		{name: "close label", value: cropper.CloseLabel},
+	} {
+		if strings.TrimSpace(label.value) == "" {
+			return fmt.Errorf("renderer.MediaCropperConfig: %s is required", label.name)
+		}
+	}
 	if cropper.Output.Width <= 0 || cropper.Output.Height <= 0 {
 		return fmt.Errorf("renderer.MediaCropperConfig: output dimensions must be positive")
 	}
-	if strings.TrimSpace(cropper.Output.MIMEType) == "" {
-		return fmt.Errorf("renderer.MediaCropperConfig: output mime type is required")
+	switch cropper.Output.MIMEType {
+	case MediaCropperOutputMIMETypeJPEG, MediaCropperOutputMIMETypePNG, MediaCropperOutputMIMETypeWebP:
+	default:
+		return fmt.Errorf("renderer.MediaCropperConfig: unsupported output mime type %q", cropper.Output.MIMEType)
 	}
 	if cropper.Output.Quality < 0 || cropper.Output.Quality > 1 || math.IsNaN(cropper.Output.Quality) || math.IsInf(cropper.Output.Quality, 0) {
 		return fmt.Errorf("renderer.MediaCropperConfig: output quality must be between 0 and 1")

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -3,6 +3,8 @@ package renderer
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strings"
 )
 
 type Universal struct {
@@ -344,6 +346,63 @@ type FieldMediaConfig struct {
 	Upload  *MediaUploadConfig   `json:"upload,omitempty"`
 	Labels  *MediaGalleryLabels  `json:"labels,omitempty"`
 	Actions *MediaGalleryActions `json:"actions,omitempty"`
+	Cropper *MediaCropperConfig  `json:"cropper,omitempty"`
+}
+
+type MediaCropperConfig struct {
+	Title        string                     `json:"title,omitempty"`
+	Subtitle     string                     `json:"subtitle,omitempty"`
+	Hint         string                     `json:"hint,omitempty"`
+	ChooseLabel  string                     `json:"choose_label,omitempty"`
+	CancelLabel  string                     `json:"cancel_label,omitempty"`
+	ConfirmLabel string                     `json:"confirm_label,omitempty"`
+	CloseLabel   string                     `json:"close_label,omitempty"`
+	Accept       string                     `json:"accept,omitempty"`
+	Viewport     MediaCropperViewportConfig `json:"viewport"`
+	Output       MediaCropperOutputConfig   `json:"output"`
+}
+
+type MediaCropperViewportConfig struct {
+	Shape       MediaCropperViewportShape `json:"shape"`
+	AspectRatio float64                   `json:"aspect_ratio"`
+}
+
+type MediaCropperOutputConfig struct {
+	Width    int     `json:"width"`
+	Height   int     `json:"height"`
+	MIMEType string  `json:"mime_type"`
+	Quality  float64 `json:"quality"`
+}
+
+func (config *FieldMediaConfig) Validate() error {
+	if config == nil || config.Cropper == nil {
+		return nil
+	}
+	return config.Cropper.Validate()
+}
+
+func (cropper *MediaCropperConfig) Validate() error {
+	if cropper == nil {
+		return nil
+	}
+	switch cropper.Viewport.Shape {
+	case MediaCropperViewportCircle, MediaCropperViewportRounded, MediaCropperViewportRectangle:
+	default:
+		return fmt.Errorf("renderer.MediaCropperConfig: unsupported viewport shape %q", cropper.Viewport.Shape)
+	}
+	if cropper.Viewport.AspectRatio <= 0 || math.IsNaN(cropper.Viewport.AspectRatio) || math.IsInf(cropper.Viewport.AspectRatio, 0) {
+		return fmt.Errorf("renderer.MediaCropperConfig: viewport aspect ratio must be positive")
+	}
+	if cropper.Output.Width <= 0 || cropper.Output.Height <= 0 {
+		return fmt.Errorf("renderer.MediaCropperConfig: output dimensions must be positive")
+	}
+	if strings.TrimSpace(cropper.Output.MIMEType) == "" {
+		return fmt.Errorf("renderer.MediaCropperConfig: output mime type is required")
+	}
+	if cropper.Output.Quality < 0 || cropper.Output.Quality > 1 || math.IsNaN(cropper.Output.Quality) || math.IsInf(cropper.Output.Quality, 0) {
+		return fmt.Errorf("renderer.MediaCropperConfig: output quality must be between 0 and 1")
+	}
+	return nil
 }
 
 type TextBinding struct {

--- a/renderer/tokens.go
+++ b/renderer/tokens.go
@@ -289,6 +289,14 @@ const (
 	MediaCropperViewportRectangle MediaCropperViewportShape = "rectangle"
 )
 
+type MediaCropperOutputMIMEType string
+
+const (
+	MediaCropperOutputMIMETypeJPEG MediaCropperOutputMIMEType = "image/jpeg"
+	MediaCropperOutputMIMETypePNG  MediaCropperOutputMIMEType = "image/png"
+	MediaCropperOutputMIMETypeWebP MediaCropperOutputMIMEType = "image/webp"
+)
+
 type DisplayComponentType string
 
 const (

--- a/renderer/tokens.go
+++ b/renderer/tokens.go
@@ -281,6 +281,14 @@ const (
 	MediaUsagePoster  MediaUsage = "poster"
 )
 
+type MediaCropperViewportShape string
+
+const (
+	MediaCropperViewportCircle    MediaCropperViewportShape = "circle"
+	MediaCropperViewportRounded   MediaCropperViewportShape = "rounded"
+	MediaCropperViewportRectangle MediaCropperViewportShape = "rectangle"
+)
+
 type DisplayComponentType string
 
 const (

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -114,6 +114,26 @@ func setupUniversalRendererRouter(t *testing.T) *gin.Engine {
 						Crop:   &renderer.Action{ID: "crop", Label: "Crop", Type: renderer.ActionEmit, Icon: "crop"},
 						Remove: &renderer.Action{ID: "remove", Label: "Remove", Type: renderer.ActionAPI, API: &renderer.APIAction{Method: "POST", Endpoint: "/profiles/avatar/remove"}},
 					},
+					Cropper: &renderer.MediaCropperConfig{
+						Title:        "Adjust image",
+						Subtitle:     "Move and scale the image",
+						Hint:         "Drag or pinch to zoom",
+						ChooseLabel:  "Choose image",
+						CancelLabel:  "Cancel",
+						ConfirmLabel: "Use image",
+						CloseLabel:   "Close",
+						Accept:       "image/jpeg,image/png,image/webp",
+						Viewport: renderer.MediaCropperViewportConfig{
+							Shape:       renderer.MediaCropperViewportCircle,
+							AspectRatio: 1,
+						},
+						Output: renderer.MediaCropperOutputConfig{
+							Width:    512,
+							Height:   512,
+							MIMEType: "image/jpeg",
+							Quality:  0.92,
+						},
+					},
 				},
 			},
 		},
@@ -229,6 +249,10 @@ func TestUniversalRendererMetadata_DefrecResponse(t *testing.T) {
 	assert.Equal(t, "Crop", avatarField.Media.Actions.Crop.Label)
 	require.NotNil(t, avatarField.Media.Actions.Remove)
 	assert.Equal(t, "/profiles/avatar/remove", avatarField.Media.Actions.Remove.API.Endpoint)
+	require.NotNil(t, avatarField.Media.Cropper)
+	assert.Equal(t, renderer.MediaCropperViewportCircle, avatarField.Media.Cropper.Viewport.Shape)
+	assert.Equal(t, 512, avatarField.Media.Cropper.Output.Width)
+	assert.Equal(t, "Use image", avatarField.Media.Cropper.ConfirmLabel)
 }
 
 func TestUniversalRendererMetadata_FormSectionMediaGallery(t *testing.T) {
@@ -715,6 +739,9 @@ func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	assert.Equal(t, "ipfs://avatar", avatarField.Media.Item.Src)
 	require.NotNil(t, avatarField.Media.Actions)
 	assert.Equal(t, "Remove", avatarField.Media.Actions.Remove.Label)
+	require.NotNil(t, avatarField.Media.Cropper)
+	assert.Equal(t, 1.0, avatarField.Media.Cropper.Viewport.AspectRatio)
+	assert.Equal(t, "image/jpeg", avatarField.Media.Cropper.Output.MIMEType)
 }
 
 func TestUniversalRendererMetadata_ViewFormPageResponse(t *testing.T) {

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -130,7 +130,7 @@ func setupUniversalRendererRouter(t *testing.T) *gin.Engine {
 						Output: renderer.MediaCropperOutputConfig{
 							Width:    512,
 							Height:   512,
-							MIMEType: "image/jpeg",
+							MIMEType: renderer.MediaCropperOutputMIMETypeJPEG,
 							Quality:  0.92,
 						},
 					},
@@ -741,7 +741,7 @@ func TestUniversalRendererMetadata_ViewResponse(t *testing.T) {
 	assert.Equal(t, "Remove", avatarField.Media.Actions.Remove.Label)
 	require.NotNil(t, avatarField.Media.Cropper)
 	assert.Equal(t, 1.0, avatarField.Media.Cropper.Viewport.AspectRatio)
-	assert.Equal(t, "image/jpeg", avatarField.Media.Cropper.Output.MIMEType)
+	assert.Equal(t, renderer.MediaCropperOutputMIMETypeJPEG, avatarField.Media.Cropper.Output.MIMEType)
 }
 
 func TestUniversalRendererMetadata_ViewFormPageResponse(t *testing.T) {


### PR DESCRIPTION
## Изменения

- `FieldMediaConfig.Cropper` добавляет optional typed contract универсального image cropper;
- typed viewport shapes: `circle`, `rounded`, `rectangle`;
- output описывает размеры, MIME type и quality;
- cropper labels локализуются перед выдачей response;
- clone сохраняет независимую конфигурацию;
- startup validation отклоняет некорректный cropper;
- покрыты validation, clone/localization и JSON paths `defrec`/`view`;
- UniversalRenderer contract дополнен JSON и Go примерами.

## Проверка

- `go test ./...`