### PR TITLE
feat: add typed card action layout

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -765,6 +765,7 @@ Renderer-specific enum values должны быть описаны в разде
 | `card_schema.variant` | `default`, `media`, `compact` |
 | `card_schema.surface_variant` | `default`, `primary`, `secondary` |
 | `card_schema.surface_effect` | `none`, `flat`, `elevated` |
+| `card_schema.action_layout` | `inline`, `edge_fill` |
 | `card_schema.media.ratio` | `square`, `portrait`, `landscape`, `wide` |
 | `card_schema.media.size` | `thumb`, `card`, `hero` |
 | `form_page.layout` | `one_column`, `two_column`, `three_column` |
@@ -854,6 +855,7 @@ Pagination: `count`, `size`, `page`.
   "surface_effect": "flat",
   "badge_size": "sm",
   "action_size": "sm",
+  "action_layout": "edge_fill",
   "primary_action": "open",
   "media": {"field": "avatar", "ratio": "portrait", "size": "card"},
   "title": {"field": "name"},
@@ -865,6 +867,8 @@ Pagination: `count`, `size`, `page`.
   "actions": []
 }
 ```
+
+`action_layout` определяет раскладку `actions`: пустое значение и `inline` используют обычный ряд. При `edge_fill` действия сохраняют объявленный порядок, а свободное место заполняет только действие без `icon_only`. `block` не меняет поведение этого поля.
 
 ## Action Contract
 

--- a/renderer/card_action_layout_test.go
+++ b/renderer/card_action_layout_test.go
@@ -1,0 +1,43 @@
+package renderer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCardActionLayoutValidationAndJSON(t *testing.T) {
+	schema := CardSchema{ActionLayout: CardActionLayoutEdgeFill}
+	if err := schema.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	encoded, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if got, want := string(encoded), `{"action_layout":"edge_fill"}`; got != want {
+		t.Fatalf("Marshal() = %s, want %s", got, want)
+	}
+
+	invalid := CardSchema{ActionLayout: CardActionLayout("stacked")}
+	if got, want := invalid.Validate().Error(), `renderer.CardSchema: unsupported action layout "stacked"`; got != want {
+		t.Fatalf("Validate() error = %q, want %q", got, want)
+	}
+}
+
+func TestCardActionLayoutIsNotChangedByLocalization(t *testing.T) {
+	value := true
+	source := Universal{List: &ListPage{CardSchema: &CardSchema{
+		ActionLayout: CardActionLayoutEdgeFill,
+		Actions:      []Action{{LabelKey: "action.open", IconOnly: &value}},
+	}}}
+
+	localized := Localize(source, func(value, key string) string { return "Open" })
+	got := localized.List.CardSchema
+	if got.ActionLayout != CardActionLayoutEdgeFill {
+		t.Fatalf("ActionLayout = %q, want %q", got.ActionLayout, CardActionLayoutEdgeFill)
+	}
+	if got.Actions[0].Label != "Open" {
+		t.Fatalf("localized action label = %q, want Open", got.Actions[0].Label)
+	}
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -154,6 +154,9 @@ func (r Universal) Validate() error {
 			return err
 		}
 		if r.ResourceGrid.Card != nil {
+			if err := r.ResourceGrid.Card.Validate(); err != nil {
+				return err
+			}
 			if err := validateActions("resource grid card", r.ResourceGrid.Card.Actions); err != nil {
 				return err
 			}
@@ -170,6 +173,9 @@ func validateListPage(scope string, page *ListPage) error {
 		return err
 	}
 	if page.CardSchema != nil {
+		if err := page.CardSchema.Validate(); err != nil {
+			return err
+		}
 		if err := validateActions(scope+" card schema", page.CardSchema.Actions); err != nil {
 			return err
 		}
@@ -585,25 +591,45 @@ type Summary struct {
 	ShowAction    *bool  `json:"show_action,omitempty"`
 }
 
+type CardActionLayout string
+
+const (
+	CardActionLayoutInline   CardActionLayout = "inline"
+	CardActionLayoutEdgeFill CardActionLayout = "edge_fill"
+)
+
 type CardSchema struct {
-	Type             string         `json:"type,omitempty"`
-	Variant          CardVariant    `json:"variant,omitempty"`
-	Size             SizeToken      `json:"size,omitempty"`
-	SurfaceVariant   SurfaceVariant `json:"surface_variant,omitempty"`
-	SurfaceEffect    SurfaceEffect  `json:"surface_effect,omitempty"`
-	BadgeSize        SizeToken      `json:"badge_size,omitempty"`
-	ActionSize       SizeToken      `json:"action_size,omitempty"`
-	DeleteActionSize SizeToken      `json:"delete_action_size,omitempty"`
-	PrimaryAction    string         `json:"primary_action,omitempty"`
-	Media            *Media         `json:"media,omitempty"`
-	Title            *TextBinding   `json:"title,omitempty"`
-	Subtitle         *TextBinding   `json:"subtitle,omitempty"`
-	SubtitleTone     string         `json:"subtitle_tone,omitempty"`
-	Description      *TextBinding   `json:"description,omitempty"`
-	Status           *StatusBinding `json:"status,omitempty"`
-	Badges           []Badge        `json:"badges,omitempty"`
-	Stats            []Badge        `json:"stats,omitempty"`
-	Actions          []Action       `json:"actions,omitempty"`
+	Type             string           `json:"type,omitempty"`
+	Variant          CardVariant      `json:"variant,omitempty"`
+	Size             SizeToken        `json:"size,omitempty"`
+	SurfaceVariant   SurfaceVariant   `json:"surface_variant,omitempty"`
+	SurfaceEffect    SurfaceEffect    `json:"surface_effect,omitempty"`
+	BadgeSize        SizeToken        `json:"badge_size,omitempty"`
+	ActionSize       SizeToken        `json:"action_size,omitempty"`
+	DeleteActionSize SizeToken        `json:"delete_action_size,omitempty"`
+	ActionLayout     CardActionLayout `json:"action_layout,omitempty"`
+	PrimaryAction    string           `json:"primary_action,omitempty"`
+	Media            *Media           `json:"media,omitempty"`
+	Title            *TextBinding     `json:"title,omitempty"`
+	Subtitle         *TextBinding     `json:"subtitle,omitempty"`
+	SubtitleTone     string           `json:"subtitle_tone,omitempty"`
+	Description      *TextBinding     `json:"description,omitempty"`
+	Status           *StatusBinding   `json:"status,omitempty"`
+	Badges           []Badge          `json:"badges,omitempty"`
+	Stats            []Badge          `json:"stats,omitempty"`
+	Actions          []Action         `json:"actions,omitempty"`
+}
+
+func (schema *CardSchema) Validate() error {
+	if schema == nil {
+		return nil
+	}
+	switch schema.ActionLayout {
+	case "", CardActionLayoutInline, CardActionLayoutEdgeFill:
+		return nil
+	default:
+		return fmt.Errorf("renderer.CardSchema: unsupported action layout %q", schema.ActionLayout)
+	}
 }
 
 type Media struct {


### PR DESCRIPTION
## Что изменено
- добавлен typed `CardActionLayout` (`inline`, `edge_fill`) и поле `card_schema.action_layout`;
- `CardSchema.Validate()` принимает только поддерживаемые значения; валидация подключена для list и resource-grid карточек;
- дополнен UniversalRenderer contract и тесты JSON/локализации.

## Проверка
- `go test ./...`