### PR TITLE
feat: retain internal field ordering metadata

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -431,6 +431,7 @@ Typed field metadata нужна для одиночных полей, где б�
 |---|---|
 | `chip_select` | Множественный выбор через chips. Используется с `form_type: multiselect`. |
 | `primary_radio` | Выбор одного основного варианта. Используется со scalar `form_type`, например `select`. |
+| `badge` | Статус или enum с tone, в том числе `presentation.tone_by_value`. |
 
 Каждый option может содержать `icon`. Значение и label остаются стандартными:
 

--- a/fields/module_field.go
+++ b/fields/module_field.go
@@ -121,12 +121,16 @@ type ModuleField struct {
 	Convert              func(c *gin.Context, value interface{}) (interface{}, error) `json:"-"`
 	ResultValueConverter func(value interface{}) interface{}                          `json:"-"`
 	Translatable         bool                                                         `json:"-"`
-	FieldName            string                                                       `json:"-"`
-	FilterCondition      func(c *gin.Context) bool                                    `json:"-"`
-	Roles                []string                                                     `json:"roles,omitempty"`
-	Section              string                                                       `json:"section,omitempty"`
-	RoleSection          map[string]string                                            `json:"-"`
-	RoleFormType         map[string]ModuleFieldFormType                               `json:"-"`
+	// Group and Order are producer-only inputs used to build typed renderer
+	// composition. They are never serialized as field metadata.
+	Group           string                         `json:"-"`
+	Order           int                            `json:"-"`
+	FieldName       string                         `json:"-"`
+	FilterCondition func(c *gin.Context) bool      `json:"-"`
+	Roles           []string                       `json:"roles,omitempty"`
+	Section         string                         `json:"section,omitempty"`
+	RoleSection     map[string]string              `json:"-"`
+	RoleFormType    map[string]ModuleFieldFormType `json:"-"`
 }
 
 // ColumnName returns the database column name from the Jet column.

--- a/fields/module_field_test.go
+++ b/fields/module_field_test.go
@@ -1,0 +1,15 @@
+package fields
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleFieldDoesNotSerializeInternalOrdering(t *testing.T) {
+	payload, err := json.Marshal(ModuleField{Group: "profile", Order: 10})
+	require.NoError(t, err)
+	require.NotContains(t, string(payload), "group")
+	require.NotContains(t, string(payload), "order")
+}

--- a/renderer/tokens.go
+++ b/renderer/tokens.go
@@ -207,6 +207,7 @@ const (
 	RendererCollectionManager   RendererKey = "collection.manager"
 	RendererFieldMatrix         RendererKey = "field.matrix"
 	RendererAvatar              RendererKey = "avatar"
+	RendererBadge               RendererKey = "badge"
 	RendererChipSelect          RendererKey = "chip_select"
 	RendererPrimaryRadio        RendererKey = "primary_radio"
 )


### PR DESCRIPTION
Возвращает `ModuleField.Group` и `ModuleField.Order` только как producer-side inputs (`json:"-"`). Они нужны сервису для построения typed `FormSection.Fields`; field metadata и response contract их не сериализуют.

Legacy `Extra*` и `OptionsURL` не возвращаются. Добавлен тест JSON-сериализации.

Проверки: `go test ./...`, `go vet ./...`.