### PR TITLE
feat: add icon to typed field presentation

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -412,6 +412,7 @@ Typed field metadata нужна для одиночных полей, где б�
 | `presentation.renderer` | Renderer/component key, например `avatar`, `universal.display`, `universal.section`. |
 | `presentation.variant` | Вариант компонента внутри renderer. |
 | `presentation.style` | Optional style token, если renderer поддерживает несколько визуальных стилей. |
+| `presentation.icon` | Стабильный ключ иконки из icon registry. Не локализуется. |
 | `presentation.size` | Media size token: `thumb`, `card`, `hero`. |
 | `presentation.ratio` | Media ratio token: `square`, `portrait`, `landscape`, `wide`. |
 | `presentation.prefix`, `presentation.suffix` | Локализуемый текст до или после значения. |

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -386,6 +386,7 @@ type FieldPresentation struct {
 	Renderer    RendererKey      `json:"renderer,omitempty"`
 	Variant     string           `json:"variant,omitempty"`
 	Style       string           `json:"style,omitempty"`
+	Icon        string           `json:"icon,omitempty"`
 	Size        MediaSize        `json:"size,omitempty"`
 	Ratio       MediaRatio       `json:"ratio,omitempty"`
 	Prefix      string           `json:"prefix,omitempty"`

--- a/tests/integration/typed_option_renderer_response_test.go
+++ b/tests/integration/typed_option_renderer_response_test.go
@@ -40,6 +40,7 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 				FormType: fields.ModuleFieldFormTypeSelect,
 				Presentation: &renderer.FieldPresentation{
 					Renderer:    renderer.RendererPrimaryRadio,
+					Icon:        "status",
 					Prefix:      "items.status.prefix",
 					Suffix:      "items.status.suffix",
 					Hint:        "items.status.hint",
@@ -162,6 +163,7 @@ func TestTypedOptionRenderersPreserveIconsAndLocalizedLabels(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &defrecResponse))
 	require.Equal(t, renderer.RendererPrimaryRadio, defrecResponse.Fields["status"].Presentation.Renderer)
+	require.Equal(t, "status", defrecResponse.Fields["status"].Presentation.Icon)
 	require.Equal(t, "Current:", defrecResponse.Fields["status"].Presentation.Prefix)
 	require.Equal(t, "state", defrecResponse.Fields["status"].Presentation.Suffix)
 	require.Equal(t, "Choose current state", defrecResponse.Fields["status"].Presentation.Hint)


### PR DESCRIPTION
Добавляет стабильный `icon` в `renderer.FieldPresentation` для typed form/view metadata.

Нужно для migration profile fields: checkbox-поля передают иконку без `extra`.

Проверки: `go test ./...`, `go vet ./...`.