### PR TITLE
feat: add typed confirmation cancel label

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -909,6 +909,7 @@ Actions используются в `card_schema.actions`, `record_page.actions`
   "confirm": {
     "title": "ui.confirm",
     "message": "ui.confirm_message",
+    "cancel_label": "ui.cancel",
     "confirm_label": "ui.confirm"
   },
   "after_success": {

--- a/renderer/confirm_test.go
+++ b/renderer/confirm_test.go
@@ -1,0 +1,36 @@
+package renderer
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestConfirmCancelLabelJSONCloneAndLocalization(t *testing.T) {
+	source := Universal{List: &ListPage{Actions: []Action{{
+		ID: "delete",
+		Confirm: &Confirm{
+			Title:        "Delete record",
+			Message:      "This cannot be undone",
+			CancelLabel:  "Cancel",
+			ConfirmLabel: "Delete",
+		},
+	}}}}
+
+	encoded, err := json.Marshal(source)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if got, want := string(encoded), `"cancel_label":"Cancel"`; !strings.Contains(got, want) {
+		t.Fatalf("Marshal() = %s, want field %s", got, want)
+	}
+
+	localized := Localize(source, func(value, key string) string { return "localized: " + value })
+	confirm := localized.List.Actions[0].Confirm
+	if got, want := confirm.CancelLabel, "localized: Cancel"; got != want {
+		t.Fatalf("localized cancel label = %q, want %q", got, want)
+	}
+	if got, want := source.List.Actions[0].Confirm.CancelLabel, "Cancel"; got != want {
+		t.Fatalf("source cancel label = %q, want %q", got, want)
+	}
+}

--- a/renderer/localize.go
+++ b/renderer/localize.go
@@ -34,7 +34,7 @@ func (localizer textLocalizer) localizeRendererAction(action *Action) {
 		localizer.localizeTextFields(&action.Modal.Title)
 	}
 	if action.Confirm != nil {
-		localizer.localizeTextFields(&action.Confirm.Title, &action.Confirm.Message, &action.Confirm.ConfirmLabel)
+		localizer.localizeTextFields(&action.Confirm.Title, &action.Confirm.Message, &action.Confirm.CancelLabel, &action.Confirm.ConfirmLabel)
 	}
 	if action.AfterSuccess != nil {
 		localizer.localizeTextFields(&action.AfterSuccess.Toast)

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -1293,6 +1293,7 @@ type ModalAction struct {
 type Confirm struct {
 	Title        string `json:"title,omitempty"`
 	Message      string `json:"message,omitempty"`
+	CancelLabel  string `json:"cancel_label,omitempty"`
 	ConfirmLabel string `json:"confirm_label,omitempty"`
 }
 


### PR DESCRIPTION
## Что изменено
- `renderer.Confirm` дополнен локализуемым `cancel_label`;
- поле участвует в clone и `renderer.Localize`;
- обновлён UniversalRenderer contract и добавлен JSON/localization test.

Это закрывает зависимость [#70](https://github.com/darkrain/request-generator/issues/70) для API issue #124.

## Проверка
- `go test ./...`