### PR TITLE
refactor: убрать legacy view adapter из config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,9 +1379,6 @@ type TranslationContext struct {
           "url": "/api/api/catalog",
           "method": "GET"
         },
-        "data": {
-          "view_adapter": "list_table"
-        },
         "children": {}
       },
       "title": "Catalog",

--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -378,11 +378,6 @@ func actionWidget(action actions.ModuleAction) *actions.WidgetConfig {
 func (generator *Generator) buildListRoute(module *BaseModule, render renderer.Universal, action actions.ListModuleAction, role string) RouteConfig {
 	routePath := module.Path + "/" + module.Name
 
-	viewAdapter := "list_table"
-	if adapter, exists := generator.ViewAdapters["list"]; exists {
-		viewAdapter = adapter
-	}
-
 	route := RouteConfig{
 		Title:     action.Label,
 		MenuTitle: action.Label,
@@ -392,22 +387,14 @@ func (generator *Generator) buildListRoute(module *BaseModule, render renderer.U
 			Url:    apiQueryURL(routePath),
 			Method: "GET",
 		},
-		Data: map[string]interface{}{
-			"view_adapter": viewAdapter,
-		},
 	}
 
-	route.Data["actions"] = generator.buildRouteActions(module, role)
 	route.Children = generator.buildRouteChildren(module, render, role)
 
 	return route
 }
 
 func (generator *Generator) buildViewRoute(module *BaseModule, render renderer.Universal, action actions.ViewModuleAction) RouteConfig {
-	viewAdapter := "view"
-	if adapter, exists := generator.ViewAdapters["view"]; exists {
-		viewAdapter = adapter
-	}
 	pageType := viewActionPageType(action)
 
 	return RouteConfig{
@@ -417,9 +404,6 @@ func (generator *Generator) buildViewRoute(module *BaseModule, render renderer.U
 		Query: &RouteQuery{
 			Url:    apiQueryURL(module.Path + "/" + module.Name + "/view/:bykey/:value"),
 			Method: "GET",
-		},
-		Data: map[string]interface{}{
-			"view_adapter": viewAdapter,
 		},
 	}
 }
@@ -463,11 +447,6 @@ func viewRoutePageType(render renderer.Universal, pageType renderer.PageType) re
 }
 
 func (generator *Generator) buildAddRoute(module *BaseModule, render renderer.Universal, action actions.AddModuleAction) RouteConfig {
-	viewAdapter := "add"
-	if adapter, exists := generator.ViewAdapters["add"]; exists {
-		viewAdapter = adapter
-	}
-
 	return RouteConfig{
 		Title:    action.Label,
 		Renderer: render.FormIdentity(),
@@ -476,18 +455,10 @@ func (generator *Generator) buildAddRoute(module *BaseModule, render renderer.Un
 			Url:    apiQueryURL(module.Path + "/" + module.Name),
 			Method: "PUT",
 		},
-		Data: map[string]interface{}{
-			"view_adapter": viewAdapter,
-		},
 	}
 }
 
 func (generator *Generator) buildDefrecRoute(module *BaseModule, render renderer.Universal, action actions.DefrecModuleAction) RouteConfig {
-	viewAdapter := "add"
-	if adapter, exists := generator.ViewAdapters["add"]; exists {
-		viewAdapter = adapter
-	}
-
 	return RouteConfig{
 		Title:    action.Label,
 		Renderer: render.FormIdentity(),
@@ -495,9 +466,6 @@ func (generator *Generator) buildDefrecRoute(module *BaseModule, render renderer
 		Query: &RouteQuery{
 			Url:    apiQueryURL(module.Path + "/" + module.Name + "/defrec/"),
 			Method: "GET",
-		},
-		Data: map[string]interface{}{
-			"view_adapter": viewAdapter,
 		},
 	}
 }
@@ -507,41 +475,6 @@ func apiQueryURL(path string) string {
 		return path
 	}
 	return "/api" + path
-}
-
-// buildRouteActions формирует actions для маршрута
-func (generator *Generator) buildRouteActions(module *BaseModule, role string) []map[string]interface{} {
-	var result []map[string]interface{}
-
-	for _, entry := range module.Navigation {
-		for _, action := range module.Actions {
-			if string(action.Action()) != entry.ActionName {
-				continue
-			}
-			if !hasPermission(action, role) {
-				continue
-			}
-
-			actionMap := map[string]interface{}{
-				"title": entry.Title,
-				"type":  entry.ActionName,
-				"icon":  entry.Icon,
-				"show":  entry.Show,
-			}
-
-			if entry.Query != nil {
-				actionMap["query"] = entry.Query
-			}
-			if entry.Data != nil {
-				actionMap["data"] = entry.Data
-			}
-
-			result = append(result, actionMap)
-			break
-		}
-	}
-
-	return result
 }
 
 // buildRouteChildren формирует children маршруты (view, edit, add)
@@ -585,11 +518,6 @@ func (generator *Generator) buildViewChild(module *BaseModule, render renderer.U
 		return RouteConfig{}, false
 	}
 
-	viewAdapter := "view"
-	if adapter, exists := generator.ViewAdapters["view"]; exists {
-		viewAdapter = adapter
-	}
-
 	return RouteConfig{
 		Title:    a.Label,
 		Renderer: viewRouteIdentity(render, viewActionPageType(a)),
@@ -598,20 +526,12 @@ func (generator *Generator) buildViewChild(module *BaseModule, render renderer.U
 			Url:    apiQueryURL(module.Path + "/" + module.Name + "/view/:bykey/:value"),
 			Method: "GET",
 		},
-		Data: map[string]interface{}{
-			"view_adapter": viewAdapter,
-		},
 	}, true
 }
 
 func (generator *Generator) buildUpdateChild(module *BaseModule, render renderer.Universal, a actions.UpdateModuleAction, role string) (RouteConfig, bool) {
 	if !hasPermission(a, role) {
 		return RouteConfig{}, false
-	}
-
-	editAdapter := "edit"
-	if adapter, exists := generator.ViewAdapters["edit"]; exists {
-		editAdapter = adapter
 	}
 
 	return RouteConfig{
@@ -622,20 +542,12 @@ func (generator *Generator) buildUpdateChild(module *BaseModule, render renderer
 			Url:    apiQueryURL(module.Path + "/" + module.Name + "/:bykey/:value"),
 			Method: "POST",
 		},
-		Data: map[string]interface{}{
-			"view_adapter": editAdapter,
-		},
 	}, true
 }
 
 func (generator *Generator) buildAddChild(module *BaseModule, render renderer.Universal, a actions.AddModuleAction, role string) (RouteConfig, bool) {
 	if !hasPermission(a, role) {
 		return RouteConfig{}, false
-	}
-
-	addAdapter := "add"
-	if adapter, exists := generator.ViewAdapters["add"]; exists {
-		addAdapter = adapter
 	}
 
 	return RouteConfig{
@@ -645,9 +557,6 @@ func (generator *Generator) buildAddChild(module *BaseModule, render renderer.Un
 		Query: &RouteQuery{
 			Url:    apiQueryURL(module.Path + "/" + module.Name),
 			Method: "PUT",
-		},
-		Data: map[string]interface{}{
-			"view_adapter": addAdapter,
 		},
 	}, true
 }

--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -29,7 +29,6 @@ type ConfigNavigationEntry struct {
 	Order  int                    `json:"order,omitempty"`
 	Group  string                 `json:"group,omitempty"`
 	Query  map[string]interface{} `json:"query,omitempty"`
-	Data   map[string]interface{} `json:"data,omitempty"`
 }
 
 type NavigationPageTarget struct {
@@ -39,7 +38,6 @@ type NavigationPageTarget struct {
 	Renderer *renderer.Identity     `json:"renderer,omitempty"`
 	PageType renderer.PageType      `json:"page_type,omitempty"`
 	Query    *RouteQuery            `json:"query,omitempty"`
-	Data     map[string]interface{} `json:"data,omitempty"`
 	Children map[string]RouteConfig `json:"children,omitempty"`
 }
 
@@ -61,7 +59,6 @@ type RouteConfig struct {
 	Renderer  *renderer.Identity     `json:"renderer,omitempty"`
 	PageType  renderer.PageType      `json:"page_type,omitempty"`
 	Query     *RouteQuery            `json:"query,omitempty"`
-	Data      map[string]interface{} `json:"data,omitempty"`
 	Children  map[string]RouteConfig `json:"children,omitempty"`
 }
 
@@ -214,7 +211,6 @@ func (generator *Generator) buildNavigation(c *gin.Context, role string, lang lo
 				target.Renderer = route.Renderer
 				target.PageType = route.PageType
 				target.Query = route.Query
-				target.Data = route.Data
 				target.Children = route.Children
 				if target.Query != nil && entry.Query != nil {
 					target.Query.Params = entry.Query
@@ -230,7 +226,6 @@ func (generator *Generator) buildNavigation(c *gin.Context, role string, lang lo
 				Order:  entry.Order,
 				Target: target,
 				Query:  entry.Query,
-				Data:   entry.Data,
 			})
 		}
 	}

--- a/generator.go
+++ b/generator.go
@@ -40,7 +40,6 @@ type Generator struct {
 	translations         map[locale.Lang]map[string]string
 	EnableOpenAPI        bool
 	GroupTitles          map[string]string
-	ViewAdapters         map[string]string
 	IconMap              map[string]string
 	Realtime             RealtimeConfig
 	realtimeHub          *realtimeHub

--- a/module.go
+++ b/module.go
@@ -22,7 +22,6 @@ type NavigationEntry struct {
 	Target     NavigationTarget       `json:"target,omitempty"`
 	Roles      []actions.Role         `json:"roles,omitempty"`
 	Query      map[string]interface{} `json:"query,omitempty"`
-	Data       map[string]interface{} `json:"data,omitempty"`
 }
 
 type NavigationTarget struct {

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/darkrain/request-generator"
@@ -278,7 +279,22 @@ func TestConfigEndpoint_NavigationStructure(t *testing.T) {
 		assert.NotEmpty(t, element.Path, "Page navigation item path should not be empty")
 		assert.NotEmpty(t, element.Target.Query.Url, "Page navigation target query URL should not be empty")
 		assert.NotEmpty(t, element.Target.Query.Method, "Page navigation target query method should not be empty")
-		assert.Nil(t, element.Target.Data, "Page navigation target must not emit legacy adapter data")
+		encoded, err := json.Marshal(element)
+		require.NoError(t, err)
+		assert.NotContains(t, string(encoded), `"data"`, "Navigation must not emit arbitrary legacy data")
+		assert.NotContains(t, string(encoded), "view_adapter", "Navigation must not emit legacy view adapters")
+	}
+}
+
+func TestNavigationContract_HasNoArbitraryDataField(t *testing.T) {
+	for _, value := range []interface{}{
+		module.NavigationEntry{},
+		module.ConfigNavigationEntry{},
+		module.NavigationPageTarget{},
+		module.RouteConfig{},
+	} {
+		_, exists := reflect.TypeOf(value).FieldByName("Data")
+		assert.False(t, exists, "%T must not expose an arbitrary Data field", value)
 	}
 }
 
@@ -316,5 +332,8 @@ func TestConfigEndpoint_PageTargetStructure(t *testing.T) {
 	assert.Equal(t, renderer.PageTypeList, usersEntry.Target.PageType)
 	assert.Equal(t, "/api/admin/users", usersEntry.Target.Query.Url)
 	assert.Equal(t, "GET", usersEntry.Target.Query.Method)
-	assert.Nil(t, usersEntry.Target.Data, "Users page target must not emit legacy adapter data")
+	encoded, err := json.Marshal(usersEntry)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), `"data"`, "Users page target must not emit arbitrary legacy data")
+	assert.NotContains(t, string(encoded), "view_adapter", "Users page target must not emit legacy view adapters")
 }

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -278,7 +278,7 @@ func TestConfigEndpoint_NavigationStructure(t *testing.T) {
 		assert.NotEmpty(t, element.Path, "Page navigation item path should not be empty")
 		assert.NotEmpty(t, element.Target.Query.Url, "Page navigation target query URL should not be empty")
 		assert.NotEmpty(t, element.Target.Query.Method, "Page navigation target query method should not be empty")
-		assert.NotNil(t, element.Target.Data, "Page navigation target data should not be nil")
+		assert.Nil(t, element.Target.Data, "Page navigation target must not emit legacy adapter data")
 	}
 }
 
@@ -316,5 +316,5 @@ func TestConfigEndpoint_PageTargetStructure(t *testing.T) {
 	assert.Equal(t, renderer.PageTypeList, usersEntry.Target.PageType)
 	assert.Equal(t, "/api/admin/users", usersEntry.Target.Query.Url)
 	assert.Equal(t, "GET", usersEntry.Target.Query.Method)
-	assert.NotNil(t, usersEntry.Target.Data, "Users page target data should not be nil")
+	assert.Nil(t, usersEntry.Target.Data, "Users page target must not emit legacy adapter data")
 }


### PR DESCRIPTION
Удаляет `view_adapter` и legacy route actions из `/api/config`. Navigation target теперь описывает только typed route/query/renderer/page type/children contract. Обновлены integration assertions.

Проверки: `go test ./...`, `go vet ./...`.