### PR TITLE
fix: apply add permissions to defrec

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -205,6 +205,12 @@ func (generator *Generator) Run() {
 				if addAction.Auth && generator.AuthMiddleware != nil {
 					defrecGroup.Use(generator.AuthMiddleware(addAction))
 				}
+				if len(addAction.Permission) > 0 {
+					if generator.PermissionMiddleware == nil {
+						panic(fmt.Sprintf("permission middleware not implemented in module: %s", module.Name))
+					}
+					defrecGroup.Use(generator.PermissionMiddleware(addAction, addAction.Permission))
+				}
 				defrecGroup.GET("/", generator.actionDefrec(module))
 
 			case actions.ModuleActionNameView:

--- a/tests/integration/defrec_permission_test.go
+++ b/tests/integration/defrec_permission_test.go
@@ -1,0 +1,43 @@
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	module "github.com/darkrain/request-generator"
+	"github.com/darkrain/request-generator/actions"
+	"github.com/darkrain/request-generator/renderer"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefrecAppliesAddPermission(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(
+		nil,
+		*group,
+		[]*module.BaseModule{{
+			Name:   "restricted-items",
+			Path:   "/admin",
+			Render: renderer.Universal{Form: &renderer.FormPage{ID: "restricted-items"}},
+			Actions: []actions.ModuleAction{actions.AddModuleAction{
+				Permission: []actions.Role{"admin"},
+			}},
+		}},
+		func(_ actions.ModuleAction, permissions []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) {
+				if permissions[0] != "admin" {
+					t.Fatalf("permission middleware received %v, want admin", permissions)
+				}
+				c.AbortWithStatus(http.StatusForbidden)
+			}
+		},
+		nil,
+	)
+	generator.Run()
+
+	w := executeRequest(engine, http.MethodGet, "/admin/restricted-items/defrec/", nil)
+	require.Equal(t, http.StatusForbidden, w.Code)
+}


### PR DESCRIPTION
## Проблема
`/defrec/` наследовал authentication Add action, но не применял его permission middleware. Пользователь с другой ролью мог получить metadata формы создания.

## Изменение
- к defrec route добавлен `PermissionMiddleware` с разрешениями Add action;
- добавлен integration test, подтверждающий `403` для запрещённой роли.

## Проверка
- `go test ./...`