### PR TITLE
feat: complete typed field metadata contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,12 @@ BaseModule
   │     ├── Options/OptionsFunc
   │     ├── Check/DefaultFunc/Convert
   │     ├── Presentation  -> typed metadata визуального представления поля
-  │     ├── Media         -> typed metadata одиночного media-поля
-  │     └── Extra         -> legacy escape hatch
+  │     └── Media         -> typed metadata одиночного media-поля
   │
   ├── ListModuleAction
   │     ├── Filter/Search/Sort/SortDefault
   │     ├── Where/Permission/Auth
-  │     └── ExtraFunc -> legacy/dynamic app-specific metadata
-  │
-  ├── ViewModuleAction
-  │     └── Extra -> legacy custom view/detail metadata
+  │     └── VirtualFilters -> typed filters without a module field
   │
   ├── DefrecModuleAction
   │     └── schema for add/edit forms
@@ -93,7 +89,6 @@ BaseModule
 - ключи иконок;
 - typed metadata для UniversalRenderer через `BaseModule.Render`;
 - typed metadata одиночных полей через `ModuleField.Presentation` и специализированные typed blocks вроде `ModuleField.Media`;
-- legacy/application-specific metadata через `extra` только для старого кода. Новые возможности UniversalRenderer нужно добавлять в typed contract.
 
 Frontend должен получать готовую схему и рендерить ее своими универсальными компонентами. Frontend не должен угадывать, что поле `status` нужно показать badge, что `category_ids` является multiselect, а `owner_id` нужно скрыть от определенной роли.
 
@@ -107,18 +102,17 @@ Frontend должен получать готовую схему и рендер
 | Универсальная form/edit page | `BaseModule.Render.Form` |
 | Страница просмотра записи | `BaseModule.Render.Record` |
 | Рабочий grid с create/update/delete/status | `BaseModule.Render.ResourceGrid` |
-| Legacy/detail groups | `ViewModuleAction.Extra` |
 | Навигация и page routes | `BaseModule.Navigation` |
 | Динамический список колонок по роли | `ColumnsFunc` или `Fields`/`RoleContext` |
 | Динамические фильтры по роли | `FilterFunc` |
 | Права на строки | `Where`, `RoleWhere`, `BeforeAction`, `DataCheckRule` |
-| Options из базы | `OptionsFunc` или `Extra.Defrec.options_url` |
+| Options из базы | `OptionsFunc` или typed `OptionsSource` |
 
 Подробная спецификация UniversalRenderer: [docs/universal-renderer-contract.md](docs/universal-renderer-contract.md).
 
 ### Typed field metadata
 
-Для новых UI-возможностей нельзя заставлять frontend угадывать поведение по имени поля и нельзя добавлять ad-hoc `extra`. Если поле требует явного renderer contract, используйте typed поля `ModuleField`.
+Для новых UI-возможностей нельзя заставлять frontend угадывать поведение по имени поля и нельзя добавлять ad-hoc maps. Если поле требует явного renderer contract, используйте typed поля `ModuleField`.
 
 Пример одиночного media-поля:
 
@@ -214,85 +208,6 @@ renderer.FormSection{
 `FieldMatrixColumnsFour`. Для table используется отдельная typed структура с
 heads, rows и cells; полный contract и правила локализации приведены в
 [docs/universal-renderer-contract.md](docs/universal-renderer-contract.md).
-
-### Extra.Defrec
-
-`Extra.Defrec` является legacy-механизмом. Его можно использовать только для существующих модулей или временной совместимости, пока нужный UI contract еще не типизирован.
-
-```go
-{
-    Column:   table.CatalogItems.CategoryIDs,
-    Title:    "catalog_items.fields.categories",
-    Type:     fields.ModuleFieldTypeArray,
-    FormType: fields.ModuleFieldFormTypeMultiselect,
-    OptionsFunc: categoryOptions,
-    Extra: &fields.FieldExtra{
-        Defrec: map[string]interface{}{
-            "visual_kind": "select",
-            "multiple":    true,
-            "searchable":  true,
-            "icon":        "tag",
-            "section":     "general",
-            "group":       "main",
-            "order":       30,
-            "layout":      "full",
-            "placeholder": "ui.search",
-        },
-    },
-}
-```
-
-Рекомендуемые ключи:
-
-| Ключ | Назначение |
-|---|---|
-| `visual_kind` | Универсальный тип: `input`, `textarea`, `select`, `location`, `radio`, `switch`, `matrix`, `media`, `collection`. |
-| `section` | ID секции страницы. |
-| `group` | ID группы внутри секции. |
-| `order` | Порядок поля. |
-| `layout` | `full`, `grid`, `inline`, `compact`, `matrix`. |
-| `icon` | Ключ иконки из реестра. |
-| `hint` | Ключ перевода подсказки. |
-| `placeholder` | Ключ перевода placeholder. |
-| `multiple` | Множественный выбор. |
-| `searchable` | Поиск внутри select. |
-| `options_url` | Endpoint для server-driven options. |
-| `options_params` | Параметры endpoint options. |
-| `prefix` / `suffix` | Внутренний prefix/suffix поля. |
-| `min` / `max` / `step` | Числовые ограничения. |
-
-Нельзя добавлять поле так, чтобы frontend узнавал его по имени и вручную выбирал компонент.
-
-### Extra.View
-
-`Extra.View` описывает отображение значения в list/detail/card view.
-
-```go
-Extra: &fields.FieldExtra{
-    View: map[string]interface{}{
-        "display": map[string]interface{}{
-            "type":   "badge",
-            "tone":   "glass-cyan",
-            "marker": false,
-            "option": "status",
-        },
-    },
-}
-```
-
-Типовые `display`:
-
-- `text`;
-- `badge`;
-- `chips`;
-- `boolean`;
-- `code`;
-- `json`;
-- `masked`;
-- `media`;
-- `money`;
-- `date`;
-- `location`.
 
 ### Typed Render и страницы списков
 
@@ -425,7 +340,7 @@ Frontend строит стандартные list/defrec/action endpoints из `
 
 ### Resource grid metadata
 
-Для страниц типа “управление сущностями” модуль описывает typed `BaseModule.Render.ResourceGrid`. `ExtraFunc` и `extra.resource_grid_page` остаются legacy compatibility, но не являются canonical способом для новых модулей.
+Для страниц типа “управление сущностями” модуль описывает typed `BaseModule.Render.ResourceGrid`.
 
 Для одного list route `Render.List` и `Render.ResourceGrid` взаимоисключающие. Если нужны обе страницы, создавайте отдельный route/module; request-generator валидирует это при старте.
 
@@ -489,7 +404,7 @@ Render: renderer.Universal{
 - [docs/specification-process.md](docs/specification-process.md) - процесс предложения, принятия, статусов и версионирования спецификаций.
 - [docs/specification-goals.md](docs/specification-goals.md) - общие цели, одинаковые для всех спецификаций.
 
-README содержит только обзор request-generator. Полная схема typed `BaseModule.Render`, `renderer`, `field.extra`, `list_page`, `resource_grid_page`, `form_page`, `record_page`, legacy `extra`, actions, conditions, filters и renderer registry описывается в спецификации.
+README содержит только обзор request-generator. Полная схема typed `BaseModule.Render`, `renderer`, `list_page`, `resource_grid_page`, `form_page`, `record_page`, actions, conditions, filters и renderer registry описывается в спецификации.
 
 ### Правила совместимости с универсальным frontend
 
@@ -497,7 +412,7 @@ PR в модуле считается неготовым, если:
 
 - новое поле требует `if field.key == ...` на frontend;
 - options захардкожены во frontend, хотя зависят от базы или роли;
-- UniversalRenderer metadata добавляется через legacy `ExtraFunc`, хотя уже есть typed `BaseModule.Render`;
+- UniversalRenderer metadata добавляется через произвольный map вместо typed `BaseModule.Render`;
 - действие скрывается только на frontend, но API все равно разрешает его выполнить;
 - фильтр есть в UI, но не применяется в `Filter`/`Where`;
 - переводимый текст отдается literal-строкой вместо ключа;
@@ -803,24 +718,10 @@ actions.ListModuleAction{
     Maxsize:     1000,
     Join:        []actions.ModuleActionJoin{...},
     Where:       func(c *gin.Context) pg.BoolExpression { ... },
-    ExtraFunc:   func(c *gin.Context) interface{} { ... }, // legacy/dynamic app-specific extra
 }
 ```
 
 **Обязательные поля:** `Label`, `Columns`.
-
-**`ExtraFunc`** вызывается при каждом запросе; результат включается в ответ как поле `extra`. Используется для legacy/dynamic app-specific данных, зависящих от роли или параметров запроса. UniversalRenderer page metadata для новых модулей описывайте через `BaseModule.Render`.
-
-```go
-ExtraFunc: func(c *gin.Context) interface{} {
-    return map[string]interface{}{
-        "pills": []map[string]interface{}{
-            {"label": "All"},
-            {"label": "Verified", "key": "verify_status", "val": "verified"},
-        },
-    }
-},
-```
 
 **`FilterFunc`** заменяет/дополняет статический `Filter` — используется когда набор доступных фильтров зависит от роли:
 
@@ -989,11 +890,10 @@ allModules := []*module.BaseModule{
 - `UpdateModuleAction.Where` и `DeleteModuleAction.Where` не позволяют менять чужие записи.
 - `AddModuleAction.Columns` содержит только поля, которые клиент имеет право прислать.
 - Системные поля задаются через `DefaultFunc`, а не принимаются от клиента.
-- Все options приходят из `Options`, `OptionsFunc` или `options_url`.
+- Все options приходят из `Options`, `OptionsFunc` или typed `OptionsSource`.
 - Все поля формы имеют `Title` как ключ перевода.
-- Новые UI-возможности описаны typed metadata (`Presentation`, `Media` и т.п.), а не ad-hoc `Extra`.
-- `Extra.Defrec` и `Extra.View` используются только для legacy-совместимости.
-- UniversalRenderer page metadata описана через typed `BaseModule.Render`, а не через legacy `ExtraFunc`.
+- Новые UI-возможности описаны typed metadata (`Presentation`, `Media` и т.п.), а не ad-hoc maps.
+- UniversalRenderer page metadata описана через typed `BaseModule.Render`.
 - Действия, зависящие от состояния записи, описаны через `visible_if`/`hidden_if`.
 - Все ограничения из `visible_if` продублированы серверной проверкой.
 - Новые фильтры реально работают на сервере.

--- a/actions/defrec_module_action.go
+++ b/actions/defrec_module_action.go
@@ -15,7 +15,6 @@ type DefrecModuleAction struct {
 	Fields       []RoleContext     `json:"-"`
 	BeforeAction func(c *gin.Context) error
 	AfterAction  func(c *gin.Context)
-	ExtraFunc    func(c *gin.Context) interface{}
 	Widget       *WidgetConfig `json:"widget,omitempty"`
 }
 

--- a/actions/list_module_action.go
+++ b/actions/list_module_action.go
@@ -8,30 +8,35 @@ import (
 
 type ListModuleAction struct {
 	ModuleAction
-	BeforeAction         func(c *gin.Context) error
-	AfterAction          func(c *gin.Context)
-	Label                string                                 `json:"label"`
-	Labels               map[string]string                      `json:"-"`
-	Columns              []pg.Column                            `json:"-"`
-	ColumnsFunc          func(c *gin.Context) []pg.Column       `json:"-"`
-	Size                 int64                                  `json:"size,omitempty"`
-	Maxsize              int64                                  `json:"maxsize"`
-	Permission           []Role                                 `json:"permission"`
-	Auth                 bool                                   `json:"auth"`
-	Join                 []ModuleActionJoin                     `json:"join"`
-	Where                func(c *gin.Context) pg.BoolExpression `json:"-"`
-	Extra                interface{}                            `json:"extra"`
-	ExtraFunc            func(c *gin.Context) interface{}       `json:"-"`
-	Search               []pg.Column                            `json:"-"`
-	Filter               []pg.Column                            `json:"-"`
-	FilterFunc           func(c *gin.Context) []pg.Column       `json:"-"`
-	ExtraFilters         []fields.ModuleFilterField             `json:"-"`
-	Sort                 []pg.Column                            `json:"-"`
-	SortDefault          pg.Column                              `json:"-"`
-	SortDefaultDirection SortDirection                          `json:"-"`
-	SortDefaultFunc      func(c *gin.Context) *SortOption       `json:"-"`
-	Fields               []RoleContext                          `json:"-"`
-	Widget               *WidgetConfig                          `json:"widget,omitempty"`
+	BeforeAction func(c *gin.Context) error
+	AfterAction  func(c *gin.Context)
+	Label        string                                 `json:"label"`
+	Labels       map[string]string                      `json:"-"`
+	Columns      []pg.Column                            `json:"-"`
+	ColumnsFunc  func(c *gin.Context) []pg.Column       `json:"-"`
+	Size         int64                                  `json:"size,omitempty"`
+	Maxsize      int64                                  `json:"maxsize"`
+	Permission   []Role                                 `json:"permission"`
+	Auth         bool                                   `json:"auth"`
+	Join         []ModuleActionJoin                     `json:"join"`
+	Where        func(c *gin.Context) pg.BoolExpression `json:"-"`
+	Extra        interface{}                            `json:"extra"`
+	ExtraFunc    func(c *gin.Context) interface{}       `json:"-"`
+	Search       []pg.Column                            `json:"-"`
+	Filter       []pg.Column                            `json:"-"`
+	FilterFunc   func(c *gin.Context) []pg.Column       `json:"-"`
+	// VirtualFilters declares filters that are not backed by a module field.
+	// Their UI metadata is returned together with regular filters.
+	VirtualFilters []fields.ModuleFilterField `json:"-"`
+	// ExtraFilters is retained for existing modules. New modules should use
+	// VirtualFilters and typed ModuleFilterField metadata instead.
+	ExtraFilters         []fields.ModuleFilterField       `json:"-"`
+	Sort                 []pg.Column                      `json:"-"`
+	SortDefault          pg.Column                        `json:"-"`
+	SortDefaultDirection SortDirection                    `json:"-"`
+	SortDefaultFunc      func(c *gin.Context) *SortOption `json:"-"`
+	Fields               []RoleContext                    `json:"-"`
+	Widget               *WidgetConfig                    `json:"widget,omitempty"`
 }
 
 func (action ListModuleAction) Action() ModuleActionName {

--- a/actions/list_module_action.go
+++ b/actions/list_module_action.go
@@ -20,17 +20,12 @@ type ListModuleAction struct {
 	Auth         bool                                   `json:"auth"`
 	Join         []ModuleActionJoin                     `json:"join"`
 	Where        func(c *gin.Context) pg.BoolExpression `json:"-"`
-	Extra        interface{}                            `json:"extra"`
-	ExtraFunc    func(c *gin.Context) interface{}       `json:"-"`
 	Search       []pg.Column                            `json:"-"`
 	Filter       []pg.Column                            `json:"-"`
 	FilterFunc   func(c *gin.Context) []pg.Column       `json:"-"`
 	// VirtualFilters declares filters that are not backed by a module field.
 	// Their UI metadata is returned together with regular filters.
-	VirtualFilters []fields.ModuleFilterField `json:"-"`
-	// ExtraFilters is retained for existing modules. New modules should use
-	// VirtualFilters and typed ModuleFilterField metadata instead.
-	ExtraFilters         []fields.ModuleFilterField       `json:"-"`
+	VirtualFilters       []fields.ModuleFilterField       `json:"-"`
 	Sort                 []pg.Column                      `json:"-"`
 	SortDefault          pg.Column                        `json:"-"`
 	SortDefaultDirection SortDirection                    `json:"-"`

--- a/actions/view_module_action.go
+++ b/actions/view_module_action.go
@@ -18,8 +18,6 @@ type ViewModuleAction struct {
 	Auth         bool                             `json:"auth"`
 	Join         []ModuleActionJoin               `json:"join"`
 	By           []pg.Column                      `json:"-"`
-	Extra        interface{}                      `json:"extra"`
-	ExtraFunc    func(c *gin.Context) interface{} `json:"-"`
 	Fields       []RoleContext                    `json:"-"`
 	Widget       *WidgetConfig                    `json:"widget,omitempty"`
 	PageType     renderer.PageType                `json:"page_type,omitempty"`

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -25,21 +25,13 @@ flowchart TD
     B --> D["heads / filters / sort"]
     B --> E["renderer identity"]
     B --> T["typed page metadata"]
-    B --> X["legacy response.extra"]
 
-    C --> F["field.extra"]
     C --> Y["field.presentation / field.media"]
-    D --> F
 
     T --> G["list_page"]
     T --> H["resource_grid_page"]
     T --> I["form_page"]
     T --> J["record_page"]
-    X --> K["legacy view_groups / app extra"]
-
-    F --> L["form metadata"]
-    F --> M["list metadata"]
-    F --> N["view metadata"]
     Y --> Q
     Y --> R
 
@@ -47,16 +39,11 @@ flowchart TD
     H --> P["Resource grid renderer"]
     I --> Q["Form renderer"]
     J --> R["Record renderer"]
-    K --> S["Admin detail renderer"]
-    L --> Q
-    M --> O
-    N --> R
-    N --> S
 ```
 
 ## Где Лежит Metadata
 
-UniversalRenderer читает canonical metadata из typed response fields. `response.extra` и `field.extra` остаются legacy/deprecated escape hatch для старых модулей и application-specific compatibility. Новые UI-возможности должны добавляться в typed contract генератора, а не в ad-hoc `extra`.
+UniversalRenderer читает metadata только из typed response fields. Новые UI-возможности добавляются в typed contract генератора, а не в ad-hoc maps.
 
 Каждый response с typed page metadata должен содержать renderer identity:
 
@@ -106,7 +93,7 @@ RenderFunc: func(c *gin.Context, base renderer.Universal) (renderer.Universal, e
 }
 ```
 
-`Render` задает базовую статическую схему. `RenderFunc` является optional typed runtime override/merge и вызывается request-generator через `RenderFor(c)` перед построением `/api/config`, list, defrec и view responses. В `RenderFunc` передается deep clone базового `Render`, поэтому producer module может безопасно менять pointer structs, slices, maps и стандартные JSON-like значения внутри `interface{}` (`map[string]interface{}`, `[]interface{}`, `map[string]string`, `[]string` и т.п.) без протекания state в следующие запросы. Произвольные custom objects внутри `interface{}` не клонируются и остаются ответственностью producer module. Результат `RenderFunc` остается `renderer.Universal` и валидируется через `Validate()` уже после runtime изменений. Legacy `ExtraFunc` не должен использоваться для canonical UniversalRenderer metadata.
+`Render` задает базовую статическую схему. `RenderFunc` является optional typed runtime override/merge и вызывается request-generator через `RenderFor(c)` перед построением `/api/config`, list, defrec и view responses. В `RenderFunc` передается deep clone базового `Render`, поэтому producer module может безопасно менять pointer structs, slices, maps и стандартные JSON-like значения внутри `interface{}` (`map[string]interface{}`, `[]interface{}`, `map[string]string`, `[]string` и т.п.) без протекания state в следующие запросы. Произвольные custom objects внутри `interface{}` не клонируются и остаются ответственностью producer module. Результат `RenderFunc` остается `renderer.Universal` и валидируется через `Validate()` уже после runtime изменений.
 
 Closed enums должны использовать typed constants из package `renderer`. `map[string]interface{}` допустим только в явно typed runtime/transport полях (`Context`, `Payload`, `Query`, route query и т.п.), где содержимое является данными запроса или состоянием выполнения, а не схемой UI. Если producer-у нужен новый UI metadata block, он должен быть добавлен в typed renderer contract, а не передан через ad-hoc map.
 
@@ -191,7 +178,6 @@ Closed enums должны использовать typed constants из package 
 | `fields[field].section` | Базовая секция поля. |
 | `fields[field].presentation` | Typed metadata визуального представления одиночного поля. |
 | `fields[field].media` | Typed media metadata одиночного поля, если поле является media value. |
-| `fields[field].extra` | Legacy metadata формы. Не использовать для новых UniversalRenderer capabilities. |
 | `renderer` | Renderer identity/version, добавляется request-generator. |
 | `form_page` | Typed metadata универсальной form/edit страницы из `BaseModule.Render.Form`. |
 
@@ -317,7 +303,6 @@ Generator проверяет closed `type`, применимость `list`/`tab
 | `item[field].options` | Options для значения. |
 | `item[field].presentation` | Typed metadata визуального представления одиночного поля. |
 | `item[field].media` | Typed media metadata одиночного поля, если поле является media value. |
-| `item[field].extra` | Legacy metadata отображения поля. Не использовать для новых UniversalRenderer capabilities. |
 | `renderer` | Renderer identity/version, добавляется request-generator. |
 | `record_page` | Typed metadata страницы просмотра из `BaseModule.Render.Record`. |
 
@@ -743,7 +728,7 @@ Media: &renderer.FieldMediaConfig{
 }
 ```
 
-`list_page.extra` не используется. Если producer-у не хватает поля для renderer metadata, поле нужно добавить в typed contract генератора и в документацию.
+Если producer-у не хватает поля для renderer metadata, поле нужно добавить в typed contract генератора и в документацию.
 
 ### Design Tokens
 
@@ -1186,29 +1171,7 @@ Generator behavior:
 }
 ```
 
-`record_page.sections[].components` и `record_page.sections[].stack` являются canonical metadata для display renderer. Не кладите layout/display metadata в `section.extra`: такого поля нет в UniversalRenderer contract.
-
-## View Groups
-
-`view_groups` является legacy/application-specific metadata для detail view. Для новых typed modules предпочтительно описывать группировку через `record_page.sections`.
-
-```json
-{
-  "view_groups": [
-    {
-      "key": "summary",
-      "title": "admin_module.detail_group_summary",
-      "fields": ["id", "name", "status"]
-    },
-    {
-      "key": "conditional",
-      "title": "admin_module.detail_group_content",
-      "fields": ["description"],
-      "visible_when": {"field": "type", "in": ["public"]}
-    }
-  ]
-}
-```
+`record_page.sections[].components` и `record_page.sections[].stack` являются canonical metadata для display renderer.
 
 ## Renderer Registry
 
@@ -1309,16 +1272,8 @@ Examples of application-specific values:
 - resources: `/api/icons`, `/api/media_assets`, `/api/media_links`;
 - renderer-specific visual variants: `wash-brand-secondary`, `qo-panel`, `glass-cyan`.
 
-## Compatibility Notes
+## Совместимость
 
-Текущий webapp поддерживает legacy metadata, но новые producer-сервисы должны использовать canonical shapes выше.
-
-Legacy forms:
-
-- UniversalRenderer metadata внутри `response.extra.*`, например `extra.list_page`, `extra.form_page`, `extra.record_page`, `extra.resource_grid_page`;
-- application extension fields внутри top-level page `extra` не допускаются в UniversalRenderer contract;
-- `display` как string вместо object, например `"display": "badge"`;
-- `{"path": "...", "not": true}` вместо `{"not": {"path": "...", "truthy": true}}`;
-- `external: true` action without explicit `type`;
-
-`response.extra` остается deprecated escape hatch для старых модулей и application-specific данных вне UniversalRenderer. Новые producer modules должны описывать UniversalRenderer metadata через typed `BaseModule.Render renderer.Universal`, а request-generator должен отдавать canonical top-level `renderer` + page metadata fields.
+UniversalRenderer использует только canonical typed shapes этого документа. Модуль,
+которому не хватает metadata для отображения, должен расширить typed contract,
+обновить документацию и добавить response-contract тест.

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -125,10 +125,7 @@ Closed enums должны использовать typed constants из package 
   "rows": [],
   "heads": {
     "status": {
-      "title": "Status",
-      "extra": {
-        "display": {"type": "badge"}
-      }
+      "title": "Status"
     }
   },
   "filters": {
@@ -136,13 +133,7 @@ Closed enums должны использовать typed constants из package 
       "title": "Status",
       "type": "string",
       "form_type": "select",
-      "options": [],
-      "group": "main",
-      "order": 10,
-      "extra": {
-        "filter_group": "main",
-        "filter_order": 10
-      }
+      "options": []
     }
   },
   "sort": [
@@ -156,8 +147,8 @@ Closed enums должны использовать typed constants из package 
 | Path | Назначение |
 |------|------------|
 | `rows` | Данные строк. |
-| `heads[field].extra` | Metadata отображения колонки. |
-| `filters[field].extra` | Metadata UI фильтра. |
+| `heads[field]` | Локализованный заголовок колонки. Визуальное представление поля задается typed `presentation`. |
+| `filters[field]` | Тип, form type, options и typed `options_source` фильтра. Расположение задается в `list_page.filters`. |
 | `sort[].value` | Значение сортировки в формате `field:asc` или `field:desc`. |
 | `count`, `size`, `page` | Server-side pagination. |
 | `renderer` | Renderer identity/version, добавляется request-generator. |
@@ -438,6 +429,11 @@ Typed field metadata нужна для одиночных полей, где б�
 | `presentation.style` | Optional style token, если renderer поддерживает несколько визуальных стилей. |
 | `presentation.size` | Media size token: `thumb`, `card`, `hero`. |
 | `presentation.ratio` | Media ratio token: `square`, `portrait`, `landscape`, `wide`. |
+| `presentation.prefix`, `presentation.suffix` | Локализуемый текст до или после значения. |
+| `presentation.hint`, `presentation.description` | Локализуемые подсказка и описание поля. |
+| `presentation.rows` | Высота многострочного control. |
+| `presentation.visible_if` | Typed условие видимости через `renderer.Condition`. |
+| `presentation.tone_by_value` | Маппинг стабильного значения enum на theme tone. |
 
 ### Option Controls
 
@@ -466,12 +462,11 @@ Typed field metadata нужна для одиночных полей, где б�
 request-generator до выдачи JSON. `icon` является стабильным именем иконки и
 не локализуется.
 
-В list filters generator передает `form_type` и стандартные options
-(`value`, локализованный `label`, `icon`), но не передает
-`presentation.renderer`. Поэтому list filter использует свой базовый control
-по `form_type`. Если для filter понадобится специализированный control, он
-должен получить отдельный typed contract (`FilterPresentation`), а не
-неявно переиспользовать field presentation.
+В list filters generator передает `form_type`, стандартные options
+(`value`, локализованный `label`, `icon`) и `options_source`, если варианты
+подгружаются асинхронно. Расположение и порядок фильтров описываются только в
+`list_page.filters` (`primary`, `secondary`, `more`, `nested`), а не в metadata
+самого поля.
 
 ```go
 {
@@ -499,6 +494,27 @@ request-generator до выдачи JSON. `icon` является стабиль
     },
 },
 ```
+
+### Field Options Source
+
+`options_source` задает typed источник вариантов для `select` и
+`multiselect`. Он одинаково сериализуется в `list.filters`, `defrec.fields` и
+`view.item`.
+
+```json
+{
+  "options_source": {
+    "endpoint": "/api/locations",
+    "query": [{"key": "active", "value": "true"}],
+    "search_param": "search",
+    "mode": "tree"
+  }
+}
+```
+
+`endpoint` обязателен. `mode` допускает `list` или `tree`; при отсутствии поля
+frontend использует обычный список. `query` содержит статические параметры
+запроса, `search_param` задает имя параметра поиска.
 
 ### Field Media
 
@@ -676,97 +692,6 @@ Media: &renderer.FieldMediaConfig{
 }
 ```
 
-### Legacy Extra
-
-`extra` пока остается в трех контекстах для старых модулей:
-
-| Контекст | Где задается producer-side | Где приходит frontend |
-|----------|-----------------------------|-----------------------|
-| Form | `ModuleField.Extra.Defrec` | `defrec.fields[field].extra` |
-| List | `ModuleField.Extra.List` | `list.heads[field].extra`, `list.filters[field].extra` |
-| View | `ModuleField.Extra.View` | `view.item[field].extra` |
-
-Для нового UniversalRenderer metadata `extra` использовать нельзя. Если нужной структуры нет, надо добавить typed поле в `renderer` package, тест response contract и обновить эту спецификацию.
-
-Legacy shape:
-
-```json
-{
-  "extra": {
-    "visual_kind": "select",
-    "display": {
-      "type": "badge",
-      "tone": "cyan"
-    },
-    "section": "main",
-    "group": "general",
-    "order": 20,
-    "layout": "full",
-    "icon": "status",
-    "hint": "entity.fields.status_hint",
-    "placeholder": "entity.fields.status_placeholder",
-    "multiple": false,
-    "searchable": true,
-    "options_url": "/options/statuses",
-    "options_params": {
-      "scope": "active"
-    }
-  }
-}
-```
-
-### Form Metadata
-
-| Key | Назначение |
-|-----|------------|
-| `visual_kind` | UI control: `input`, `textarea`, `select`, `location`, `radio`, `switch`, `matrix`, `media`, `collection`. |
-| `section` | ID секции формы. |
-| `group` | ID группы внутри секции. |
-| `order` | Порядок поля. |
-| `layout` | `full`, `grid`, `inline`, `compact`, `matrix`. |
-| `icon` | Icon registry key. |
-| `hint` | Translation key подсказки. |
-| `placeholder` | Translation key placeholder. |
-| `multiple` | Множественный выбор. |
-| `searchable` | Поиск внутри control. |
-| `options_url` | Server-driven options endpoint. |
-| `options_params` | Параметры для `options_url`. |
-| `prefix` / `suffix` | Визуальный prefix/suffix. |
-| `min` / `max` / `step` | UI-ограничения числового ввода. |
-
-### Display Metadata
-
-`display` всегда должен быть object.
-
-```json
-{
-  "display": {
-    "type": "badge",
-    "tone": "cyan",
-    "tones": {
-      "active": "success",
-      "blocked": "danger"
-    }
-  }
-}
-```
-
-Поддерживаемые `display.type`:
-
-| Type | Назначение |
-|------|------------|
-| `text` | Обычный текст. |
-| `badge` | Статус, роль, тип. |
-| `boolean` | Boolean indicator. |
-| `code` | ID/key/code. |
-| `json` | Pretty JSON. |
-| `masked` | Token/secret/IP. |
-| `chips` | Массивы и tags. |
-| `media` | Media preview. |
-| `money` | Money value. |
-| `date` | Date/time. |
-| `location` | Location value. |
-
 ## List Contract
 
 `list_page` описывает список целиком. В Go API это `renderer.Universal.List`.
@@ -866,8 +791,9 @@ Renderer-specific enum values должны быть описаны в разде
 Filters являются server-driven:
 
 - если фильтр есть в `filters[field]`, producer должен применять его server-side;
-- `filters[field].group` и `filters[field].order` задают группировку и порядок;
-- `filters[field].extra.filter_group` и `filters[field].extra.filter_order` могут переопределять группировку и порядок;
+- расположение и порядок фильтров определяет `list_page.filters` через `primary`, `secondary`, `more` и `nested`;
+- виртуальные фильтры, не связанные с `ModuleField`, задаются typed `ListModuleAction.VirtualFilters`;
+- range presets задаются в `list_page.filters.range_presets` и содержат `field`, локализуемый `label`, `min`, `max`;
 - selected values передаются в query как `filter[field]=value`;
 - multi-value filters передаются повторением query value или согласованным serialized array;
 - search query передается отдельным search parameter, если list action поддерживает search;
@@ -1344,15 +1270,14 @@ Media metadata should reference fields, not hardcoded rendering branches.
   ],
   "heads": {
     "name": {"title": "Name"},
-    "status": {"title": "Status", "extra": {"display": {"type": "badge"}}}
+    "status": {"title": "Status"}
   },
   "filters": {
     "status": {
       "title": "Status",
       "type": "string",
       "form_type": "select",
-      "options": [{"value": "active", "label": "Active"}],
-      "extra": {"filter_group": "main", "filter_order": 10}
+      "options": [{"value": "active", "label": "Active"}]
     }
   },
   "sort": [

--- a/field_options_source_validation_test.go
+++ b/field_options_source_validation_test.go
@@ -1,0 +1,34 @@
+package module
+
+import (
+	"testing"
+
+	"github.com/darkrain/request-generator/fields"
+	"github.com/gin-gonic/gin"
+	"github.com/go-jet/jet/v2/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunRejectsInvalidFieldOptionsSource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	id := postgres.IntegerColumn("id")
+	status := postgres.StringColumn("status")
+	table := postgres.NewTable("public", "option_items", "", id, status)
+	base := &BaseModule{
+		Name:       "option-items",
+		Table:      table,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{{
+			Column:        status,
+			OptionsSource: &fields.FieldOptionsSource{Mode: fields.FieldOptionsSourceModeTree},
+		}},
+	}
+	engine := gin.New()
+	group := engine.Group("")
+	generator := NewGenerator(nil, *group, []*BaseModule{base}, nil, nil)
+
+	require.PanicsWithValue(t,
+		`invalid field options source in module option-items: field "status": field options source endpoint is required`,
+		func() { generator.Run() },
+	)
+}

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -97,13 +97,6 @@ type RoleOptions struct {
 	Options []ModuleFieldOptions
 }
 
-// FieldExtra holds per-context extra metadata for a field.
-type FieldExtra struct {
-	View   interface{} `json:"-"`
-	List   interface{} `json:"-"`
-	Defrec interface{} `json:"-"`
-}
-
 type ModuleField struct {
 	Column           pg.Column                                       `json:"-"`
 	SelectExpression pg.Projection                                   `json:"-"`
@@ -115,10 +108,8 @@ type ModuleField struct {
 	AllLabel         string                                          `json:"all_label,omitempty"`
 	Presentation     *renderer.FieldPresentation                     `json:"presentation,omitempty"`
 	Media            *renderer.FieldMediaConfig                      `json:"media,omitempty"`
-	Extra            *FieldExtra                                     `json:"-"`
 	Options          []ModuleFieldOptions                            `json:"options,omitempty"`
 	OptionsSource    *FieldOptionsSource                             `json:"options_source,omitempty"`
-	OptionsURL       string                                          `json:"options_url,omitempty"`
 	OptionsFunc      func(context *gin.Context) []ModuleFieldOptions `json:"-"`
 	RoleOptions      []RoleOptions                                   `json:"-"`
 	Check            []CheckRules                                    `json:"-"`
@@ -130,8 +121,6 @@ type ModuleField struct {
 	Convert              func(c *gin.Context, value interface{}) (interface{}, error) `json:"-"`
 	ResultValueConverter func(value interface{}) interface{}                          `json:"-"`
 	Translatable         bool                                                         `json:"-"`
-	Group                string                                                       `json:"-"`
-	Order                int                                                          `json:"-"`
 	FieldName            string                                                       `json:"-"`
 	FilterCondition      func(c *gin.Context) bool                                    `json:"-"`
 	Roles                []string                                                     `json:"roles,omitempty"`
@@ -195,9 +184,6 @@ type ModuleFilterField struct {
 	OptionsSource   *FieldOptionsSource                                          `json:"options_source,omitempty"`
 	Check           []CheckRules                                                 `json:"-"`
 	Convert         func(c *gin.Context, value interface{}) (interface{}, error) `json:"-"`
-	Group           string                                                       `json:"group,omitempty"`
-	Order           int                                                          `json:"order,omitempty"`
-	Extra           interface{}                                                  `json:"extra,omitempty"`
 	FilterCondition func(c *gin.Context) bool                                    `json:"-"`
 }
 

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -117,6 +117,7 @@ type ModuleField struct {
 	Media            *renderer.FieldMediaConfig                      `json:"media,omitempty"`
 	Extra            *FieldExtra                                     `json:"-"`
 	Options          []ModuleFieldOptions                            `json:"options,omitempty"`
+	OptionsSource    *FieldOptionsSource                             `json:"options_source,omitempty"`
 	OptionsURL       string                                          `json:"options_url,omitempty"`
 	OptionsFunc      func(context *gin.Context) []ModuleFieldOptions `json:"-"`
 	RoleOptions      []RoleOptions                                   `json:"-"`
@@ -191,6 +192,7 @@ type ModuleFilterField struct {
 	Example         string                                                       `json:"example,omitempty"`
 	AllLabel        string                                                       `json:"all_label,omitempty"`
 	Options         []ModuleFieldOptions                                         `json:"options,omitempty"`
+	OptionsSource   *FieldOptionsSource                                          `json:"options_source,omitempty"`
 	Check           []CheckRules                                                 `json:"-"`
 	Convert         func(c *gin.Context, value interface{}) (interface{}, error) `json:"-"`
 	Group           string                                                       `json:"group,omitempty"`
@@ -211,6 +213,45 @@ type ModuleFieldOptions struct {
 	Label  string            `json:"label"`
 	Icon   string            `json:"icon,omitempty"`
 	Labels map[string]string `json:"-"`
+}
+
+type FieldOptionsSourceMode string
+
+const (
+	FieldOptionsSourceModeList FieldOptionsSourceMode = "list"
+	FieldOptionsSourceModeTree FieldOptionsSourceMode = "tree"
+)
+
+type FieldOptionsQueryParam struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type FieldOptionsSource struct {
+	Endpoint    string                   `json:"endpoint"`
+	Query       []FieldOptionsQueryParam `json:"query,omitempty"`
+	SearchParam string                   `json:"search_param,omitempty"`
+	Mode        FieldOptionsSourceMode   `json:"mode,omitempty"`
+}
+
+func (source *FieldOptionsSource) Validate() error {
+	if source == nil {
+		return nil
+	}
+	if source.Endpoint == "" {
+		return fmt.Errorf("field options source endpoint is required")
+	}
+	switch source.Mode {
+	case "", FieldOptionsSourceModeList, FieldOptionsSourceModeTree:
+	default:
+		return fmt.Errorf("field options source has unsupported mode %q", source.Mode)
+	}
+	for _, param := range source.Query {
+		if param.Key == "" {
+			return fmt.Errorf("field options source query key is required")
+		}
+	}
+	return nil
 }
 
 type CheckRules interface {

--- a/generator.go
+++ b/generator.go
@@ -565,10 +565,7 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 					filter[realField.ColumnName()] = filterField
 				}
 			}
-			virtualFilters := make([]fields.ModuleFilterField, 0, len(action.VirtualFilters)+len(action.ExtraFilters))
-			virtualFilters = append(virtualFilters, action.VirtualFilters...)
-			virtualFilters = append(virtualFilters, action.ExtraFilters...)
-			for _, ef := range virtualFilters {
+			for _, ef := range action.VirtualFilters {
 				if ef.FilterCondition != nil && !ef.FilterCondition(c) {
 					continue
 				}
@@ -628,7 +625,6 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			Renderer         *renderer.Identity                  `json:"renderer,omitempty"`
 			ListPage         *renderer.ListPage                  `json:"list_page,omitempty"`
 			ResourceGridPage *renderer.ResourceGridPage          `json:"resource_grid_page,omitempty"`
-			Extra            interface{}                         `json:"extra,omitempty"`
 			Rows             []interface{}                       `json:"rows"`
 			Heads            map[string]interface{}              `json:"heads"`
 			Filters          map[string]fields.ModuleFilterField `json:"filters,omitempty"`
@@ -640,16 +636,10 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			Renderer:         render.ListIdentity(),
 			ListPage:         render.List,
 			ResourceGridPage: render.ResourceGrid,
-			Extra: func() interface{} {
-				if action.ExtraFunc != nil {
-					return action.ExtraFunc(c)
-				}
-				return action.Extra
-			}(),
-			Rows:    results,
-			Heads:   heads,
-			Filters: filter,
-			Sort:    sortOptions,
+			Rows:             results,
+			Heads:            heads,
+			Filters:          filter,
+			Sort:             sortOptions,
 		}
 
 		if isCSV == 0 {
@@ -887,17 +877,13 @@ func (generator *Generator) actionDefrec(module *BaseModule) func(c *gin.Context
 			output = append(output, field)
 		}
 
-		var extra interface{}
-		if module.Defrec.ExtraFunc != nil {
-			extra = module.Defrec.ExtraFunc(c)
-		}
 		render, err := module.RenderFor(c)
 		if err != nil {
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
 		render = generator.localizeRenderer(lang, render)
-		defrecResponse := response.NewDefrecResponse(extra, output)
+		defrecResponse := response.NewDefrecResponse(output)
 		defrecResponse.AttachRender(render)
 		response.Response(l, c, defrecResponse)
 
@@ -1046,13 +1032,6 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 			item[fieldKey] = fieldItem
 		}
 
-		var extra interface{}
-		if action.ExtraFunc != nil {
-			extra = action.ExtraFunc(c)
-		} else {
-			extra = action.Extra
-		}
-
 		render, err := module.RenderFor(c)
 		if err != nil {
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
@@ -1064,11 +1043,9 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 			Renderer   *renderer.Identity     `json:"renderer,omitempty"`
 			RecordPage *renderer.RecordPage   `json:"record_page,omitempty"`
 			FormPage   *renderer.FormPage     `json:"form_page,omitempty"`
-			Extra      interface{}            `json:"extra,omitempty"`
 			Item       map[string]interface{} `json:"item"`
 		}{
 			Renderer: viewRouteIdentity(render, pageType),
-			Extra:    extra,
 			Item:     item,
 		}
 		switch pageType {

--- a/generator.go
+++ b/generator.go
@@ -128,6 +128,12 @@ func (generator *Generator) Run() {
 		if err := validateModuleFieldMedia(module); err != nil {
 			panic(fmt.Sprintf("invalid field media config in module %s: %v", module.Name, err))
 		}
+		if err := validateModuleFieldOptionsSources(module); err != nil {
+			panic(fmt.Sprintf("invalid field options source in module %s: %v", module.Name, err))
+		}
+		if err := validateModuleVirtualFilterOptionsSources(module); err != nil {
+			panic(fmt.Sprintf("invalid virtual filter options source in module %s: %v", module.Name, err))
+		}
 		if err := generator.validateCollectionRelations(module); err != nil {
 			panic(fmt.Sprintf("invalid collection config in module %s: %v", module.Name, err))
 		}
@@ -318,6 +324,48 @@ func validateModuleFieldMedia(module *BaseModule) error {
 	return nil
 }
 
+func validateModuleFieldOptionsSources(module *BaseModule) error {
+	for _, field := range module.Fields {
+		if err := field.OptionsSource.Validate(); err != nil {
+			return fmt.Errorf("field %q: %w", field.ColumnName(), err)
+		}
+	}
+	return nil
+}
+
+func validateModuleVirtualFilterOptionsSources(module *BaseModule) error {
+	for _, moduleAction := range module.Actions {
+		listAction, ok := moduleAction.(actions.ListModuleAction)
+		if !ok {
+			continue
+		}
+		for _, filter := range listAction.VirtualFilters {
+			if err := filter.OptionsSource.Validate(); err != nil {
+				return fmt.Errorf("filter %q: %w", filter.FieldName, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (generator *Generator) fieldOptions(c *gin.Context, field fields.ModuleField, role string, lang locale.Lang) []fields.ModuleFieldOptions {
+	options := make([]fields.ModuleFieldOptions, 0, len(field.Options))
+	options = append(options, field.Options...)
+	if field.OptionsFunc != nil {
+		options = append(options, field.OptionsFunc(c)...)
+	}
+	for _, roleOptions := range field.RoleOptions {
+		if roleOptions.Role == role || roleOptions.Role == string(actions.RoleAll) {
+			options = append(options, roleOptions.Options...)
+			break
+		}
+	}
+	for i := range options {
+		options[i].Label = generator.Translate(lang, options[i].Label)
+	}
+	return options
+}
+
 func (generator *Generator) validateCollectionRelations(owner *BaseModule) error {
 	if owner.Render.Form == nil {
 		return nil
@@ -481,13 +529,9 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 
 			for _, realField := range module.Fields {
 				if containsColumn(columns, realField.Column) {
-					headItem := map[string]interface{}{
+					heads[realField.ColumnName()] = map[string]interface{}{
 						"title": generator.Translate(lang, realField.Title),
 					}
-					if realField.Extra != nil && realField.Extra.List != nil {
-						headItem["extra"] = realField.Extra.List
-					}
-					heads[realField.ColumnName()] = headItem
 				}
 			}
 		}
@@ -504,66 +548,27 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 					continue
 				}
 				if containsColumn(filterCols, realField.Column) {
-					options := make([]fields.ModuleFieldOptions, 0, 10)
-					if realField.Options != nil {
-						for _, item := range realField.Options {
-							options = append(options, item)
-						}
-					}
-					if realField.OptionsFunc != nil {
-						for _, item := range realField.OptionsFunc(c) {
-							options = append(options, item)
-						}
-					}
 					roleStr := string(actions.GetRoleFromContext(c))
-					for _, ro := range realField.RoleOptions {
-						if ro.Role == roleStr || ro.Role == string(actions.RoleAll) {
-							options = append(options, ro.Options...)
-							break
-						}
-					}
-
-					for i, opt := range options {
-						options[i].Label = generator.Translate(lang, opt.Label)
-					}
-
-					var filterExtra interface{}
-					if realField.Extra != nil && realField.Extra.List != nil {
-						filterExtra = realField.Extra.List
-					}
-					filterGroup := realField.Group
-					filterOrder := realField.Order
-					if extraMap, ok := filterExtra.(map[string]interface{}); ok {
-						if group, ok := extraMap["filter_group"].(string); ok {
-							filterGroup = group
-						}
-						switch order := extraMap["filter_order"].(type) {
-						case int:
-							filterOrder = order
-						case int64:
-							filterOrder = int(order)
-						case float64:
-							filterOrder = int(order)
-						}
-					}
+					options := generator.fieldOptions(c, realField, roleStr, lang)
 					filterField := fields.ModuleFilterField{
-						Column:   realField.Column,
-						Title:    generator.Translate(lang, realField.Title),
-						Type:     realField.Type,
-						FormType: realField.FormType,
-						Example:  realField.Example,
-						AllLabel: generator.Translate(lang, realField.AllLabel),
-						Options:  options,
-						Check:    realField.Check,
-						Convert:  realField.Convert,
-						Group:    filterGroup,
-						Order:    filterOrder,
-						Extra:    filterExtra,
+						Column:        realField.Column,
+						Title:         generator.Translate(lang, realField.Title),
+						Type:          realField.Type,
+						FormType:      realField.FormType,
+						Example:       realField.Example,
+						AllLabel:      generator.Translate(lang, realField.AllLabel),
+						Options:       options,
+						OptionsSource: realField.OptionsSource,
+						Check:         realField.Check,
+						Convert:       realField.Convert,
 					}
 					filter[realField.ColumnName()] = filterField
 				}
 			}
-			for _, ef := range action.ExtraFilters {
+			virtualFilters := make([]fields.ModuleFilterField, 0, len(action.VirtualFilters)+len(action.ExtraFilters))
+			virtualFilters = append(virtualFilters, action.VirtualFilters...)
+			virtualFilters = append(virtualFilters, action.ExtraFilters...)
+			for _, ef := range virtualFilters {
 				if ef.FilterCondition != nil && !ef.FilterCondition(c) {
 					continue
 				}
@@ -575,12 +580,9 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 					continue
 				}
 				translatedOpts := make([]fields.ModuleFieldOptions, len(ef.Options))
-				for i, opt := range ef.Options {
-					translatedOpts[i] = fields.ModuleFieldOptions{
-						Value: opt.Value,
-						Label: generator.Translate(lang, opt.Label),
-						Icon:  opt.Icon,
-					}
+				copy(translatedOpts, ef.Options)
+				for i := range translatedOpts {
+					translatedOpts[i].Label = generator.Translate(lang, translatedOpts[i].Label)
 				}
 				ef.Title = generator.Translate(lang, ef.Title)
 				ef.AllLabel = generator.Translate(lang, ef.AllLabel)
@@ -846,28 +848,7 @@ func (generator *Generator) actionDefrec(module *BaseModule) func(c *gin.Context
 			}
 
 			checkItems := make([]fields.CheckRules, 0, 10)
-			optionItems := make([]fields.ModuleFieldOptions, 0, 10)
-
-			if field.Options != nil {
-				for _, option := range field.Options {
-					optionItems = append(optionItems, option)
-				}
-			}
-			if field.OptionsFunc != nil {
-				for _, option := range field.OptionsFunc(c) {
-					optionItems = append(optionItems, option)
-				}
-			}
-			for _, ro := range field.RoleOptions {
-				if ro.Role == role || ro.Role == string(actions.RoleAll) {
-					optionItems = append(optionItems, ro.Options...)
-					break
-				}
-			}
-
-			for i, opt := range optionItems {
-				optionItems[i].Label = generator.Translate(lang, opt.Label)
-			}
+			optionItems := generator.fieldOptions(c, field, role, lang)
 
 			if field.Check != nil {
 				for _, check := range field.Check {
@@ -1046,9 +1027,6 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 				"edit":      containsColumn(editableColumns, field.Column),
 			}
 
-			if field.Extra != nil && field.Extra.View != nil {
-				fieldItem["extra"] = field.Extra.View
-			}
 			if field.Presentation != nil {
 				fieldItem["presentation"] = generator.localizeFieldPresentation(lang, field.Presentation)
 			}
@@ -1056,24 +1034,12 @@ func (generator *Generator) actionView(module *BaseModule, action actions.ViewMo
 				fieldItem["media"] = generator.localizeFieldMedia(lang, field.Media, value)
 			}
 
-			// Collect options
-			options := make([]fields.ModuleFieldOptions, 0)
-			if field.Options != nil {
-				options = append(options, field.Options...)
+			if field.OptionsSource != nil {
+				fieldItem["options_source"] = field.OptionsSource
 			}
-			if field.OptionsFunc != nil {
-				options = append(options, field.OptionsFunc(c)...)
-			}
-			for _, ro := range field.RoleOptions {
-				if ro.Role == roleStr || ro.Role == string(actions.RoleAll) {
-					options = append(options, ro.Options...)
-					break
-				}
-			}
+
+			options := generator.fieldOptions(c, field, roleStr, lang)
 			if len(options) > 0 {
-				for i, opt := range options {
-					options[i].Label = generator.Translate(lang, opt.Label)
-				}
 				fieldItem["options"] = options
 			}
 

--- a/generator.go
+++ b/generator.go
@@ -366,6 +366,25 @@ func (generator *Generator) fieldOptions(c *gin.Context, field fields.ModuleFiel
 	return options
 }
 
+func validateListFilterAvailability(page *renderer.ListPage, filters map[string]fields.ModuleFilterField) error {
+	if page == nil || page.Filters == nil {
+		return nil
+	}
+	for _, placement := range [][]string{
+		page.Filters.Primary,
+		page.Filters.Secondary,
+		page.Filters.More,
+		page.Filters.Nested,
+	} {
+		for _, field := range placement {
+			if _, ok := filters[field]; !ok {
+				return fmt.Errorf("renderer filter %q is not available for the current request", field)
+			}
+		}
+	}
+	return nil
+}
+
 func (generator *Generator) validateCollectionRelations(owner *BaseModule) error {
 	if owner.Render.Form == nil {
 		return nil
@@ -536,56 +555,53 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			}
 		}
 
-		var filter map[string]fields.ModuleFilterField
-		if addFilters == "true" {
-			filter = make(map[string]fields.ModuleFilterField)
-			filterCols := action.Filter
-			if action.FilterFunc != nil {
-				filterCols = action.FilterFunc(c)
+		filter := make(map[string]fields.ModuleFilterField)
+		filterCols := action.Filter
+		if action.FilterFunc != nil {
+			filterCols = action.FilterFunc(c)
+		}
+		for _, realField := range module.Fields {
+			if realField.FilterCondition != nil && !realField.FilterCondition(c) {
+				continue
 			}
-			for _, realField := range module.Fields {
-				if realField.FilterCondition != nil && !realField.FilterCondition(c) {
-					continue
+			if containsColumn(filterCols, realField.Column) {
+				roleStr := string(actions.GetRoleFromContext(c))
+				options := generator.fieldOptions(c, realField, roleStr, lang)
+				filterField := fields.ModuleFilterField{
+					Column:        realField.Column,
+					Title:         generator.Translate(lang, realField.Title),
+					Type:          realField.Type,
+					FormType:      realField.FormType,
+					Example:       realField.Example,
+					AllLabel:      generator.Translate(lang, realField.AllLabel),
+					Options:       options,
+					OptionsSource: realField.OptionsSource,
+					Check:         realField.Check,
+					Convert:       realField.Convert,
 				}
-				if containsColumn(filterCols, realField.Column) {
-					roleStr := string(actions.GetRoleFromContext(c))
-					options := generator.fieldOptions(c, realField, roleStr, lang)
-					filterField := fields.ModuleFilterField{
-						Column:        realField.Column,
-						Title:         generator.Translate(lang, realField.Title),
-						Type:          realField.Type,
-						FormType:      realField.FormType,
-						Example:       realField.Example,
-						AllLabel:      generator.Translate(lang, realField.AllLabel),
-						Options:       options,
-						OptionsSource: realField.OptionsSource,
-						Check:         realField.Check,
-						Convert:       realField.Convert,
-					}
-					filter[realField.ColumnName()] = filterField
-				}
+				filter[realField.ColumnName()] = filterField
 			}
-			for _, ef := range action.VirtualFilters {
-				if ef.FilterCondition != nil && !ef.FilterCondition(c) {
-					continue
-				}
-				key := ef.FieldName
-				if key == "" && ef.Column != nil {
-					key = ef.Column.Name()
-				}
-				if key == "" {
-					continue
-				}
-				translatedOpts := make([]fields.ModuleFieldOptions, len(ef.Options))
-				copy(translatedOpts, ef.Options)
-				for i := range translatedOpts {
-					translatedOpts[i].Label = generator.Translate(lang, translatedOpts[i].Label)
-				}
-				ef.Title = generator.Translate(lang, ef.Title)
-				ef.AllLabel = generator.Translate(lang, ef.AllLabel)
-				ef.Options = translatedOpts
-				filter[key] = ef
+		}
+		for _, ef := range action.VirtualFilters {
+			if ef.FilterCondition != nil && !ef.FilterCondition(c) {
+				continue
 			}
+			key := ef.FieldName
+			if key == "" && ef.Column != nil {
+				key = ef.Column.Name()
+			}
+			if key == "" {
+				continue
+			}
+			translatedOpts := make([]fields.ModuleFieldOptions, len(ef.Options))
+			copy(translatedOpts, ef.Options)
+			for i := range translatedOpts {
+				translatedOpts[i].Label = generator.Translate(lang, translatedOpts[i].Label)
+			}
+			ef.Title = generator.Translate(lang, ef.Title)
+			ef.AllLabel = generator.Translate(lang, ef.AllLabel)
+			ef.Options = translatedOpts
+			filter[key] = ef
 		}
 
 		if len(results) == 0 {
@@ -598,6 +614,14 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			return
 		}
 		render = generator.localizeRenderer(lang, render)
+		if err := validateListFilterAvailability(render.List, filter); err != nil {
+			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
+			return
+		}
+		responseFilters := filter
+		if addFilters != "true" {
+			responseFilters = nil
+		}
 
 		if len(heads) == 0 {
 			heads = make(map[string]interface{})
@@ -638,7 +662,7 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			ResourceGridPage: render.ResourceGrid,
 			Rows:             results,
 			Heads:            heads,
-			Filters:          filter,
+			Filters:          responseFilters,
 			Sort:             sortOptions,
 		}
 

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -143,7 +143,19 @@ func cloneFilters(v *Filters) *Filters {
 	cp.SecondaryPillRows = cloneMapRows(v.SecondaryPillRows)
 	cp.Reset = cloneFilterReset(v.Reset)
 	cp.Text = clonePtr(v.Text)
+	cp.RangePresets = cloneFilterRangePresets(v.RangePresets)
 	return &cp
+}
+
+func cloneFilterRangePresets(values []FilterRangePresets) []FilterRangePresets {
+	if values == nil {
+		return nil
+	}
+	out := make([]FilterRangePresets, len(values))
+	for i, value := range values {
+		out[i] = FilterRangePresets{Field: value.Field, Presets: cloneSlice(value.Presets)}
+	}
+	return out
 }
 
 func cloneMapRows(values [][]FilterPill) [][]FilterPill {
@@ -304,7 +316,13 @@ func cloneFieldMatrix(v *FieldMatrix) *FieldMatrix {
 }
 
 func CloneFieldPresentation(v *FieldPresentation) *FieldPresentation {
-	return clonePtr(v)
+	if v == nil {
+		return nil
+	}
+	cp := *v
+	cp.VisibleIf = cloneCondition(v.VisibleIf)
+	cp.ToneByValue = cloneSlice(v.ToneByValue)
+	return &cp
 }
 
 func CloneFieldMediaConfig(v *FieldMediaConfig) *FieldMediaConfig {

--- a/renderer/localize.go
+++ b/renderer/localize.go
@@ -90,12 +90,21 @@ func (localizer textLocalizer) localizeListPage(page *ListPage) {
 		localizer.localizeFilterPills(page.Filters.PillRows)
 		localizer.localizeFilterPills(page.Filters.SecondaryPillRows)
 		localizer.localizeFilterText(page.Filters.Text)
+		localizer.localizeFilterRangePresets(page.Filters.RangePresets)
 	}
 	if page.Summary != nil {
 		localizer.localizeTextFields(&page.Summary.Title, &page.Summary.TitleFallback)
 	}
 	if page.CardSchema != nil {
 		localizer.localizeCardSchema(page.CardSchema)
+	}
+}
+
+func (localizer textLocalizer) localizeFilterRangePresets(groups []FilterRangePresets) {
+	for i := range groups {
+		for j := range groups[i].Presets {
+			groups[i].Presets[j].Label = localizer.localizeRendererText(groups[i].Presets[j].Label, "")
+		}
 	}
 }
 

--- a/renderer/range_presets_test.go
+++ b/renderer/range_presets_test.go
@@ -1,0 +1,48 @@
+package renderer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniversalValidateRejectsInvalidFilterRangePresets(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters *Filters
+		err     string
+	}{
+		{
+			name:    "empty field",
+			filters: &Filters{Primary: []string{"rating"}, RangePresets: []FilterRangePresets{{Presets: []FilterRangePreset{{Min: 0, Max: 5}}}}},
+			err:     "renderer.Universal: list page range presets field is required",
+		},
+		{
+			name:    "undeclared field",
+			filters: &Filters{Primary: []string{"rating"}, RangePresets: []FilterRangePresets{{Field: "price", Presets: []FilterRangePreset{{Min: 0, Max: 5}}}}},
+			err:     `renderer.Universal: list page range presets field "price" is not declared in filters`,
+		},
+		{
+			name:    "duplicate field",
+			filters: &Filters{Primary: []string{"rating"}, RangePresets: []FilterRangePresets{{Field: "rating", Presets: []FilterRangePreset{{Min: 0, Max: 5}}}, {Field: "rating", Presets: []FilterRangePreset{{Min: 5, Max: 10}}}}},
+			err:     `renderer.Universal: list page range presets field "rating" is duplicated`,
+		},
+		{
+			name:    "empty presets",
+			filters: &Filters{Primary: []string{"rating"}, RangePresets: []FilterRangePresets{{Field: "rating"}}},
+			err:     `renderer.Universal: list page range presets field "rating" must have at least one preset`,
+		},
+		{
+			name:    "reversed bounds",
+			filters: &Filters{Primary: []string{"rating"}, RangePresets: []FilterRangePresets{{Field: "rating", Presets: []FilterRangePreset{{Min: 5, Max: 0}}}}},
+			err:     `renderer.Universal: list page range preset for field "rating" has min greater than max`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (Universal{List: &ListPage{Filters: test.filters}}).Validate()
+			require.EqualError(t, err, test.err)
+		})
+	}
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -174,6 +174,43 @@ func validateListPage(scope string, page *ListPage) error {
 			return err
 		}
 	}
+	if err := validateFilterRangePresets(scope, page.Filters); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateFilterRangePresets(scope string, filters *Filters) error {
+	if filters == nil || len(filters.RangePresets) == 0 {
+		return nil
+	}
+	declared := make(map[string]struct{}, len(filters.Primary)+len(filters.Secondary)+len(filters.More)+len(filters.Nested))
+	for _, fields := range [][]string{filters.Primary, filters.Secondary, filters.More, filters.Nested} {
+		for _, field := range fields {
+			declared[field] = struct{}{}
+		}
+	}
+	seen := make(map[string]struct{}, len(filters.RangePresets))
+	for _, group := range filters.RangePresets {
+		if group.Field == "" {
+			return fmt.Errorf("renderer.Universal: %s range presets field is required", scope)
+		}
+		if _, exists := seen[group.Field]; exists {
+			return fmt.Errorf("renderer.Universal: %s range presets field %q is duplicated", scope, group.Field)
+		}
+		seen[group.Field] = struct{}{}
+		if _, exists := declared[group.Field]; !exists {
+			return fmt.Errorf("renderer.Universal: %s range presets field %q is not declared in filters", scope, group.Field)
+		}
+		if len(group.Presets) == 0 {
+			return fmt.Errorf("renderer.Universal: %s range presets field %q must have at least one preset", scope, group.Field)
+		}
+		for _, preset := range group.Presets {
+			if preset.Min > preset.Max {
+				return fmt.Errorf("renderer.Universal: %s range preset for field %q has min greater than max", scope, group.Field)
+			}
+		}
+	}
 	return nil
 }
 
@@ -361,8 +398,8 @@ type FieldPresentation struct {
 }
 
 type FieldValueTone struct {
-	Value string `json:"value"`
-	Tone  string `json:"tone"`
+	Value TypedValue `json:"value"`
+	Tone  string     `json:"tone"`
 }
 
 type FieldMediaConfig struct {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -224,20 +224,32 @@ type Layout struct {
 }
 
 type Filters struct {
-	Renderer          RendererKey    `json:"renderer,omitempty"`
-	Enabled           bool           `json:"enabled"`
-	PrimaryPlacement  string         `json:"primary_placement,omitempty"`
-	SecondaryEnabled  *bool          `json:"secondary_enabled,omitempty"`
-	ResetPlacement    string         `json:"reset_placement,omitempty"`
-	Levels            []string       `json:"levels,omitempty"`
-	Primary           []string       `json:"primary,omitempty"`
-	Secondary         []string       `json:"secondary,omitempty"`
-	More              []string       `json:"more,omitempty"`
-	Nested            []string       `json:"nested,omitempty"`
-	PillRows          [][]FilterPill `json:"pill_rows,omitempty"`
-	SecondaryPillRows [][]FilterPill `json:"secondary_pill_rows,omitempty"`
-	Reset             *FilterReset   `json:"reset,omitempty"`
-	Text              *FilterText    `json:"text,omitempty"`
+	Renderer          RendererKey          `json:"renderer,omitempty"`
+	Enabled           bool                 `json:"enabled"`
+	PrimaryPlacement  string               `json:"primary_placement,omitempty"`
+	SecondaryEnabled  *bool                `json:"secondary_enabled,omitempty"`
+	ResetPlacement    string               `json:"reset_placement,omitempty"`
+	Levels            []string             `json:"levels,omitempty"`
+	Primary           []string             `json:"primary,omitempty"`
+	Secondary         []string             `json:"secondary,omitempty"`
+	More              []string             `json:"more,omitempty"`
+	Nested            []string             `json:"nested,omitempty"`
+	PillRows          [][]FilterPill       `json:"pill_rows,omitempty"`
+	SecondaryPillRows [][]FilterPill       `json:"secondary_pill_rows,omitempty"`
+	Reset             *FilterReset         `json:"reset,omitempty"`
+	Text              *FilterText          `json:"text,omitempty"`
+	RangePresets      []FilterRangePresets `json:"range_presets,omitempty"`
+}
+
+type FilterRangePresets struct {
+	Field   string              `json:"field"`
+	Presets []FilterRangePreset `json:"presets"`
+}
+
+type FilterRangePreset struct {
+	Label string  `json:"label"`
+	Min   float64 `json:"min"`
+	Max   float64 `json:"max"`
 }
 
 // FilterText contains all text rendered by built-in filter controls.
@@ -334,11 +346,23 @@ type Media struct {
 }
 
 type FieldPresentation struct {
-	Renderer RendererKey `json:"renderer,omitempty"`
-	Variant  string      `json:"variant,omitempty"`
-	Style    string      `json:"style,omitempty"`
-	Size     MediaSize   `json:"size,omitempty"`
-	Ratio    MediaRatio  `json:"ratio,omitempty"`
+	Renderer    RendererKey      `json:"renderer,omitempty"`
+	Variant     string           `json:"variant,omitempty"`
+	Style       string           `json:"style,omitempty"`
+	Size        MediaSize        `json:"size,omitempty"`
+	Ratio       MediaRatio       `json:"ratio,omitempty"`
+	Prefix      string           `json:"prefix,omitempty"`
+	Suffix      string           `json:"suffix,omitempty"`
+	Hint        string           `json:"hint,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Rows        uint8            `json:"rows,omitempty"`
+	VisibleIf   *Condition       `json:"visible_if,omitempty"`
+	ToneByValue []FieldValueTone `json:"tone_by_value,omitempty"`
+}
+
+type FieldValueTone struct {
+	Value string `json:"value"`
+	Tone  string `json:"tone"`
 }
 
 type FieldMediaConfig struct {

--- a/renderer_adapter.go
+++ b/renderer_adapter.go
@@ -5,8 +5,16 @@ import (
 	"github.com/darkrain/request-generator/renderer"
 )
 
-func (generator *Generator) localizeFieldPresentation(_ locale.Lang, value *renderer.FieldPresentation) *renderer.FieldPresentation {
-	return renderer.CloneFieldPresentation(value)
+func (generator *Generator) localizeFieldPresentation(lang locale.Lang, value *renderer.FieldPresentation) *renderer.FieldPresentation {
+	localized := renderer.CloneFieldPresentation(value)
+	if localized == nil {
+		return nil
+	}
+	resolver := generator.rendererTextResolver(lang)
+	for _, field := range []*string{&localized.Prefix, &localized.Suffix, &localized.Hint, &localized.Description} {
+		*field = resolver(*field, "")
+	}
+	return localized
 }
 
 func (generator *Generator) localizeFieldMedia(lang locale.Lang, value *renderer.FieldMediaConfig, fieldValue interface{}) *renderer.FieldMediaConfig {

--- a/response/defrec.go
+++ b/response/defrec.go
@@ -26,8 +26,8 @@ func NewDefrecResponse(extra interface{}, fields []f.ModuleField) DefrecResponse
 		if len(field.Options) > 0 {
 			item["options"] = field.Options
 		}
-		if field.Extra != nil && field.Extra.Defrec != nil {
-			item["extra"] = field.Extra.Defrec
+		if field.OptionsSource != nil {
+			item["options_source"] = field.OptionsSource
 		}
 		if field.Presentation != nil {
 			item["presentation"] = field.Presentation

--- a/response/defrec.go
+++ b/response/defrec.go
@@ -8,11 +8,10 @@ import (
 type DefrecResponse struct {
 	Renderer *renderer.Identity     `json:"renderer,omitempty"`
 	FormPage *renderer.FormPage     `json:"form_page,omitempty"`
-	Extra    interface{}            `json:"extra,omitempty"`
 	Fields   map[string]interface{} `json:"fields"`
 }
 
-func NewDefrecResponse(extra interface{}, fields []f.ModuleField) DefrecResponse {
+func NewDefrecResponse(fields []f.ModuleField) DefrecResponse {
 	fieldsMap := make(map[string]interface{}, len(fields))
 	for _, field := range fields {
 		item := map[string]interface{}{
@@ -65,10 +64,7 @@ func NewDefrecResponse(extra interface{}, fields []f.ModuleField) DefrecResponse
 		fieldsMap[key] = item
 	}
 
-	return DefrecResponse{
-		Extra:  extra,
-		Fields: fieldsMap,
-	}
+	return DefrecResponse{Fields: fieldsMap}
 }
 
 func (r *DefrecResponse) AttachRender(render renderer.Universal) {

--- a/tests/integration/typed_option_renderer_response_test.go
+++ b/tests/integration/typed_option_renderer_response_test.go
@@ -188,3 +188,76 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 	require.Equal(t, renderer.RendererChipSelect, viewResponse.Item["categories"].Presentation.Renderer)
 	assertOptions(t, viewResponse.Item["categories"].Options, "Example", "tag")
 }
+
+func TestListFilterContractRejectsUnavailableFilters(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		primary        string
+		virtualFilters []fields.ModuleFilterField
+	}{
+		{
+			name:    "missing regular filter",
+			primary: "missing",
+		},
+		{
+			name:    "hidden virtual filter",
+			primary: "managed_services",
+			virtualFilters: []fields.ModuleFilterField{{
+				FieldName:       "managed_services",
+				Title:           "items.fields.managed_services",
+				Type:            fields.ModuleFieldTypeArray,
+				FormType:        fields.ModuleFieldFormTypeMultiselect,
+				FilterCondition: func(_ *gin.Context) bool { return false },
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			id := pg.IntegerColumn("id")
+			status := pg.StringColumn("status")
+			table := pg.NewTable("public", "filter_contract_items", "", id, status)
+			testModule := &module.BaseModule{
+				Name:       "filter-contract-items",
+				Path:       "/admin",
+				Table:      table,
+				PrimaryKey: id,
+				Fields: []fields.ModuleField{
+					{Column: id, Title: "items.fields.id", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeOnlyView},
+					{Column: status, Title: "items.fields.status", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeSelect},
+				},
+				Render: renderer.Universal{List: &renderer.ListPage{Filters: &renderer.Filters{Primary: []string{test.primary}}}},
+				Actions: []actions.ModuleAction{actions.ListModuleAction{
+					Columns:        []pg.Column{id, status},
+					Filter:         []pg.Column{status},
+					VirtualFilters: test.virtualFilters,
+					Permission:     []actions.Role{actions.RoleAll},
+					Auth:           true,
+				}},
+			}
+
+			engine := gin.New()
+			group := engine.Group("")
+			generator := module.NewGenerator(
+				func(_ *module.BaseModule) dbpkg.DBExecutor { return fakeRendererDB{} },
+				*group,
+				[]*module.BaseModule{testModule},
+				func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+					return func(c *gin.Context) { c.Next() }
+				},
+				createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+			)
+			generator.Run()
+
+			w := executeRequest(engine, http.MethodGet, "/admin/filter-contract-items?addFilters=true", nil)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			var response struct {
+				Message string `json:"message"`
+			}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			require.Equal(t, `renderer filter "`+test.primary+`" is not available for the current request`, response.Message)
+		})
+	}
+}

--- a/tests/integration/typed_option_renderer_response_test.go
+++ b/tests/integration/typed_option_renderer_response_test.go
@@ -45,7 +45,7 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 					Hint:        "items.status.hint",
 					Description: "items.status.description",
 					VisibleIf:   &renderer.Condition{Path: "enabled", Equals: true},
-					ToneByValue: []renderer.FieldValueTone{{Value: "active", Tone: "success"}},
+					ToneByValue: []renderer.FieldValueTone{{Value: renderer.TypedValue{Type: renderer.TypedValueString, String: "active"}, Tone: "success"}},
 				},
 				OptionsSource: &fields.FieldOptionsSource{
 					Endpoint:    "/admin/status-options",
@@ -72,7 +72,7 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 			List: &renderer.ListPage{
 				ID: "typed-option-items",
 				Filters: &renderer.Filters{
-					Primary: []string{"status", "managed_services"},
+					Primary: []string{"status", "managed_services", "rating"},
 					RangePresets: []renderer.FilterRangePresets{{
 						Field:   "rating",
 						Presets: []renderer.FilterRangePreset{{Label: "items.rating.any", Min: 0, Max: 5}},
@@ -96,6 +96,11 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 					OptionsSource: &fields.FieldOptionsSource{
 						Endpoint: "/admin/services",
 					},
+				}, {
+					FieldName: "rating",
+					Title:     "items.fields.rating",
+					Type:      fields.ModuleFieldTypeFloat,
+					FormType:  fields.ModuleFieldFormTypeNumber,
 				}},
 			},
 			actions.AddModuleAction{Columns: []pg.Column{status, categories}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
@@ -104,7 +109,7 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 	}
 
 	translationsPath := filepath.Join(t.TempDir(), "en.json")
-	require.NoError(t, os.WriteFile(translationsPath, []byte(`{"items":{"fields":{"id":"ID","status":"Status","categories":"Categories","managed_services":"Managed services"},"options":{"active":"Active","example":"Example"},"status":{"prefix":"Current:","suffix":"state","hint":"Choose current state","description":"Controls item visibility"},"rating":{"any":"Any rating"}}}`), 0o600))
+	require.NoError(t, os.WriteFile(translationsPath, []byte(`{"items":{"fields":{"id":"ID","status":"Status","categories":"Categories","managed_services":"Managed services","rating":"Rating"},"options":{"active":"Active","example":"Example"},"status":{"prefix":"Current:","suffix":"state","hint":"Choose current state","description":"Controls item visibility"},"rating":{"any":"Any rating"}}}`), 0o600))
 
 	engine := gin.New()
 	group := engine.Group("")

--- a/tests/integration/typed_option_renderer_response_test.go
+++ b/tests/integration/typed_option_renderer_response_test.go
@@ -34,11 +34,25 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 		Fields: []fields.ModuleField{
 			{Column: id, Title: "items.fields.id", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeOnlyView},
 			{
-				Column:       status,
-				Title:        "items.fields.status",
-				Type:         fields.ModuleFieldTypeString,
-				FormType:     fields.ModuleFieldFormTypeSelect,
-				Presentation: &renderer.FieldPresentation{Renderer: renderer.RendererPrimaryRadio},
+				Column:   status,
+				Title:    "items.fields.status",
+				Type:     fields.ModuleFieldTypeString,
+				FormType: fields.ModuleFieldFormTypeSelect,
+				Presentation: &renderer.FieldPresentation{
+					Renderer:    renderer.RendererPrimaryRadio,
+					Prefix:      "items.status.prefix",
+					Suffix:      "items.status.suffix",
+					Hint:        "items.status.hint",
+					Description: "items.status.description",
+					VisibleIf:   &renderer.Condition{Path: "enabled", Equals: true},
+					ToneByValue: []renderer.FieldValueTone{{Value: "active", Tone: "success"}},
+				},
+				OptionsSource: &fields.FieldOptionsSource{
+					Endpoint:    "/admin/status-options",
+					Query:       []fields.FieldOptionsQueryParam{{Key: "scope", Value: "profiles"}},
+					SearchParam: "search",
+					Mode:        fields.FieldOptionsSourceModeTree,
+				},
 				Options: []fields.ModuleFieldOptions{
 					{Value: "active", Label: "items.options.active", Icon: "check"},
 				},
@@ -55,19 +69,42 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 			},
 		},
 		Render: renderer.Universal{
-			List:   &renderer.ListPage{ID: "typed-option-items"},
+			List: &renderer.ListPage{
+				ID: "typed-option-items",
+				Filters: &renderer.Filters{
+					Primary: []string{"status", "managed_services"},
+					RangePresets: []renderer.FilterRangePresets{{
+						Field:   "rating",
+						Presets: []renderer.FilterRangePreset{{Label: "items.rating.any", Min: 0, Max: 5}},
+					}},
+				},
+			},
 			Form:   &renderer.FormPage{ID: "typed-option-items-form"},
 			Record: &renderer.RecordPage{ID: "typed-option-items-record"},
 		},
 		Actions: []actions.ModuleAction{
-			actions.ListModuleAction{Columns: []pg.Column{id, status, categories}, Filter: []pg.Column{status}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
+			actions.ListModuleAction{
+				Columns:    []pg.Column{id, status, categories},
+				Filter:     []pg.Column{status},
+				Permission: []actions.Role{actions.RoleAll},
+				Auth:       true,
+				VirtualFilters: []fields.ModuleFilterField{{
+					FieldName: "managed_services",
+					Title:     "items.fields.managed_services",
+					Type:      fields.ModuleFieldTypeArray,
+					FormType:  fields.ModuleFieldFormTypeMultiselect,
+					OptionsSource: &fields.FieldOptionsSource{
+						Endpoint: "/admin/services",
+					},
+				}},
+			},
 			actions.AddModuleAction{Columns: []pg.Column{status, categories}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
 			actions.ViewModuleAction{Columns: []pg.Column{id, status, categories}, By: []pg.Column{id}, Permission: []actions.Role{actions.RoleAll}, Auth: true},
 		},
 	}
 
 	translationsPath := filepath.Join(t.TempDir(), "en.json")
-	require.NoError(t, os.WriteFile(translationsPath, []byte(`{"items":{"fields":{"id":"ID","status":"Status","categories":"Categories"},"options":{"active":"Active","example":"Example"}}}`), 0o600))
+	require.NoError(t, os.WriteFile(translationsPath, []byte(`{"items":{"fields":{"id":"ID","status":"Status","categories":"Categories","managed_services":"Managed services"},"options":{"active":"Active","example":"Example"},"status":{"prefix":"Current:","suffix":"state","hint":"Choose current state","description":"Controls item visibility"},"rating":{"any":"Any rating"}}}`), 0o600))
 
 	engine := gin.New()
 	group := engine.Group("")
@@ -93,38 +130,55 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 
 	w := executeRequest(engine, http.MethodGet, "/admin/typed-option-items?addFilters=true&lang=en", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NotContains(t, w.Body.String(), `"extra"`)
 	var listResponse struct {
 		Filters map[string]struct {
-			Options []fields.ModuleFieldOptions `json:"options"`
+			Options       []fields.ModuleFieldOptions `json:"options"`
+			OptionsSource *fields.FieldOptionsSource  `json:"options_source"`
 		} `json:"filters"`
+		ListPage *renderer.ListPage `json:"list_page"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listResponse))
 	assertOptions(t, listResponse.Filters["status"].Options, "Active", "check")
+	require.Equal(t, "/admin/status-options", listResponse.Filters["status"].OptionsSource.Endpoint)
+	require.Equal(t, fields.FieldOptionsSourceModeTree, listResponse.Filters["status"].OptionsSource.Mode)
+	require.Equal(t, "/admin/services", listResponse.Filters["managed_services"].OptionsSource.Endpoint)
+	require.Equal(t, "Any rating", listResponse.ListPage.Filters.RangePresets[0].Presets[0].Label)
 
 	w = executeRequest(engine, http.MethodGet, "/admin/typed-option-items/defrec/?lang=en", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NotContains(t, w.Body.String(), `"extra"`)
 	var defrecResponse struct {
 		Fields map[string]struct {
-			Presentation *renderer.FieldPresentation `json:"presentation"`
-			Options      []fields.ModuleFieldOptions `json:"options"`
+			Presentation  *renderer.FieldPresentation `json:"presentation"`
+			Options       []fields.ModuleFieldOptions `json:"options"`
+			OptionsSource *fields.FieldOptionsSource  `json:"options_source"`
 		} `json:"fields"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &defrecResponse))
 	require.Equal(t, renderer.RendererPrimaryRadio, defrecResponse.Fields["status"].Presentation.Renderer)
+	require.Equal(t, "Current:", defrecResponse.Fields["status"].Presentation.Prefix)
+	require.Equal(t, "state", defrecResponse.Fields["status"].Presentation.Suffix)
+	require.Equal(t, "Choose current state", defrecResponse.Fields["status"].Presentation.Hint)
+	require.Equal(t, "Controls item visibility", defrecResponse.Fields["status"].Presentation.Description)
+	require.Equal(t, "/admin/status-options", defrecResponse.Fields["status"].OptionsSource.Endpoint)
 	assertOptions(t, defrecResponse.Fields["status"].Options, "Active", "check")
 	require.Equal(t, renderer.RendererChipSelect, defrecResponse.Fields["categories"].Presentation.Renderer)
 	assertOptions(t, defrecResponse.Fields["categories"].Options, "Example", "tag")
 
 	w = executeRequest(engine, http.MethodGet, "/admin/typed-option-items/view/id/1?lang=en", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NotContains(t, w.Body.String(), `"extra"`)
 	var viewResponse struct {
 		Item map[string]struct {
-			Presentation *renderer.FieldPresentation `json:"presentation"`
-			Options      []fields.ModuleFieldOptions `json:"options"`
+			Presentation  *renderer.FieldPresentation `json:"presentation"`
+			Options       []fields.ModuleFieldOptions `json:"options"`
+			OptionsSource *fields.FieldOptionsSource  `json:"options_source"`
 		} `json:"item"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &viewResponse))
 	require.Equal(t, renderer.RendererPrimaryRadio, viewResponse.Item["status"].Presentation.Renderer)
+	require.Equal(t, "/admin/status-options", viewResponse.Item["status"].OptionsSource.Endpoint)
 	assertOptions(t, viewResponse.Item["status"].Options, "Active", "check")
 	require.Equal(t, renderer.RendererChipSelect, viewResponse.Item["categories"].Presentation.Renderer)
 	assertOptions(t, viewResponse.Item["categories"].Options, "Example", "tag")


### PR DESCRIPTION
## Что меняется

- Добавляет типизированный `options_source` для `ModuleField` и фильтров: endpoint, статические query-параметры, search parameter и режим `list`/`tree`.
- Унифицирует сериализацию options в `list`, `defrec` и `view`; typed field path больше не возвращает field-level `extra`.
- Расширяет `FieldPresentation`: prefix/suffix, hint/description, rows, visible_if и mapping tone по значению.
- Добавляет `ListModuleAction.VirtualFilters` и `range_presets` в renderer filters; размещение фильтров определяется `list_page.filters`.
- Добавляет валидацию source-конфигурации, локализацию и безопасное клонирование новых структур.
- Обновляет UniversalRenderer contract и интеграционные тесты ответа.

## Проверки

- `go test ./...`
- `go vet ./...`

Связано с #56. Это prerequisite для переноса `profiles` и `shell_profile` в API issue theGHub1/api#102.