### PR TITLE
feat: use effective typed list filter registry

### DIFF
--- a/db/executor.go
+++ b/db/executor.go
@@ -28,7 +28,7 @@ type DBExecutor interface {
 		table pg.Table,
 		primaryKey pg.Column,
 		moduleFields []fields.ModuleField,
-		allFields []fields.ModuleField,
+		filterRegistry map[string]fields.ModuleFilterField,
 		page int64,
 		size int64,
 		searchColumns []pg.Column,

--- a/db/postgres_db.go
+++ b/db/postgres_db.go
@@ -288,7 +288,7 @@ func (db *DB) List(
 	table pg.Table,
 	primaryKey pg.Column,
 	moduleFields []fields.ModuleField,
-	allFields []fields.ModuleField,
+	filterRegistry map[string]fields.ModuleFilterField,
 	page int64,
 	size int64,
 	searchColumns []pg.Column,
@@ -362,12 +362,6 @@ func (db *DB) List(
 
 	// Filters
 	if len(filter) > 0 {
-		fieldTypeMap := make(map[string]fields.ModuleFieldType)
-		formTypeMap := make(map[string]fields.ModuleFieldFormType)
-		for _, field := range allFields {
-			fieldTypeMap[field.ColumnName()] = field.Type
-			formTypeMap[field.ColumnName()] = field.FormType
-		}
 		for key, value := range filter {
 			parts := strings.Split(key, ".")
 			colName := key
@@ -377,8 +371,17 @@ func (db *DB) List(
 				tblRef = parts[0]
 			}
 
-			ft := fieldTypeMap[colName]
-			fmt2 := formTypeMap[colName]
+			definition, ok := filterRegistry[key]
+			if !ok {
+				// Dotted relation filters retain the existing physical-key path.
+				definition, ok = filterRegistry[colName]
+			}
+			if !ok || definition.Column == nil {
+				continue
+			}
+			colName = definition.Column.Name()
+			ft := definition.Type
+			fmt2 := definition.FormType
 
 			// 1. Array-type columns → overlap operator (&&)
 			if ft == fields.ModuleFieldTypeArray {

--- a/db/postgres_db.go
+++ b/db/postgres_db.go
@@ -362,14 +362,12 @@ func (db *DB) List(
 
 	// Filters
 	if len(filter) > 0 {
-		// Build lookup maps from allFields (all module fields, not just SELECT columns)
 		fieldTypeMap := make(map[string]fields.ModuleFieldType)
 		formTypeMap := make(map[string]fields.ModuleFieldFormType)
-		for _, f := range allFields {
-			fieldTypeMap[f.ColumnName()] = f.Type
-			formTypeMap[f.ColumnName()] = f.FormType
+		for _, field := range allFields {
+			fieldTypeMap[field.ColumnName()] = field.Type
+			formTypeMap[field.ColumnName()] = field.FormType
 		}
-
 		for key, value := range filter {
 			parts := strings.Split(key, ".")
 			colName := key

--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -784,6 +784,7 @@ Filters являются server-driven:
 - для ordered nested composition generic group использует `items`. Каждый item содержит ровно один `field` или вложенную typed `group`; вложенная группа наследует placement родителя и поэтому не задаёт собственный `placement`;
 - виртуальные фильтры, не связанные с `ModuleField`, задаются typed `ListModuleAction.VirtualFilters`;
 - range presets задаются в `list_page.filters.range_presets` и содержат `field`, локализуемый `label`, `min`, `max`;
+- numeric range controls используют локализованные `list_page.filters.text.range_min_label` и `range_max_label`;
 - selected values передаются в query как `filter[field]=value`;
 - multi-value filters передаются повторением query value или согласованным serialized array;
 - search query передается отдельным search parameter, если list action поддерживает search;
@@ -837,6 +838,8 @@ Pagination: `count`, `size`, `page`.
 ```
 
 Все поля группы, включая section fields и nested items, обязаны присутствовать в top-level `filters` при `addFilters=true`; generator проверяет это до сериализации ответа. Поле принадлежит ровно одному flat placement либо одной группе: `group.fields` для generic group, item `field`, или одной section для group с presentation.
+
+Для list action generator строит effective typed filter registry из разрешённых module fields и `VirtualFilters`. Virtual definition с тем же logical key имеет приоритет для нормализации query, metadata ответа и SQL predicate; так action может изменить filter semantics, не меняя form semantics записи.
 
 ## Card Schema
 

--- a/effective_list_filters_test.go
+++ b/effective_list_filters_test.go
@@ -1,0 +1,37 @@
+package module
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/darkrain/request-generator/actions"
+	"github.com/darkrain/request-generator/fields"
+	"github.com/darkrain/request-generator/locale"
+	"github.com/gin-gonic/gin"
+	pg "github.com/go-jet/jet/v2/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveListFilters_VirtualDefinitionOverridesModuleField(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ethnicity := pg.StringColumn("ethnicity")
+	request := httptest.NewRequest("GET", "/items", nil)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = request
+	generator := &Generator{}
+	registry := generator.effectiveListFilters(context, &BaseModule{Fields: []fields.ModuleField{{
+		Column: ethnicity, Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeSelect,
+	}}}, actions.ListModuleAction{
+		Filter: []pg.Column{ethnicity},
+		VirtualFilters: []fields.ModuleFilterField{{
+			FieldName: "ethnicity", Column: ethnicity, Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeMultiselect,
+		}},
+	}, locale.EN)
+
+	require.Equal(t, fields.ModuleFieldFormTypeMultiselect, registry["ethnicity"].FormType)
+	normalized := generator.normalizeFilters(map[string]string{"ethnicity": "{asian,latin}"}, registry, locale.EN)
+	require.Equal(t, "{asian,latin}", normalized["ethnicity"])
+	effective := effectiveListFilterFields(registry)
+	require.Len(t, effective, 1)
+	require.Equal(t, fields.ModuleFieldFormTypeMultiselect, effective[0].FormType)
+}

--- a/effective_list_filters_test.go
+++ b/effective_list_filters_test.go
@@ -31,7 +31,4 @@ func TestEffectiveListFilters_VirtualDefinitionOverridesModuleField(t *testing.T
 	require.Equal(t, fields.ModuleFieldFormTypeMultiselect, registry["ethnicity"].FormType)
 	normalized := generator.normalizeFilters(map[string]string{"ethnicity": "{asian,latin}"}, registry, locale.EN)
 	require.Equal(t, "{asian,latin}", normalized["ethnicity"])
-	effective := effectiveListFilterFields(registry)
-	require.Len(t, effective, 1)
-	require.Equal(t, fields.ModuleFieldFormTypeMultiselect, effective[0].FormType)
 }

--- a/generator.go
+++ b/generator.go
@@ -558,7 +558,7 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			module.Table,
 			module.PrimaryKey,
 			realFields,
-			effectiveListFilterFields(filter),
+			filter,
 			page,
 			size,
 			action.Search,

--- a/generator.go
+++ b/generator.go
@@ -488,7 +488,8 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			size = action.Maxsize
 		}
 		isCSV := int64QueryParam(c, "csv", 0)
-		filters := generator.normalizeFilters(c, c.QueryMap("filter"), module, action, lang)
+		filter := generator.effectiveListFilters(c, module, action, lang)
+		filters := generator.normalizeFilters(c.QueryMap("filter"), filter, lang)
 		searchText := c.Query("search")
 		addFilters := c.Query("addFilters")
 		addHeads := c.Query("addHeads")
@@ -557,7 +558,7 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 			module.Table,
 			module.PrimaryKey,
 			realFields,
-			module.Fields,
+			effectiveListFilterFields(filter),
 			page,
 			size,
 			action.Search,
@@ -585,55 +586,6 @@ func (generator *Generator) actionList(module *BaseModule, action actions.ListMo
 					}
 				}
 			}
-		}
-
-		filter := make(map[string]fields.ModuleFilterField)
-		filterCols := action.Filter
-		if action.FilterFunc != nil {
-			filterCols = action.FilterFunc(c)
-		}
-		for _, realField := range module.Fields {
-			if realField.FilterCondition != nil && !realField.FilterCondition(c) {
-				continue
-			}
-			if containsColumn(filterCols, realField.Column) {
-				roleStr := string(actions.GetRoleFromContext(c))
-				options := generator.fieldOptions(c, realField, roleStr, lang)
-				filterField := fields.ModuleFilterField{
-					Column:        realField.Column,
-					Title:         generator.Translate(lang, realField.Title),
-					Type:          realField.Type,
-					FormType:      realField.FormType,
-					Example:       realField.Example,
-					AllLabel:      generator.Translate(lang, realField.AllLabel),
-					Options:       options,
-					OptionsSource: realField.OptionsSource,
-					Check:         realField.Check,
-					Convert:       realField.Convert,
-				}
-				filter[realField.ColumnName()] = filterField
-			}
-		}
-		for _, ef := range action.VirtualFilters {
-			if ef.FilterCondition != nil && !ef.FilterCondition(c) {
-				continue
-			}
-			key := ef.FieldName
-			if key == "" && ef.Column != nil {
-				key = ef.Column.Name()
-			}
-			if key == "" {
-				continue
-			}
-			translatedOpts := make([]fields.ModuleFieldOptions, len(ef.Options))
-			copy(translatedOpts, ef.Options)
-			for i := range translatedOpts {
-				translatedOpts[i].Label = generator.Translate(lang, translatedOpts[i].Label)
-			}
-			ef.Title = generator.Translate(lang, ef.Title)
-			ef.AllLabel = generator.Translate(lang, ef.AllLabel)
-			ef.Options = translatedOpts
-			filter[key] = ef
 		}
 
 		if len(results) == 0 {

--- a/helpers.go
+++ b/helpers.go
@@ -29,25 +29,12 @@ func (generator *Generator) getPagination(page int64, size int64) (int64, int64,
 	return limit, offset, page
 }
 
-func (generator *Generator) normalizeFilters(c *gin.Context, data map[string]string, module *BaseModule, listAction actions.ListModuleAction, lang locale.Lang) map[string]string {
+func (generator *Generator) normalizeFilters(data map[string]string, filters map[string]fields.ModuleFilterField, lang locale.Lang) map[string]string {
 	resultFilterMap := make(map[string]string)
 
-	// Resolve allowed filter columns: static Filter + dynamic FilterFunc
-	allowedCols := listAction.Filter
-	if listAction.FilterFunc != nil {
-		allowedCols = append(allowedCols, listAction.FilterFunc(c)...)
-	}
-
-	filters := make(map[string]fields.ModuleField)
-	for _, realField := range module.Fields {
-		if containsColumn(allowedCols, realField.Column) {
-			filters[realField.ColumnName()] = realField
-		}
-	}
-
 parentLoop:
-	for _, filter := range filters {
-		filterValue, ok := data[filter.ColumnName()]
+	for key, filter := range filters {
+		filterValue, ok := data[key]
 		if !ok || len(filterValue) == 0 {
 			continue
 		}
@@ -58,7 +45,7 @@ parentLoop:
 			}
 		}
 
-		resultFilterMap[filter.ColumnName()] = filterValue
+		resultFilterMap[key] = filterValue
 	}
 
 	for key, value := range data {
@@ -69,6 +56,59 @@ parentLoop:
 	}
 
 	return resultFilterMap
+}
+
+// effectiveListFilters is the sole typed registry for a list action. Virtual
+// definitions intentionally override the same logical key for that action.
+func (generator *Generator) effectiveListFilters(c *gin.Context, module *BaseModule, action actions.ListModuleAction, lang locale.Lang) map[string]fields.ModuleFilterField {
+	allowedColumns := append([]pg.Column{}, action.Filter...)
+	if action.FilterFunc != nil {
+		allowedColumns = append(allowedColumns, action.FilterFunc(c)...)
+	}
+	registry := make(map[string]fields.ModuleFilterField)
+	role := string(actions.GetRoleFromContext(c))
+	for _, field := range module.Fields {
+		if field.FilterCondition != nil && !field.FilterCondition(c) || !containsColumn(allowedColumns, field.Column) {
+			continue
+		}
+		registry[field.ColumnName()] = fields.ModuleFilterField{
+			Column: field.Column, Title: generator.Translate(lang, field.Title), Type: field.Type, FormType: field.FormType,
+			Example: field.Example, AllLabel: generator.Translate(lang, field.AllLabel), Options: generator.fieldOptions(c, field, role, lang),
+			OptionsSource: field.OptionsSource, Check: field.Check, Convert: field.Convert,
+		}
+	}
+	for _, field := range action.VirtualFilters {
+		if field.FilterCondition != nil && !field.FilterCondition(c) {
+			continue
+		}
+		key := field.FieldName
+		if key == "" && field.Column != nil {
+			key = field.Column.Name()
+		}
+		if key == "" {
+			continue
+		}
+		options := append([]fields.ModuleFieldOptions(nil), field.Options...)
+		for i := range options {
+			options[i].Label = generator.Translate(lang, options[i].Label)
+		}
+		field.Title = generator.Translate(lang, field.Title)
+		field.AllLabel = generator.Translate(lang, field.AllLabel)
+		field.Options = options
+		registry[key] = field
+	}
+	return registry
+}
+
+func effectiveListFilterFields(registry map[string]fields.ModuleFilterField) []fields.ModuleField {
+	result := make([]fields.ModuleField, 0, len(registry))
+	for _, filter := range registry {
+		if filter.Column == nil {
+			continue
+		}
+		result = append(result, fields.ModuleField{Column: filter.Column, Type: filter.Type, FormType: filter.FormType})
+	}
+	return result
 }
 
 func (generator *Generator) checkRequest(

--- a/helpers.go
+++ b/helpers.go
@@ -100,16 +100,6 @@ func (generator *Generator) effectiveListFilters(c *gin.Context, module *BaseMod
 	return registry
 }
 
-func effectiveListFilterFields(registry map[string]fields.ModuleFilterField) []fields.ModuleField {
-	result := make([]fields.ModuleField, 0, len(registry))
-	for _, filter := range registry {
-		if filter.Column == nil {
-			continue
-		}
-		result = append(result, fields.ModuleField{Column: filter.Column, Type: filter.Type, FormType: filter.FormType})
-	}
-	return result
-}
 
 func (generator *Generator) checkRequest(
 	context *gin.Context,

--- a/renderer/localize.go
+++ b/renderer/localize.go
@@ -131,7 +131,7 @@ func (localizer textLocalizer) localizeFilterRangePresets(groups []FilterRangePr
 
 func (localizer textLocalizer) localizeFilterText(text *FilterText) {
 	if text != nil {
-		localizer.localizeTextFields(&text.SearchPlaceholder, &text.ResetLabel, &text.ResetAllLabel, &text.ApplyLabel, &text.LoadingLabel, &text.EmptyLabel, &text.NoResultsLabel, &text.CancelLabel, &text.CloseLabel)
+		localizer.localizeTextFields(&text.SearchPlaceholder, &text.ResetLabel, &text.ResetAllLabel, &text.ApplyLabel, &text.LoadingLabel, &text.EmptyLabel, &text.NoResultsLabel, &text.CancelLabel, &text.CloseLabel, &text.RangeMinLabel, &text.RangeMaxLabel)
 	}
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -537,6 +537,8 @@ type FilterText struct {
 	NoResultsLabel    string `json:"no_results_label,omitempty"`
 	CancelLabel       string `json:"cancel_label,omitempty"`
 	CloseLabel        string `json:"close_label,omitempty"`
+	RangeMinLabel     string `json:"range_min_label,omitempty"`
+	RangeMaxLabel     string `json:"range_max_label,omitempty"`
 }
 
 type FilterPill struct {

--- a/renderer_localization_test.go
+++ b/renderer_localization_test.go
@@ -23,6 +23,8 @@ func TestLocalizeRenderer_LocalizesPublicTextOnly(t *testing.T) {
 			"filter.no_results":  "Нет результатов",
 			"filter.cancel":      "Отмена",
 			"filter.close":       "Закрыть",
+			"filter.range_min":   "Минимум",
+			"filter.range_max":   "Максимум",
 			"filter.price":       "Цена",
 			"filter.incall":      "Инколл",
 			"filter.others":      "Другие",
@@ -78,6 +80,8 @@ func TestLocalizeRenderer_LocalizesPublicTextOnly(t *testing.T) {
 				NoResultsLabel:    "filter.no_results",
 				CancelLabel:       "filter.cancel",
 				CloseLabel:        "filter.close",
+				RangeMinLabel:     "filter.range_min",
+				RangeMaxLabel:     "filter.range_max",
 			}},
 			Summary: &renderer.Summary{Title: "summary.title"},
 			CardSchema: &renderer.CardSchema{
@@ -152,6 +156,8 @@ func TestLocalizeRenderer_LocalizesPublicTextOnly(t *testing.T) {
 	require.Equal(t, "Нет результатов", localized.List.Filters.Text.NoResultsLabel)
 	require.Equal(t, "Отмена", localized.List.Filters.Text.CancelLabel)
 	require.Equal(t, "Закрыть", localized.List.Filters.Text.CloseLabel)
+	require.Equal(t, "Минимум", localized.List.Filters.Text.RangeMinLabel)
+	require.Equal(t, "Максимум", localized.List.Filters.Text.RangeMaxLabel)
 	require.Equal(t, "Цена", localized.List.Filters.Groups[0].Label)
 	require.Empty(t, localized.List.Filters.Groups[0].LabelKey)
 	require.Equal(t, "Инколл", localized.List.Filters.Groups[0].Sections[0].Label)

--- a/tests/integration/relation_scope_actions_test.go
+++ b/tests/integration/relation_scope_actions_test.go
@@ -35,7 +35,7 @@ func (db *scopedActionDB) List(
 	table pg.Table,
 	_ pg.Column,
 	_ []fields.ModuleField,
-	_ []fields.ModuleField,
+	_ map[string]fields.ModuleFilterField,
 	_ int64,
 	_ int64,
 	_ []pg.Column,

--- a/tests/integration/universal_renderer_response_test.go
+++ b/tests/integration/universal_renderer_response_test.go
@@ -28,7 +28,7 @@ func (fakeRendererDB) List(
 	_ pg.Table,
 	_ pg.Column,
 	_ []fields.ModuleField,
-	_ []fields.ModuleField,
+	_ map[string]fields.ModuleFilterField,
 	_ int64,
 	_ int64,
 	_ []pg.Column,

--- a/tests/postgres_db_test.go
+++ b/tests/postgres_db_test.go
@@ -125,6 +125,14 @@ func testModuleFields() []fields.ModuleField {
 	}
 }
 
+func testFilterRegistry(values []fields.ModuleField) map[string]fields.ModuleFilterField {
+	registry := make(map[string]fields.ModuleFilterField, len(values))
+	for _, field := range values {
+		registry[field.ColumnName()] = fields.ModuleFilterField{Column: field.Column, Type: field.Type, FormType: field.FormType}
+	}
+	return registry
+}
+
 func seedItem(t *testing.T, name, email string, age int, role string) int64 {
 	mf := testModuleFields()
 	input := map[string]interface{}{
@@ -232,11 +240,25 @@ func TestViewNotFound(t *testing.T) {
 
 // --- List ---
 
+func TestListUsesLogicalVirtualFilterKey(t *testing.T) {
+	cleanTable(t)
+	seedItem(t, "Alice", "alice@test.com", 25, "admin")
+	seedItem(t, "Bob", "bob@test.com", 30, "user")
+	mf := testModuleFields()
+	registry := testFilterRegistry(mf)
+	registry["appearance"] = fields.ModuleFilterField{Column: tbl.Role, Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeMultiselect}
+
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, registry, 0, 100, nil, "", map[string]string{"appearance": "{admin,user}"}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), count)
+	require.Len(t, results, 2)
+}
+
 func TestListEmpty(t *testing.T) {
 	cleanTable(t)
 
 	mf := testModuleFields()
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 	assert.Empty(t, results)
@@ -249,7 +271,7 @@ func TestListMultipleItems(t *testing.T) {
 	seedItem(t, "Charlie", "charlie@test.com", 35, "user")
 
 	mf := testModuleFields()
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), count)
 	assert.Len(t, results, 3)
@@ -263,11 +285,11 @@ func TestListPagination(t *testing.T) {
 
 	mf := testModuleFields()
 
-	results, _, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 2, nil, "", nil, nil, nil, nil, nil)
+	results, _, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 2, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Len(t, results, 2)
 
-	results, _, err = testDB.List(testLog, tbl, tbl.ID, mf, mf, 1, 2, nil, "", nil, nil, nil, nil, nil)
+	results, _, err = testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 1, 2, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 }
@@ -280,7 +302,7 @@ func TestListSearch(t *testing.T) {
 	mf := testModuleFields()
 	searchColumns := []postgres.Column{tbl.Email}
 
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, searchColumns, "alice", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, searchColumns, "alice", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.Len(t, results, 1)
@@ -295,7 +317,7 @@ func TestListFilter(t *testing.T) {
 	mf := testModuleFields()
 	filter := map[string]string{"role": "user"}
 
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", filter, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, nil, "", filter, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), count)
 	assert.Len(t, results, 2)
@@ -317,7 +339,7 @@ func TestListDateRangeFilter(t *testing.T) {
 	mf := testModuleFields()
 	filter := map[string]string{"creation_date": "2026-06-01..2026-06-30"}
 
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", filter, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, nil, "", filter, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), count)
 	assert.Len(t, results, 2)
@@ -331,7 +353,7 @@ func TestListWhere(t *testing.T) {
 	mf := testModuleFields()
 	where := postgres.RawBool(`test_items."age" > #age`, postgres.RawArgs{"#age": 26})
 
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, where, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, nil, "", nil, where, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.Len(t, results, 1)
@@ -393,7 +415,7 @@ func TestDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	mf := testModuleFields()
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 	assert.Empty(t, results)
@@ -432,7 +454,7 @@ func TestListWithJoin(t *testing.T) {
 	}
 
 	mf := testModuleFields()
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, []actions.ModuleActionJoin{join}, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, nil, "", nil, nil, []actions.ModuleActionJoin{join}, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.Len(t, results, 1)
@@ -466,7 +488,7 @@ func TestListSearchJoinedColumn(t *testing.T) {
 	}
 
 	mf := testModuleFields()
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, []postgres.Column{tagCol}, "rust", nil, nil, []actions.ModuleActionJoin{join}, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, []postgres.Column{tagCol}, "rust", nil, nil, []actions.ModuleActionJoin{join}, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.Len(t, results, 1)
@@ -487,7 +509,7 @@ func TestAddRollbackOnError(t *testing.T) {
 	_, err = testDB.Add(testLog, tbl, tbl.ID, mf, input2, nil)
 	assert.Error(t, err)
 
-	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, mf, 0, 100, nil, "", nil, nil, nil, nil, nil)
+	results, count, err := testDB.List(testLog, tbl, tbl.ID, mf, testFilterRegistry(mf), 0, 100, nil, "", nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 	assert.Len(t, results, 1)


### PR DESCRIPTION
## Что изменено
- generator собирает единый effective typed filter registry для list action; VirtualFilters с тем же logical key переопределяет module field;
- registry используется для normalizing query, metadata `filters` и typed field list, из которого DB выбирает SQL predicate;
- добавлены localized `FilterText.range_min_label` и `range_max_label`;
- обновлён UniversalRenderer contract и тесты override/localization.

## Проверка
- `go test ./...`