### PR TITLE
feat: add typed icon-only action flag

### DIFF
--- a/renderer/localize_test.go
+++ b/renderer/localize_test.go
@@ -1,15 +1,17 @@
 package renderer
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestLocalizeUsesResolverWithoutMutatingSource(t *testing.T) {
+	iconOnly := true
 	source := Universal{Form: &FormPage{
 		Title:   "form.title",
-		Actions: []Action{{ID: "save", Label: "Save", LabelKey: "actions.save"}},
+		Actions: []Action{{ID: "save", Label: "Save", LabelKey: "actions.save", AriaLabel: "Save", AriaLabelKey: "actions.save", Title: "Save", TitleKey: "actions.save", IconOnly: &iconOnly}},
 		Sections: []FormSection{{
 			ID: "rates",
 			Matrix: &FieldMatrix{Type: FieldMatrixTypeTable, Table: &FieldMatrixTable{
@@ -42,6 +44,13 @@ func TestLocalizeUsesResolverWithoutMutatingSource(t *testing.T) {
 	require.Equal(t, "Settings", localized.Form.Title)
 	require.Equal(t, "Save changes", localized.Form.Actions[0].Label)
 	require.Empty(t, localized.Form.Actions[0].LabelKey)
+	require.Equal(t, "Save changes", localized.Form.Actions[0].AriaLabel)
+	require.Equal(t, "Save changes", localized.Form.Actions[0].Title)
+	require.NotNil(t, localized.Form.Actions[0].IconOnly)
+	require.True(t, *localized.Form.Actions[0].IconOnly)
+	encoded, err := json.Marshal(localized.Form.Actions[0])
+	require.NoError(t, err)
+	require.JSONEq(t, `{"id":"save","label":"Save changes","aria_label":"Save changes","title":"Save changes","icon_only":true}`, string(encoded))
 	require.Equal(t, "Duration", localized.Form.Sections[0].Matrix.Table.Heads[0])
 	require.Equal(t, "Not available", localized.Form.Sections[0].Matrix.Table.Rows[0].Cells[0].Text)
 	require.Equal(t, "form.title", source.Form.Title)

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -1203,6 +1203,7 @@ type Action struct {
 	SavingLabel      string           `json:"saving_label,omitempty"`
 	SavedLabel       string           `json:"saved_label,omitempty"`
 	Icon             string           `json:"icon,omitempty"`
+	IconOnly         *bool            `json:"icon_only,omitempty"`
 	Variant          ActionVariant    `json:"variant,omitempty"`
 	Appearance       ActionAppearance `json:"appearance,omitempty"`
 	ActiveAppearance ActionAppearance `json:"active_appearance,omitempty"`


### PR DESCRIPTION
Добавлен `renderer.Action.IconOnly` с JSON `icon_only`. Локализация label/aria_label/title не меняется; контрактный тест проверяет сохранение флага и сериализацию.

Проверка: `go test ./...`.