### PR TITLE
feat: support ordered nested filter groups

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -781,6 +781,7 @@ Filters являются server-driven:
 - расположение и порядок фильтров определяет `list_page.filters` через `primary`, `secondary`, `more` и `nested`;
 - именованный control, объединяющий несколько полей, задаётся через `list_page.filters.groups`: `id`, локализуемый `label`/`label_key`, `placement` и `fields`; это позволяет renderer отобразить, например, единый `Options`, не выводя дочерние поля отдельными dropdown;
 - для control со сложным layout задаются typed `presentation` и `sections`. Например, `presentation: "tabs"` описывает порядок вкладок через section `id`, локализуемый заголовок и `fields`. В этом варианте поля задаются только внутри sections, а не в `group.fields`;
+- для ordered nested composition generic group использует `items`. Каждый item содержит ровно один `field` или вложенную typed `group`; вложенная группа наследует placement родителя и поэтому не задаёт собственный `placement`;
 - виртуальные фильтры, не связанные с `ModuleField`, задаются typed `ListModuleAction.VirtualFilters`;
 - range presets задаются в `list_page.filters.range_presets` и содержат `field`, локализуемый `label`, `min`, `max`;
 - selected values передаются в query как `filter[field]=value`;
@@ -797,6 +798,24 @@ Pagination: `count`, `size`, `page`.
 ```json
 {
   "groups": [
+    {
+      "id": "others",
+      "label": "Others",
+      "placement": "nested",
+      "items": [
+        {"field": "language"},
+        {"group": {
+          "id": "breast",
+          "label": "Breast",
+          "presentation": "tabs",
+          "sections": [
+            {"id": "size", "label": "Size", "fields": ["breast_size"]},
+            {"id": "type", "label": "Type", "fields": ["breast_type"]}
+          ]
+        }},
+        {"field": "height"}
+      ]
+    },
     {
       "id": "price",
       "label": "Price",
@@ -817,7 +836,7 @@ Pagination: `count`, `size`, `page`.
 }
 ```
 
-Все поля группы, включая section fields, обязаны присутствовать в top-level `filters` при `addFilters=true`; generator проверяет это до сериализации ответа. Поле принадлежит ровно одному flat placement либо одной группе: `group.fields` для generic group или одной section для group с presentation.
+Все поля группы, включая section fields и nested items, обязаны присутствовать в top-level `filters` при `addFilters=true`; generator проверяет это до сериализации ответа. Поле принадлежит ровно одному flat placement либо одной группе: `group.fields` для generic group, item `field`, или одной section для group с presentation.
 
 ## Card Schema
 

--- a/generator.go
+++ b/generator.go
@@ -382,16 +382,35 @@ func validateListFilterAvailability(page *renderer.ListPage, filters map[string]
 		}
 	}
 	for _, group := range page.Filters.Groups {
-		for _, field := range group.Fields {
+		if err := validateFilterGroupAvailability(group, filters); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateFilterGroupAvailability(group renderer.FilterGroup, filters map[string]fields.ModuleFilterField) error {
+	for _, field := range group.Fields {
+		if _, ok := filters[field]; !ok {
+			return fmt.Errorf("renderer filter group %q field %q is not available for the current request", group.ID, field)
+		}
+	}
+	for _, section := range group.Sections {
+		for _, field := range section.Fields {
 			if _, ok := filters[field]; !ok {
-				return fmt.Errorf("renderer filter group %q field %q is not available for the current request", group.ID, field)
+				return fmt.Errorf("renderer filter group %q section %q field %q is not available for the current request", group.ID, section.ID, field)
 			}
 		}
-		for _, section := range group.Sections {
-			for _, field := range section.Fields {
-				if _, ok := filters[field]; !ok {
-					return fmt.Errorf("renderer filter group %q section %q field %q is not available for the current request", group.ID, section.ID, field)
-				}
+	}
+	for _, item := range group.Items {
+		if item.Field != "" {
+			if _, ok := filters[item.Field]; !ok {
+				return fmt.Errorf("renderer filter group %q field %q is not available for the current request", group.ID, item.Field)
+			}
+		}
+		if item.Group != nil {
+			if err := validateFilterGroupAvailability(*item.Group, filters); err != nil {
+				return err
 			}
 		}
 	}

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -157,6 +157,22 @@ func cloneFilterGroups(values []FilterGroup) []FilterGroup {
 		out[i] = value
 		out[i].Fields = cloneSlice(value.Fields)
 		out[i].Sections = cloneFilterGroupSections(value.Sections)
+		out[i].Items = cloneFilterGroupItems(value.Items)
+	}
+	return out
+}
+
+func cloneFilterGroupItems(values []FilterGroupItem) []FilterGroupItem {
+	if values == nil {
+		return nil
+	}
+	out := make([]FilterGroupItem, len(values))
+	for i, value := range values {
+		out[i] = value
+		if value.Group != nil {
+			cloned := cloneFilterGroups([]FilterGroup{*value.Group})
+			out[i].Group = &cloned[0]
+		}
 	}
 	return out
 }

--- a/renderer/filter_groups_test.go
+++ b/renderer/filter_groups_test.go
@@ -73,4 +73,35 @@ func TestUniversalValidateFilterGroups(t *testing.T) {
 			require.EqualError(t, err, test.errText)
 		})
 	}
+
+	t.Run("ordered nested group", func(t *testing.T) {
+		filters := &Filters{Groups: []FilterGroup{{
+			ID: "others", Label: "Others", Placement: FilterGroupPlacementNested,
+			Items: []FilterGroupItem{
+				{Field: "language"},
+				{Group: &FilterGroup{ID: "breast", Label: "Breast", Presentation: FilterGroupPresentationTabs, Sections: []FilterGroupSection{
+					{ID: "size", Label: "Size", Fields: []string{"breast_size"}},
+					{ID: "type", Label: "Type", Fields: []string{"breast_type"}},
+				}}},
+				{Field: "height"},
+			},
+		}}}
+		require.NoError(t, (Universal{List: &ListPage{Filters: filters}}).Validate())
+	})
+
+	itemTests := []struct {
+		name    string
+		group   FilterGroup
+		errText string
+	}{
+		{name: "item without value", group: FilterGroup{ID: "others", Label: "Others", Placement: FilterGroupPlacementNested, Items: []FilterGroupItem{{}}}, errText: `renderer.Universal: list page filter group "others" item must contain exactly one field or group`},
+		{name: "child placement", group: FilterGroup{ID: "others", Label: "Others", Placement: FilterGroupPlacementNested, Items: []FilterGroupItem{{Group: &FilterGroup{ID: "breast", Label: "Breast", Placement: FilterGroupPlacementPrimary, Fields: []string{"breast_size"}}}}}, errText: `renderer.Universal: list page nested filter group "breast" must not declare placement`},
+		{name: "duplicate child field", group: FilterGroup{ID: "others", Label: "Others", Placement: FilterGroupPlacementNested, Items: []FilterGroupItem{{Field: "breast_size"}, {Group: &FilterGroup{ID: "breast", Label: "Breast", Fields: []string{"breast_size"}}}}}, errText: `renderer.Universal: list page filter field "breast_size" is declared in both group "others" and group "breast"`},
+	}
+	for _, test := range itemTests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (Universal{List: &ListPage{Filters: &Filters{Groups: []FilterGroup{test.group}}}}).Validate()
+			require.EqualError(t, err, test.errText)
+		})
+	}
 }

--- a/renderer/localize.go
+++ b/renderer/localize.go
@@ -103,11 +103,20 @@ func (localizer textLocalizer) localizeListPage(page *ListPage) {
 
 func (localizer textLocalizer) localizeFilterGroups(groups []FilterGroup) {
 	for i := range groups {
-		groups[i].Label = localizer.localizeRendererText(groups[i].Label, groups[i].LabelKey)
-		groups[i].LabelKey = ""
-		for j := range groups[i].Sections {
-			groups[i].Sections[j].Label = localizer.localizeRendererText(groups[i].Sections[j].Label, groups[i].Sections[j].LabelKey)
-			groups[i].Sections[j].LabelKey = ""
+		localizer.localizeFilterGroup(&groups[i])
+	}
+}
+
+func (localizer textLocalizer) localizeFilterGroup(group *FilterGroup) {
+	group.Label = localizer.localizeRendererText(group.Label, group.LabelKey)
+	group.LabelKey = ""
+	for j := range group.Sections {
+		group.Sections[j].Label = localizer.localizeRendererText(group.Sections[j].Label, group.Sections[j].LabelKey)
+		group.Sections[j].LabelKey = ""
+	}
+	for j := range group.Items {
+		if group.Items[j].Group != nil {
+			localizer.localizeFilterGroup(group.Items[j].Group)
 		}
 	}
 }

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -194,16 +194,28 @@ func filterFields(filters *Filters) map[string]struct{} {
 		}
 	}
 	for _, group := range filters.Groups {
-		for _, field := range group.Fields {
-			declared[field] = struct{}{}
-		}
-		for _, section := range group.Sections {
-			for _, field := range section.Fields {
-				declared[field] = struct{}{}
-			}
-		}
+		appendFilterGroupFields(declared, group)
 	}
 	return declared
+}
+
+func appendFilterGroupFields(declared map[string]struct{}, group FilterGroup) {
+	for _, field := range group.Fields {
+		declared[field] = struct{}{}
+	}
+	for _, section := range group.Sections {
+		for _, field := range section.Fields {
+			declared[field] = struct{}{}
+		}
+	}
+	for _, item := range group.Items {
+		if item.Field != "" {
+			declared[item.Field] = struct{}{}
+		}
+		if item.Group != nil {
+			appendFilterGroupFields(declared, *item.Group)
+		}
+	}
 }
 
 func validateFilterRangePresets(scope string, filters *Filters) error {
@@ -286,7 +298,10 @@ func validateFilterGroupContent(scope string, group FilterGroup, fieldOwners map
 		if len(group.Sections) != 0 {
 			return fmt.Errorf("renderer.Universal: %s filter group %q sections require a presentation", scope, group.ID)
 		}
-		if len(group.Fields) == 0 {
+		if len(group.Fields) != 0 && len(group.Items) != 0 {
+			return fmt.Errorf("renderer.Universal: %s filter group %q must use either fields or items", scope, group.ID)
+		}
+		if len(group.Fields) == 0 && len(group.Items) == 0 {
 			return fmt.Errorf("renderer.Universal: %s filter group %q must contain at least one field", scope, group.ID)
 		}
 		for _, field := range group.Fields {
@@ -294,9 +309,12 @@ func validateFilterGroupContent(scope string, group FilterGroup, fieldOwners map
 				return err
 			}
 		}
+		if err := validateFilterGroupItems(scope, group.ID, group.Items, fieldOwners); err != nil {
+			return err
+		}
 		return nil
 	}
-	if len(group.Fields) != 0 {
+	if len(group.Fields) != 0 || len(group.Items) != 0 {
 		return fmt.Errorf("renderer.Universal: %s filter group %q with presentation %q must use sections instead of fields", scope, group.ID, group.Presentation)
 	}
 	if len(group.Sections) == 0 {
@@ -321,6 +339,39 @@ func validateFilterGroupContent(scope string, group FilterGroup, fieldOwners map
 			if err := claimFilterGroupField(scope, group.ID, section.ID, field, fieldOwners); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func validateFilterGroupItems(scope, parentID string, items []FilterGroupItem, fieldOwners map[string]string) error {
+	childIDs := make(map[string]struct{})
+	for _, item := range items {
+		if (item.Field == "") == (item.Group == nil) {
+			return fmt.Errorf("renderer.Universal: %s filter group %q item must contain exactly one field or group", scope, parentID)
+		}
+		if item.Field != "" {
+			if err := claimFilterGroupField(scope, parentID, "", item.Field, fieldOwners); err != nil {
+				return err
+			}
+			continue
+		}
+		child := *item.Group
+		if child.Placement != "" {
+			return fmt.Errorf("renderer.Universal: %s nested filter group %q must not declare placement", scope, child.ID)
+		}
+		if child.ID == "" {
+			return fmt.Errorf("renderer.Universal: %s filter group %q nested group id is required", scope, parentID)
+		}
+		if _, exists := childIDs[child.ID]; exists {
+			return fmt.Errorf("renderer.Universal: %s filter group %q nested group %q is duplicated", scope, parentID, child.ID)
+		}
+		childIDs[child.ID] = struct{}{}
+		if child.Label == "" && child.LabelKey == "" {
+			return fmt.Errorf("renderer.Universal: %s filter group %q nested group %q label is required", scope, parentID, child.ID)
+		}
+		if err := validateFilterGroupContent(scope, child, fieldOwners); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -440,10 +491,11 @@ type FilterGroup struct {
 	ID           string                  `json:"id"`
 	Label        string                  `json:"label,omitempty"`
 	LabelKey     string                  `json:"label_key,omitempty"`
-	Placement    FilterGroupPlacement    `json:"placement"`
+	Placement    FilterGroupPlacement    `json:"placement,omitempty"`
 	Presentation FilterGroupPresentation `json:"presentation,omitempty"`
 	Fields       []string                `json:"fields,omitempty"`
 	Sections     []FilterGroupSection    `json:"sections,omitempty"`
+	Items        []FilterGroupItem       `json:"items,omitempty"`
 }
 
 // FilterGroupSection describes an ordered typed section inside a presented group.
@@ -452,6 +504,13 @@ type FilterGroupSection struct {
 	Label    string   `json:"label,omitempty"`
 	LabelKey string   `json:"label_key,omitempty"`
 	Fields   []string `json:"fields"`
+}
+
+// FilterGroupItem preserves the order of direct fields and nested groups.
+// Exactly one of Field or Group must be set.
+type FilterGroupItem struct {
+	Field string       `json:"field,omitempty"`
+	Group *FilterGroup `json:"group,omitempty"`
 }
 
 type FilterRangePresets struct {

--- a/renderer_localization_test.go
+++ b/renderer_localization_test.go
@@ -25,6 +25,8 @@ func TestLocalizeRenderer_LocalizesPublicTextOnly(t *testing.T) {
 			"filter.close":       "Закрыть",
 			"filter.price":       "Цена",
 			"filter.incall":      "Инколл",
+			"filter.others":      "Другие",
+			"filter.breast":      "Грудь",
 			"summary.title":      "Результаты",
 			"badge.verified":     "Проверен",
 			"action.open":        "Открыть",
@@ -63,6 +65,9 @@ func TestLocalizeRenderer_LocalizesPublicTextOnly(t *testing.T) {
 			}}, Groups: []renderer.FilterGroup{{
 				ID: "price", Label: "Price", LabelKey: "filter.price", Placement: renderer.FilterGroupPlacementPrimary, Presentation: renderer.FilterGroupPresentationTabs,
 				Sections: []renderer.FilterGroupSection{{ID: "incall", Label: "Incall", LabelKey: "filter.incall", Fields: []string{"price"}}},
+			}, {
+				ID: "others", Label: "Others", LabelKey: "filter.others", Placement: renderer.FilterGroupPlacementNested,
+				Items: []renderer.FilterGroupItem{{Group: &renderer.FilterGroup{ID: "breast", Label: "Breast", LabelKey: "filter.breast", Fields: []string{"breast_size"}}}},
 			}}, Text: &renderer.FilterText{
 				SearchPlaceholder: "filter.search",
 				ResetLabel:        "filter.reset",
@@ -151,6 +156,10 @@ func TestLocalizeRenderer_LocalizesPublicTextOnly(t *testing.T) {
 	require.Empty(t, localized.List.Filters.Groups[0].LabelKey)
 	require.Equal(t, "Инколл", localized.List.Filters.Groups[0].Sections[0].Label)
 	require.Empty(t, localized.List.Filters.Groups[0].Sections[0].LabelKey)
+	require.Equal(t, "Другие", localized.List.Filters.Groups[1].Label)
+	require.Empty(t, localized.List.Filters.Groups[1].LabelKey)
+	require.Equal(t, "Грудь", localized.List.Filters.Groups[1].Items[0].Group.Label)
+	require.Empty(t, localized.List.Filters.Groups[1].Items[0].Group.LabelKey)
 	require.Equal(t, "Проверен", localized.List.CardSchema.Badges[0].Label)
 	require.Empty(t, localized.List.CardSchema.Badges[0].LabelKey)
 	action := localized.List.CardSchema.Actions[0]


### PR DESCRIPTION
## Что изменено
- generic `FilterGroup` поддерживает typed ordered `items`; каждый item содержит ровно одно: direct `field` или nested `group`;
- nested group не имеет собственного placement и может использовать `presentation: "tabs"` с sections;
- добавлены рекурсивные validation, availability, clone и localization;
- обновлена спецификация UniversalRenderer и unit-тесты, включая ownership дочерних полей.

## Зачем
API может описывать сложную композицию вроде `Others`: прямые поля в заданном порядке, внутри них named `Breast` control с tabs `Size` и `Type`, без route/field-name эвристик во frontend.

## Проверка
- `go test ./...`