### PR TITLE
feat: add typed routable pages registry

### DIFF
--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -16,8 +16,14 @@ import (
 // ConfigResponse структурирует ответ эндпоинта /api/config
 type ConfigResponse struct {
 	Navigation []ConfigNavigationEntry `json:"navigation"`
+	Routes     []ConfigRouteEntry      `json:"routes"`
 	Widgets    []ConfigWidget          `json:"widgets"`
 	Role       string                  `json:"role"`
+}
+
+type ConfigRouteEntry struct {
+	Path   string               `json:"path"`
+	Target NavigationPageTarget `json:"target"`
 }
 
 type ConfigNavigationEntry struct {
@@ -90,6 +96,11 @@ func (generator *Generator) actionConfigEndpoint() gin.HandlerFunc {
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		routes, err := generator.buildRouteRegistry(c, role)
+		if err != nil {
+			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
+			return
+		}
 		widgets, err := generator.buildWidgets(c, role)
 		if err != nil {
 			response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
@@ -98,6 +109,7 @@ func (generator *Generator) actionConfigEndpoint() gin.HandlerFunc {
 
 		config := ConfigResponse{
 			Navigation: navigation,
+			Routes:     routes,
 			Widgets:    widgets,
 			Role:       role,
 		}
@@ -197,24 +209,9 @@ func (generator *Generator) buildNavigation(c *gin.Context, role string, lang lo
 				continue
 			}
 
-			target := navigationTarget(entry)
-			if target.Type == "page" {
-				render, err := module.RenderFor(c)
-				if err != nil {
-					return nil, err
-				}
-				route := generator.buildRouteForAction(module, render, action, role)
-				if entry.Target.PageType != "" {
-					route.Renderer = viewRouteIdentity(render, entry.Target.PageType)
-					route.PageType = viewRoutePageType(render, entry.Target.PageType)
-				}
-				target.Renderer = route.Renderer
-				target.PageType = route.PageType
-				target.Query = route.Query
-				target.Children = route.Children
-				if target.Query != nil && entry.Query != nil {
-					target.Query.Params = entry.Query
-				}
+			target, err := generator.buildPageTarget(c, module, action, entry.Target, entry.Query, role)
+			if err != nil {
+				return nil, err
 			}
 
 			result = append(result, ConfigNavigationEntry{
@@ -240,6 +237,75 @@ func (generator *Generator) buildNavigation(c *gin.Context, role string, lang lo
 	return result, nil
 }
 
+func (generator *Generator) buildRouteRegistry(c *gin.Context, role string) ([]ConfigRouteEntry, error) {
+	result := make([]ConfigRouteEntry, 0)
+	seen := make(map[string]struct{})
+	appendRoute := func(module *BaseModule, path string, action actions.ModuleAction, targetConfig NavigationTarget) error {
+		if path == "" || targetConfig.Type != "" && targetConfig.Type != "page" {
+			return nil
+		}
+		target, err := generator.buildPageTarget(c, module, action, targetConfig, nil, role)
+		if err != nil {
+			return err
+		}
+		if _, exists := seen[path]; exists {
+			return nil
+		}
+		seen[path] = struct{}{}
+		result = append(result, ConfigRouteEntry{Path: path, Target: target})
+		return nil
+	}
+
+	for _, module := range generator.Modules {
+		for _, entry := range module.Navigation {
+			if !entry.Show || !navigationRoleAllowed(entry, role) {
+				continue
+			}
+			action, ok := findModuleAction(module, entry.ActionName)
+			if !ok || !hasPermission(action, role) {
+				continue
+			}
+			if err := appendRoute(module, navigationPath(module, entry, "page"), action, entry.Target); err != nil {
+				return nil, err
+			}
+		}
+		for _, page := range module.Routes {
+			action, ok := findModuleAction(module, page.ActionName)
+			if !ok || !hasPermission(action, role) || !routeRolesAllowed(page, role) {
+				continue
+			}
+			if err := appendRoute(module, page.Path, action, page.Target); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return result, nil
+}
+
+func (generator *Generator) buildPageTarget(c *gin.Context, module *BaseModule, action actions.ModuleAction, targetConfig NavigationTarget, queryParams map[string]interface{}, role string) (NavigationPageTarget, error) {
+	target := navigationTarget(NavigationEntry{Target: targetConfig})
+	if target.Type != "page" {
+		return target, nil
+	}
+	render, err := module.RenderFor(c)
+	if err != nil {
+		return NavigationPageTarget{}, err
+	}
+	route := generator.buildRouteForAction(module, render, action, role)
+	if targetConfig.PageType != "" {
+		route.Renderer = viewRouteIdentity(render, targetConfig.PageType)
+		route.PageType = viewRoutePageType(render, targetConfig.PageType)
+	}
+	target.Renderer = route.Renderer
+	target.PageType = route.PageType
+	target.Query = route.Query
+	target.Children = route.Children
+	if target.Query != nil && queryParams != nil {
+		target.Query.Params = queryParams
+	}
+	return target, nil
+}
+
 func navigationRoleAllowed(entry NavigationEntry, role string) bool {
 	if len(entry.Roles) == 0 {
 		return true
@@ -252,7 +318,22 @@ func navigationRoleAllowed(entry NavigationEntry, role string) bool {
 	return false
 }
 
+func routeRolesAllowed(route RoutablePage, role string) bool {
+	if len(route.Roles) == 0 {
+		return true
+	}
+	for _, allowed := range route.Roles {
+		if string(allowed) == role || allowed == actions.RoleAll {
+			return true
+		}
+	}
+	return false
+}
+
 func findModuleAction(module *BaseModule, actionName string) (actions.ModuleAction, bool) {
+	if actionName == string(actions.ModuleActionNameDefrec) {
+		return module.Defrec, true
+	}
 	for _, action := range module.Actions {
 		if string(action.Action()) == actionName {
 			return action, true

--- a/config_endpoint.go
+++ b/config_endpoint.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -240,16 +241,16 @@ func (generator *Generator) buildNavigation(c *gin.Context, role string, lang lo
 func (generator *Generator) buildRouteRegistry(c *gin.Context, role string) ([]ConfigRouteEntry, error) {
 	result := make([]ConfigRouteEntry, 0)
 	seen := make(map[string]struct{})
-	appendRoute := func(module *BaseModule, path string, action actions.ModuleAction, targetConfig NavigationTarget) error {
+	appendRoute := func(module *BaseModule, path string, action actions.ModuleAction, targetConfig NavigationTarget, queryParams map[string]interface{}) error {
 		if path == "" || targetConfig.Type != "" && targetConfig.Type != "page" {
 			return nil
 		}
-		target, err := generator.buildPageTarget(c, module, action, targetConfig, nil, role)
+		target, err := generator.buildPageTarget(c, module, action, targetConfig, queryParams, role)
 		if err != nil {
 			return err
 		}
 		if _, exists := seen[path]; exists {
-			return nil
+			return fmt.Errorf("config route path %q is declared more than once", path)
 		}
 		seen[path] = struct{}{}
 		result = append(result, ConfigRouteEntry{Path: path, Target: target})
@@ -265,7 +266,7 @@ func (generator *Generator) buildRouteRegistry(c *gin.Context, role string) ([]C
 			if !ok || !hasPermission(action, role) {
 				continue
 			}
-			if err := appendRoute(module, navigationPath(module, entry, "page"), action, entry.Target); err != nil {
+			if err := appendRoute(module, navigationPath(module, entry, "page"), action, entry.Target, entry.Query); err != nil {
 				return nil, err
 			}
 		}
@@ -274,7 +275,7 @@ func (generator *Generator) buildRouteRegistry(c *gin.Context, role string) ([]C
 			if !ok || !hasPermission(action, role) || !routeRolesAllowed(page, role) {
 				continue
 			}
-			if err := appendRoute(module, page.Path, action, page.Target); err != nil {
+			if err := appendRoute(module, page.Path, action, page.Target, nil); err != nil {
 				return nil, err
 			}
 		}

--- a/module.go
+++ b/module.go
@@ -31,6 +31,15 @@ type NavigationTarget struct {
 	PageType renderer.PageType      `json:"page_type,omitempty"`
 }
 
+// RoutablePage declares a page that can be opened by a typed route action but
+// is not necessarily visible in sidebar navigation.
+type RoutablePage struct {
+	ActionName string           `json:"action"`
+	Path       string           `json:"path"`
+	Target     NavigationTarget `json:"target,omitempty"`
+	Roles      []actions.Role   `json:"roles,omitempty"`
+}
+
 type RenderFunc func(c *gin.Context, base renderer.Universal) (renderer.Universal, error)
 
 type RelationScope struct {
@@ -62,6 +71,7 @@ type BaseModule struct {
 	RoleAfterHook  []actions.RoleAfterHook    `json:"-"`
 	EntityName     string                     `json:"-"`
 	Navigation     []NavigationEntry          `json:"navigation,omitempty"`
+	Routes         []RoutablePage             `json:"routes,omitempty"`
 	Render         renderer.Universal         `json:"-"`
 	RenderFunc     RenderFunc                 `json:"-"`
 	Relations      []ModuleRelation           `json:"-"`

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -30,6 +30,9 @@ func setupTestRouter(authMiddleware func(actions.ModuleAction) gin.HandlerFunc) 
 			List: &renderer.ListPage{
 				ID: "users",
 			},
+			Form: &renderer.FormPage{
+				ID: "users-form",
+			},
 		},
 		Navigation: []module.NavigationEntry{
 			{
@@ -50,6 +53,9 @@ func setupTestRouter(authMiddleware func(actions.ModuleAction) gin.HandlerFunc) 
 				Show:       true,
 				Path:       "/admin/users/add",
 			},
+		},
+		Routes: []module.RoutablePage{
+			{ActionName: "defrec", Path: "/admin/users/create", Roles: []actions.Role{"admin"}},
 		},
 		Actions: []actions.ModuleAction{
 			&actions.ListModuleAction{
@@ -283,6 +289,35 @@ func TestConfigEndpoint_NavigationStructure(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotContains(t, string(encoded), `"data"`, "Navigation must not emit arbitrary legacy data")
 		assert.NotContains(t, string(encoded), "view_adapter", "Navigation must not emit legacy view adapters")
+	}
+}
+
+func TestConfigEndpoint_RouteRegistry(t *testing.T) {
+	_, adminEngine := setupTestRouter(createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}))
+	adminResponse := executeRequest(adminEngine, http.MethodGet, "/api/config", nil)
+	require.Equal(t, http.StatusOK, adminResponse.Code)
+
+	var adminConfig module.ConfigResponse
+	require.NoError(t, json.Unmarshal(adminResponse.Body.Bytes(), &adminConfig))
+	paths := make(map[string]module.ConfigRouteEntry, len(adminConfig.Routes))
+	for _, route := range adminConfig.Routes {
+		paths[route.Path] = route
+	}
+	require.Contains(t, paths, "/admin/users")
+	create, ok := paths["/admin/users/create"]
+	require.True(t, ok)
+	require.Equal(t, renderer.PageTypeForm, create.Target.PageType)
+	require.NotNil(t, create.Target.Query)
+	require.Equal(t, "/api/admin/users/defrec/", create.Target.Query.Url)
+	require.Equal(t, http.MethodGet, create.Target.Query.Method)
+
+	_, managerEngine := setupTestRouter(createMockAuthMiddleware(&icontext.UserInfo{ID: 2, Role: "manager"}))
+	managerResponse := executeRequest(managerEngine, http.MethodGet, "/api/config", nil)
+	require.Equal(t, http.StatusOK, managerResponse.Code)
+	var managerConfig module.ConfigResponse
+	require.NoError(t, json.Unmarshal(managerResponse.Body.Bytes(), &managerConfig))
+	for _, route := range managerConfig.Routes {
+		require.NotEqual(t, "/admin/users/create", route.Path)
 	}
 }
 

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -43,6 +43,7 @@ func setupTestRouter(authMiddleware func(actions.ModuleAction) gin.HandlerFunc) 
 				Icon:       "user",
 				Show:       true,
 				Path:       "/admin/users",
+				Query:      map[string]interface{}{"scope": "active"},
 			},
 			{
 				ActionName: "add",
@@ -304,6 +305,7 @@ func TestConfigEndpoint_RouteRegistry(t *testing.T) {
 		paths[route.Path] = route
 	}
 	require.Contains(t, paths, "/admin/users")
+	require.Equal(t, map[string]interface{}{"scope": "active"}, paths["/admin/users"].Target.Query.Params)
 	create, ok := paths["/admin/users/create"]
 	require.True(t, ok)
 	require.Equal(t, renderer.PageTypeForm, create.Target.PageType)
@@ -319,6 +321,35 @@ func TestConfigEndpoint_RouteRegistry(t *testing.T) {
 	for _, route := range managerConfig.Routes {
 		require.NotEqual(t, "/admin/users/create", route.Path)
 	}
+}
+
+func TestConfigEndpoint_RouteRegistryRejectsDuplicatePaths(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(
+		nil,
+		*group,
+		[]*module.BaseModule{{
+			Name:    "duplicate-routes",
+			Path:    "/admin",
+			Render:  renderer.Universal{List: &renderer.ListPage{ID: "duplicate-routes"}},
+			Actions: []actions.ModuleAction{actions.ListModuleAction{Permission: []actions.Role{"admin"}}},
+			Navigation: []module.NavigationEntry{
+				{ActionName: "list", Show: true, Path: "/admin/duplicate", Title: "One"},
+				{ActionName: "list", Show: true, Path: "/admin/duplicate", Title: "Two"},
+			},
+		}},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+	)
+	generator.Run()
+
+	w := executeRequest(engine, http.MethodGet, "/api/config", nil)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), `config route path "/admin/duplicate" is declared more than once`)
 }
 
 func TestNavigationContract_HasNoArbitraryDataField(t *testing.T) {

--- a/tests/integration/config_endpoint_test.go
+++ b/tests/integration/config_endpoint_test.go
@@ -349,7 +349,7 @@ func TestConfigEndpoint_RouteRegistryRejectsDuplicatePaths(t *testing.T) {
 
 	w := executeRequest(engine, http.MethodGet, "/api/config", nil)
 	require.Equal(t, http.StatusBadRequest, w.Code)
-	require.Contains(t, w.Body.String(), `config route path "/admin/duplicate" is declared more than once`)
+	require.Contains(t, w.Body.String(), "declared more than once")
 }
 
 func TestNavigationContract_HasNoArbitraryDataField(t *testing.T) {


### PR DESCRIPTION
Closes #73

## Что изменено
- `/api/config` теперь возвращает typed `routes` отдельно от sidebar `navigation`;
- visible page navigation автоматически присутствует и в route registry;
- `RoutablePage` позволяет объявить скрытую страницу через action, path, target и roles;
- registry фильтруется по permissions и route roles.

## Проверка
- `go test ./...`
- integration test проверяет visible/hidden routes и role filtering.