### PR TITLE
feat: add typed filter groups to universal renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ Render: renderer.Universal{
             Primary:          []string{"status", "category_id", "price"},
             Secondary:        []string{"created_at", "owner_id"},
             More:             []string{"rating", "tags"},
+			Groups: []renderer.FilterGroup{
+				{ID: "price", Label: "catalog.filters.price", Placement: renderer.FilterGroupPlacementPrimary, Fields: []string{"price", "discount_price"}},
+			},
         },
         Grid: &renderer.Grid{Enabled: true, Mode: renderer.GridModeCards},
         Pagination: &renderer.Pagination{

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -779,6 +779,7 @@ Filters являются server-driven:
 
 - если фильтр есть в `filters[field]`, producer должен применять его server-side;
 - расположение и порядок фильтров определяет `list_page.filters` через `primary`, `secondary`, `more` и `nested`;
+- именованный control, объединяющий несколько полей, задаётся через `list_page.filters.groups`: `id`, локализуемый `label`/`label_key`, `placement` и `fields`; это позволяет renderer отобразить, например, единый `Price` или `Options`, не выводя дочерние поля отдельными dropdown;
 - виртуальные фильтры, не связанные с `ModuleField`, задаются typed `ListModuleAction.VirtualFilters`;
 - range presets задаются в `list_page.filters.range_presets` и содержат `field`, локализуемый `label`, `min`, `max`;
 - selected values передаются в query как `filter[field]=value`;
@@ -789,6 +790,29 @@ Filters являются server-driven:
 Sort format: `field:asc` или `field:desc`.
 
 Pagination: `count`, `size`, `page`.
+
+Пример named controls:
+
+```json
+{
+  "groups": [
+    {
+      "id": "price",
+      "label": "Price",
+      "placement": "primary",
+      "fields": ["incall_1h_price", "outcall_1h_price"]
+    },
+    {
+      "id": "options",
+      "label": "Options",
+      "placement": "primary",
+      "fields": ["smoker", "piercing", "tattoo"]
+    }
+  ]
+}
+```
+
+Все поля группы обязаны присутствовать в top-level `filters` при `addFilters=true`; generator проверяет это до сериализации ответа.
 
 ## Card Schema
 

--- a/generator.go
+++ b/generator.go
@@ -381,6 +381,13 @@ func validateListFilterAvailability(page *renderer.ListPage, filters map[string]
 			}
 		}
 	}
+	for _, group := range page.Filters.Groups {
+		for _, field := range group.Fields {
+			if _, ok := filters[field]; !ok {
+				return fmt.Errorf("renderer filter group %q field %q is not available for the current request", group.ID, field)
+			}
+		}
+	}
 	return nil
 }
 

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -139,12 +139,25 @@ func cloneFilters(v *Filters) *Filters {
 	cp.Secondary = cloneSlice(v.Secondary)
 	cp.More = cloneSlice(v.More)
 	cp.Nested = cloneSlice(v.Nested)
+	cp.Groups = cloneFilterGroups(v.Groups)
 	cp.PillRows = cloneMapRows(v.PillRows)
 	cp.SecondaryPillRows = cloneMapRows(v.SecondaryPillRows)
 	cp.Reset = cloneFilterReset(v.Reset)
 	cp.Text = clonePtr(v.Text)
 	cp.RangePresets = cloneFilterRangePresets(v.RangePresets)
 	return &cp
+}
+
+func cloneFilterGroups(values []FilterGroup) []FilterGroup {
+	if values == nil {
+		return nil
+	}
+	out := make([]FilterGroup, len(values))
+	for i, value := range values {
+		out[i] = value
+		out[i].Fields = cloneSlice(value.Fields)
+	}
+	return out
 }
 
 func cloneFilterRangePresets(values []FilterRangePresets) []FilterRangePresets {

--- a/renderer/filter_groups_test.go
+++ b/renderer/filter_groups_test.go
@@ -1,0 +1,37 @@
+package renderer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniversalValidateFilterGroups(t *testing.T) {
+	tests := []struct {
+		name    string
+		group   FilterGroup
+		errText string
+	}{
+		{name: "missing id", group: FilterGroup{Label: "Price", Placement: FilterGroupPlacementPrimary, Fields: []string{"price"}}, errText: "renderer.Universal: list page filter group id is required"},
+		{name: "missing label", group: FilterGroup{ID: "price", Placement: FilterGroupPlacementPrimary, Fields: []string{"price"}}, errText: `renderer.Universal: list page filter group "price" label is required`},
+		{name: "invalid placement", group: FilterGroup{ID: "price", Label: "Price", Placement: "topbar", Fields: []string{"price"}}, errText: `renderer.Universal: list page filter group "price" has invalid placement "topbar"`},
+		{name: "empty fields", group: FilterGroup{ID: "price", Label: "Price", Placement: FilterGroupPlacementPrimary}, errText: `renderer.Universal: list page filter group "price" must contain at least one field`},
+		{name: "duplicate field", group: FilterGroup{ID: "price", Label: "Price", Placement: FilterGroupPlacementPrimary, Fields: []string{"price", "price"}}, errText: `renderer.Universal: list page filter group "price" contains duplicate field "price"`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (Universal{List: &ListPage{Filters: &Filters{Groups: []FilterGroup{test.group}}}}).Validate()
+			require.EqualError(t, err, test.errText)
+		})
+	}
+
+	t.Run("duplicate ids", func(t *testing.T) {
+		filters := &Filters{Groups: []FilterGroup{
+			{ID: "price", Label: "Price", Placement: FilterGroupPlacementPrimary, Fields: []string{"price"}},
+			{ID: "price", Label: "Options", Placement: FilterGroupPlacementPrimary, Fields: []string{"option"}},
+		}}
+		err := (Universal{List: &ListPage{Filters: filters}}).Validate()
+		require.EqualError(t, err, `renderer.Universal: list page filter group "price" is duplicated`)
+	})
+}

--- a/renderer/filter_groups_test.go
+++ b/renderer/filter_groups_test.go
@@ -34,4 +34,22 @@ func TestUniversalValidateFilterGroups(t *testing.T) {
 		err := (Universal{List: &ListPage{Filters: filters}}).Validate()
 		require.EqualError(t, err, `renderer.Universal: list page filter group "price" is duplicated`)
 	})
+
+	t.Run("field repeated in flat placement and group", func(t *testing.T) {
+		filters := &Filters{
+			Primary: []string{"price"},
+			Groups:  []FilterGroup{{ID: "price", Label: "Price", Placement: FilterGroupPlacementPrimary, Fields: []string{"price"}}},
+		}
+		err := (Universal{List: &ListPage{Filters: filters}}).Validate()
+		require.EqualError(t, err, `renderer.Universal: list page filter field "price" is declared in both primary and group "price"`)
+	})
+
+	t.Run("field repeated in two groups", func(t *testing.T) {
+		filters := &Filters{Groups: []FilterGroup{
+			{ID: "price", Label: "Price", Placement: FilterGroupPlacementPrimary, Fields: []string{"price"}},
+			{ID: "options", Label: "Options", Placement: FilterGroupPlacementPrimary, Fields: []string{"price"}},
+		}}
+		err := (Universal{List: &ListPage{Filters: filters}}).Validate()
+		require.EqualError(t, err, `renderer.Universal: list page filter field "price" is declared in both group "price" and group "options"`)
+	})
 }

--- a/renderer/localize.go
+++ b/renderer/localize.go
@@ -89,6 +89,7 @@ func (localizer textLocalizer) localizeListPage(page *ListPage) {
 	if page.Filters != nil {
 		localizer.localizeFilterPills(page.Filters.PillRows)
 		localizer.localizeFilterPills(page.Filters.SecondaryPillRows)
+		localizer.localizeFilterGroups(page.Filters.Groups)
 		localizer.localizeFilterText(page.Filters.Text)
 		localizer.localizeFilterRangePresets(page.Filters.RangePresets)
 	}
@@ -97,6 +98,13 @@ func (localizer textLocalizer) localizeListPage(page *ListPage) {
 	}
 	if page.CardSchema != nil {
 		localizer.localizeCardSchema(page.CardSchema)
+	}
+}
+
+func (localizer textLocalizer) localizeFilterGroups(groups []FilterGroup) {
+	for i := range groups {
+		groups[i].Label = localizer.localizeRendererText(groups[i].Label, groups[i].LabelKey)
+		groups[i].LabelKey = ""
 	}
 }
 

--- a/renderer/range_presets_test.go
+++ b/renderer/range_presets_test.go
@@ -45,4 +45,9 @@ func TestUniversalValidateRejectsInvalidFilterRangePresets(t *testing.T) {
 			require.EqualError(t, err, test.err)
 		})
 	}
+
+	t.Run("field declared in group", func(t *testing.T) {
+		filters := &Filters{Groups: []FilterGroup{{ID: "price", Label: "Price", Placement: FilterGroupPlacementPrimary, Fields: []string{"rating"}}}, RangePresets: []FilterRangePresets{{Field: "rating", Presets: []FilterRangePreset{{Min: 0, Max: 5}}}}}
+		require.NoError(t, (Universal{List: &ListPage{Filters: filters}}).Validate())
+	})
 }

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -234,6 +234,23 @@ func validateFilterGroups(scope string, filters *Filters) error {
 	if filters == nil {
 		return nil
 	}
+	fieldOwners := make(map[string]string)
+	for _, placement := range []struct {
+		name   string
+		fields []string
+	}{
+		{name: "primary", fields: filters.Primary},
+		{name: "secondary", fields: filters.Secondary},
+		{name: "more", fields: filters.More},
+		{name: "nested", fields: filters.Nested},
+	} {
+		for _, field := range placement.fields {
+			if owner, exists := fieldOwners[field]; exists {
+				return fmt.Errorf("renderer.Universal: %s filter field %q is declared in both %s and %s", scope, field, owner, placement.name)
+			}
+			fieldOwners[field] = placement.name
+		}
+	}
 	ids := make(map[string]struct{}, len(filters.Groups))
 	for _, group := range filters.Groups {
 		if group.ID == "" {
@@ -260,7 +277,11 @@ func validateFilterGroups(scope string, filters *Filters) error {
 			if _, exists := fields[field]; exists {
 				return fmt.Errorf("renderer.Universal: %s filter group %q contains duplicate field %q", scope, group.ID, field)
 			}
+			if owner, exists := fieldOwners[field]; exists {
+				return fmt.Errorf("renderer.Universal: %s filter field %q is declared in both %s and group %q", scope, field, owner, group.ID)
+			}
 			fields[field] = struct{}{}
+			fieldOwners[field] = fmt.Sprintf("group %q", group.ID)
 		}
 	}
 	return nil

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -177,19 +177,35 @@ func validateListPage(scope string, page *ListPage) error {
 	if err := validateFilterRangePresets(scope, page.Filters); err != nil {
 		return err
 	}
+	if err := validateFilterGroups(scope, page.Filters); err != nil {
+		return err
+	}
 	return nil
+}
+
+func filterFields(filters *Filters) map[string]struct{} {
+	declared := make(map[string]struct{})
+	if filters == nil {
+		return declared
+	}
+	for _, placement := range [][]string{filters.Primary, filters.Secondary, filters.More, filters.Nested} {
+		for _, field := range placement {
+			declared[field] = struct{}{}
+		}
+	}
+	for _, group := range filters.Groups {
+		for _, field := range group.Fields {
+			declared[field] = struct{}{}
+		}
+	}
+	return declared
 }
 
 func validateFilterRangePresets(scope string, filters *Filters) error {
 	if filters == nil || len(filters.RangePresets) == 0 {
 		return nil
 	}
-	declared := make(map[string]struct{}, len(filters.Primary)+len(filters.Secondary)+len(filters.More)+len(filters.Nested))
-	for _, fields := range [][]string{filters.Primary, filters.Secondary, filters.More, filters.Nested} {
-		for _, field := range fields {
-			declared[field] = struct{}{}
-		}
-	}
+	declared := filterFields(filters)
 	seen := make(map[string]struct{}, len(filters.RangePresets))
 	for _, group := range filters.RangePresets {
 		if group.Field == "" {
@@ -209,6 +225,42 @@ func validateFilterRangePresets(scope string, filters *Filters) error {
 			if preset.Min > preset.Max {
 				return fmt.Errorf("renderer.Universal: %s range preset for field %q has min greater than max", scope, group.Field)
 			}
+		}
+	}
+	return nil
+}
+
+func validateFilterGroups(scope string, filters *Filters) error {
+	if filters == nil {
+		return nil
+	}
+	ids := make(map[string]struct{}, len(filters.Groups))
+	for _, group := range filters.Groups {
+		if group.ID == "" {
+			return fmt.Errorf("renderer.Universal: %s filter group id is required", scope)
+		}
+		if _, exists := ids[group.ID]; exists {
+			return fmt.Errorf("renderer.Universal: %s filter group %q is duplicated", scope, group.ID)
+		}
+		ids[group.ID] = struct{}{}
+		if group.Label == "" && group.LabelKey == "" {
+			return fmt.Errorf("renderer.Universal: %s filter group %q label is required", scope, group.ID)
+		}
+		if !group.Placement.Valid() {
+			return fmt.Errorf("renderer.Universal: %s filter group %q has invalid placement %q", scope, group.ID, group.Placement)
+		}
+		if len(group.Fields) == 0 {
+			return fmt.Errorf("renderer.Universal: %s filter group %q must contain at least one field", scope, group.ID)
+		}
+		fields := make(map[string]struct{}, len(group.Fields))
+		for _, field := range group.Fields {
+			if field == "" {
+				return fmt.Errorf("renderer.Universal: %s filter group %q contains an empty field", scope, group.ID)
+			}
+			if _, exists := fields[field]; exists {
+				return fmt.Errorf("renderer.Universal: %s filter group %q contains duplicate field %q", scope, group.ID, field)
+			}
+			fields[field] = struct{}{}
 		}
 	}
 	return nil
@@ -271,11 +323,40 @@ type Filters struct {
 	Secondary         []string             `json:"secondary,omitempty"`
 	More              []string             `json:"more,omitempty"`
 	Nested            []string             `json:"nested,omitempty"`
+	Groups            []FilterGroup        `json:"groups,omitempty"`
 	PillRows          [][]FilterPill       `json:"pill_rows,omitempty"`
 	SecondaryPillRows [][]FilterPill       `json:"secondary_pill_rows,omitempty"`
 	Reset             *FilterReset         `json:"reset,omitempty"`
 	Text              *FilterText          `json:"text,omitempty"`
 	RangePresets      []FilterRangePresets `json:"range_presets,omitempty"`
+}
+
+type FilterGroupPlacement string
+
+const (
+	FilterGroupPlacementPrimary   FilterGroupPlacement = "primary"
+	FilterGroupPlacementSecondary FilterGroupPlacement = "secondary"
+	FilterGroupPlacementMore      FilterGroupPlacement = "more"
+	FilterGroupPlacementNested    FilterGroupPlacement = "nested"
+)
+
+func (placement FilterGroupPlacement) Valid() bool {
+	switch placement {
+	case FilterGroupPlacementPrimary, FilterGroupPlacementSecondary, FilterGroupPlacementMore, FilterGroupPlacementNested:
+		return true
+	default:
+		return false
+	}
+}
+
+// FilterGroup describes one named filter control and the fields it owns.
+// Placement determines the typed level in which the control is rendered.
+type FilterGroup struct {
+	ID        string               `json:"id"`
+	Label     string               `json:"label,omitempty"`
+	LabelKey  string               `json:"label_key,omitempty"`
+	Placement FilterGroupPlacement `json:"placement"`
+	Fields    []string             `json:"fields"`
 }
 
 type FilterRangePresets struct {

--- a/renderer_localization_test.go
+++ b/renderer_localization_test.go
@@ -23,6 +23,7 @@ func TestLocalizeRenderer_LocalizesPublicTextOnly(t *testing.T) {
 			"filter.no_results":  "Нет результатов",
 			"filter.cancel":      "Отмена",
 			"filter.close":       "Закрыть",
+			"filter.price":       "Цена",
 			"summary.title":      "Результаты",
 			"badge.verified":     "Проверен",
 			"action.open":        "Открыть",
@@ -58,6 +59,8 @@ func TestLocalizeRenderer_LocalizesPublicTextOnly(t *testing.T) {
 			Subtitle: "list.subtitle",
 			Filters: &renderer.Filters{PillRows: [][]renderer.FilterPill{{
 				{Label: "All", LabelKey: "pill.all", Key: "status", Val: "all"},
+			}}, Groups: []renderer.FilterGroup{{
+				ID: "price", Label: "Price", LabelKey: "filter.price", Placement: renderer.FilterGroupPlacementPrimary, Fields: []string{"price"},
 			}}, Text: &renderer.FilterText{
 				SearchPlaceholder: "filter.search",
 				ResetLabel:        "filter.reset",
@@ -142,6 +145,8 @@ func TestLocalizeRenderer_LocalizesPublicTextOnly(t *testing.T) {
 	require.Equal(t, "Нет результатов", localized.List.Filters.Text.NoResultsLabel)
 	require.Equal(t, "Отмена", localized.List.Filters.Text.CancelLabel)
 	require.Equal(t, "Закрыть", localized.List.Filters.Text.CloseLabel)
+	require.Equal(t, "Цена", localized.List.Filters.Groups[0].Label)
+	require.Empty(t, localized.List.Filters.Groups[0].LabelKey)
 	require.Equal(t, "Проверен", localized.List.CardSchema.Badges[0].Label)
 	require.Empty(t, localized.List.CardSchema.Badges[0].LabelKey)
 	action := localized.List.CardSchema.Actions[0]


### PR DESCRIPTION
## Что изменено
- добавлен универсальный typed `renderer.FilterGroup`: `id`, локализуемая подпись, `placement`, дочерние поля;
- renderer валидирует структуру групп, range presets и доступность каждого дочернего фильтра в `addFilters=true`;
- clone и локализация покрывают группы;
- обновлена спецификация UniversalRenderer и добавлены unit-тесты.

## Зачем
Один control, например `Price` или `Options`, теперь явно описывается API как группа полей. Frontend не должен угадывать такую группировку по route или field ID.

## Проверка
- `go test ./...`