### PR TITLE
feat: typed atomic add contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,6 +1324,48 @@ type TranslationContext struct {
 
 ---
 
+## Атомарное создание связанных записей
+
+Обычный `AddModuleAction` остаётся CRUD-операцией для одной записи. Если доменный сценарий создаёт несколько связанных записей, используйте отдельный `Mode: actions.AddModeAtomic`.
+
+Generator сам выполняет нормализацию и validation input, открывает transaction, вызывает операцию и делает commit или rollback. Atomic operation не получает `*sql.Tx` или типы драйвера: ей доступен только `actions.AtomicExecutor`. Нельзя добавлять `BeforeAction`, `AfterAction`, `RoleBeforeHook` или `RoleAfterHook` в модуль с atomic add: generator завершит запуск configuration error.
+
+```go
+actions.AddModuleAction{
+    Mode: actions.AddModeAtomic,
+    Columns: []pg.Column{profiles.Nick},
+    Atomic: &actions.AtomicAddConfig{
+        Operation: func(ctx context.Context, executor actions.AtomicExecutor, input actions.AtomicInput) (actions.AtomicRecord, error) {
+            nick, err := input.RequireString("nick")
+            if err != nil {
+                return actions.AtomicRecord{}, err
+            }
+
+            profile, err := executor.Insert(ctx, actions.AtomicInsert{
+                Table: profiles,
+                PrimaryKey: profiles.ID,
+                Fields: []actions.AtomicInsertField{
+                    {Column: profiles.Nick, Value: actions.AtomicString(nick)},
+                },
+            })
+            if err != nil {
+                return actions.AtomicRecord{}, err
+            }
+
+            return actions.AtomicRecord{
+                Value: profile.Value,
+                PrimaryKey: "id",
+                Fields: []actions.AtomicField{
+                    {Name: "nick", Value: actions.AtomicString(nick)},
+                },
+            }, nil
+        },
+    },
+}
+```
+
+`AtomicRecord` является ответом add action. Поля из `Fields` также используются для интерполяции `AfterSuccess.Route`: например, `record.InterpolateRoute("/profiles/{nick}")` вернёт маршрут только на основании самого record. Отдельный источник route bindings не предусмотрен.
+
 ## API эндпоинты
 
 Для модуля с `Name: "courses"` и `Path: ""` генерируются:

--- a/README.md
+++ b/README.md
@@ -1364,7 +1364,7 @@ actions.AddModuleAction{
 }
 ```
 
-`AtomicRecord` является ответом add action. Поля из `Fields` также используются для интерполяции `AfterSuccess.Route`: например, `record.InterpolateRoute("/profiles/{nick}")` вернёт маршрут только на основании самого record. Отдельный источник route bindings не предусмотрен.
+`AtomicRecord` является ответом add action. Его `Fields` сериализуются на верхнем уровне ответа: поле `{Name: "nick", ...}` станет JSON-полем `nick`. Поэтому `AfterSuccess.Route` интерполируется shell только из response record, например `/profiles/{nick}`. Отдельный источник route bindings не предусмотрен.
 
 ## API эндпоинты
 

--- a/actions/add_module_action.go
+++ b/actions/add_module_action.go
@@ -7,6 +7,8 @@ import (
 
 type AddModuleAction struct {
 	ModuleAction
+	Mode         AddMode          `json:"mode,omitempty"`
+	Atomic       *AtomicAddConfig `json:"-"`
 	BeforeAction func(c *gin.Context) error
 	AfterAction  func(c *gin.Context)
 	Label        string                           `json:"label"`

--- a/actions/atomic_add.go
+++ b/actions/atomic_add.go
@@ -33,6 +33,38 @@ func AtomicInt(value int64) AtomicValue     { return AtomicValue{Int: &value} }
 func AtomicFloat(value float64) AtomicValue { return AtomicValue{Float: &value} }
 func AtomicBool(value bool) AtomicValue     { return AtomicValue{Bool: &value} }
 
+func (value AtomicValue) Validate() error {
+	variants := 0
+	if value.String != nil {
+		variants++
+	}
+	if value.Int != nil {
+		variants++
+	}
+	if value.Float != nil {
+		variants++
+	}
+	if value.Bool != nil {
+		variants++
+	}
+	if value.Strings != nil {
+		variants++
+	}
+	if value.Ints != nil {
+		variants++
+	}
+	if value.JSON != nil {
+		variants++
+		if !json.Valid(value.JSON) {
+			return fmt.Errorf("atomic JSON value is invalid")
+		}
+	}
+	if variants != 1 {
+		return fmt.Errorf("atomic value must contain exactly one variant")
+	}
+	return nil
+}
+
 func (value AtomicValue) Interface() interface{} {
 	switch {
 	case value.String != nil:
@@ -129,6 +161,9 @@ func (record AtomicRecord) Validate() error {
 			return fmt.Errorf("atomic record field %q is duplicated or reserved", field.Name)
 		}
 		seen[field.Name] = struct{}{}
+		if err := field.Value.Validate(); err != nil {
+			return fmt.Errorf("atomic record field %q: %w", field.Name, err)
+		}
 	}
 	return nil
 }

--- a/actions/atomic_add.go
+++ b/actions/atomic_add.go
@@ -2,8 +2,8 @@ package actions
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strings"
 
 	pg "github.com/go-jet/jet/v2/postgres"
 )
@@ -111,12 +111,47 @@ type AtomicInsertField struct {
 }
 
 // AtomicRecord is both the atomic add response and the source for route
-// interpolation. Fields such as nick must be explicitly returned by the
-// operation when a follow-up route needs them.
+// interpolation. Fields are serialized at the top level of the response, so a
+// renderer can resolve routes such as /profiles/{nick} from the HTTP result.
 type AtomicRecord struct {
 	Value      int64         `json:"value"`
 	PrimaryKey string        `json:"primary_key"`
 	Fields     []AtomicField `json:"fields,omitempty"`
+}
+
+func (record AtomicRecord) Validate() error {
+	seen := map[string]struct{}{"value": {}, "primary_key": {}}
+	for _, field := range record.Fields {
+		if field.Name == "" {
+			return fmt.Errorf("atomic record field name is required")
+		}
+		if _, exists := seen[field.Name]; exists {
+			return fmt.Errorf("atomic record field %q is duplicated or reserved", field.Name)
+		}
+		seen[field.Name] = struct{}{}
+	}
+	return nil
+}
+
+func (record AtomicRecord) MarshalJSON() ([]byte, error) {
+	if err := record.Validate(); err != nil {
+		return nil, err
+	}
+	result := map[string]interface{}{
+		"value":       record.Value,
+		"primary_key": record.PrimaryKey,
+	}
+	for _, field := range record.Fields {
+		result[field.Name] = atomicResponseValue(field.Value)
+	}
+	return json.Marshal(result)
+}
+
+func atomicResponseValue(value AtomicValue) interface{} {
+	if value.JSON != nil {
+		return json.RawMessage(value.JSON)
+	}
+	return value.Interface()
 }
 
 func (record AtomicRecord) Field(name string) (AtomicValue, bool) {
@@ -134,24 +169,6 @@ func (record AtomicRecord) String(name string) (string, bool) {
 		return "", false
 	}
 	return *value.String, true
-}
-
-// InterpolateRoute resolves a renderer AfterSuccess.Route template from this
-// record only. It intentionally has no secondary binding source.
-func (record AtomicRecord) InterpolateRoute(template string) (string, error) {
-	result := template
-	for _, field := range record.Fields {
-		if field.Value.String != nil {
-			result = strings.ReplaceAll(result, "{"+field.Name+"}", *field.Value.String)
-		}
-		if field.Value.Int != nil {
-			result = strings.ReplaceAll(result, "{"+field.Name+"}", fmt.Sprintf("%d", *field.Value.Int))
-		}
-	}
-	if strings.Contains(result, "{") || strings.Contains(result, "}") {
-		return "", fmt.Errorf("route has unresolved record fields")
-	}
-	return result, nil
 }
 
 // AtomicExecutor deliberately exposes only the operations needed by domain

--- a/actions/atomic_add.go
+++ b/actions/atomic_add.go
@@ -1,0 +1,167 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pg "github.com/go-jet/jet/v2/postgres"
+)
+
+// AddMode selects the persistence path for an add action.
+type AddMode string
+
+const (
+	AddModeStandard AddMode = "standard"
+	AddModeAtomic   AddMode = "atomic"
+)
+
+// AtomicValue is the explicit value union passed to an atomic operation.
+// It avoids exposing the request's untyped JSON map to domain code.
+type AtomicValue struct {
+	String  *string  `json:"string,omitempty"`
+	Int     *int64   `json:"int,omitempty"`
+	Float   *float64 `json:"float,omitempty"`
+	Bool    *bool    `json:"bool,omitempty"`
+	Strings []string `json:"strings,omitempty"`
+	Ints    []int64  `json:"ints,omitempty"`
+	JSON    []byte   `json:"json,omitempty"`
+}
+
+func AtomicString(value string) AtomicValue { return AtomicValue{String: &value} }
+func AtomicInt(value int64) AtomicValue     { return AtomicValue{Int: &value} }
+func AtomicFloat(value float64) AtomicValue { return AtomicValue{Float: &value} }
+func AtomicBool(value bool) AtomicValue     { return AtomicValue{Bool: &value} }
+
+func (value AtomicValue) Interface() interface{} {
+	switch {
+	case value.String != nil:
+		return *value.String
+	case value.Int != nil:
+		return *value.Int
+	case value.Float != nil:
+		return *value.Float
+	case value.Bool != nil:
+		return *value.Bool
+	case value.Strings != nil:
+		return value.Strings
+	case value.Ints != nil:
+		return value.Ints
+	case value.JSON != nil:
+		return value.JSON
+	default:
+		return nil
+	}
+}
+
+type AtomicField struct {
+	Name  string      `json:"name"`
+	Value AtomicValue `json:"value"`
+}
+
+// AtomicInput contains normalized and validated add fields.
+type AtomicInput struct {
+	Fields []AtomicField `json:"fields"`
+}
+
+func (input AtomicInput) Field(name string) (AtomicValue, bool) {
+	for _, field := range input.Fields {
+		if field.Name == name {
+			return field.Value, true
+		}
+	}
+	return AtomicValue{}, false
+}
+
+func (input AtomicInput) String(name string) (string, bool) {
+	value, ok := input.Field(name)
+	if !ok || value.String == nil {
+		return "", false
+	}
+	return *value.String, true
+}
+
+func (input AtomicInput) Int(name string) (int64, bool) {
+	value, ok := input.Field(name)
+	if !ok || value.Int == nil {
+		return 0, false
+	}
+	return *value.Int, true
+}
+
+func (input AtomicInput) RequireString(name string) (string, error) {
+	value, ok := input.String(name)
+	if !ok {
+		return "", fmt.Errorf("atomic input field %q is not a string", name)
+	}
+	return value, nil
+}
+
+// AtomicInsert is a single INSERT statement executed within the generator-owned
+// transaction. The operation never receives the underlying transaction type.
+type AtomicInsert struct {
+	Table      pg.Table            `json:"-"`
+	PrimaryKey pg.Column           `json:"-"`
+	Fields     []AtomicInsertField `json:"-"`
+}
+
+type AtomicInsertField struct {
+	Column pg.Column   `json:"-"`
+	Value  AtomicValue `json:"value"`
+}
+
+// AtomicRecord is both the atomic add response and the source for route
+// interpolation. Fields such as nick must be explicitly returned by the
+// operation when a follow-up route needs them.
+type AtomicRecord struct {
+	Value      int64         `json:"value"`
+	PrimaryKey string        `json:"primary_key"`
+	Fields     []AtomicField `json:"fields,omitempty"`
+}
+
+func (record AtomicRecord) Field(name string) (AtomicValue, bool) {
+	for _, field := range record.Fields {
+		if field.Name == name {
+			return field.Value, true
+		}
+	}
+	return AtomicValue{}, false
+}
+
+func (record AtomicRecord) String(name string) (string, bool) {
+	value, ok := record.Field(name)
+	if !ok || value.String == nil {
+		return "", false
+	}
+	return *value.String, true
+}
+
+// InterpolateRoute resolves a renderer AfterSuccess.Route template from this
+// record only. It intentionally has no secondary binding source.
+func (record AtomicRecord) InterpolateRoute(template string) (string, error) {
+	result := template
+	for _, field := range record.Fields {
+		if field.Value.String != nil {
+			result = strings.ReplaceAll(result, "{"+field.Name+"}", *field.Value.String)
+		}
+		if field.Value.Int != nil {
+			result = strings.ReplaceAll(result, "{"+field.Name+"}", fmt.Sprintf("%d", *field.Value.Int))
+		}
+	}
+	if strings.Contains(result, "{") || strings.Contains(result, "}") {
+		return "", fmt.Errorf("route has unresolved record fields")
+	}
+	return result, nil
+}
+
+// AtomicExecutor deliberately exposes only the operations needed by domain
+// creation logic, not a driver transaction or connection.
+type AtomicExecutor interface {
+	Insert(context.Context, AtomicInsert) (AtomicRecord, error)
+}
+
+type AtomicAddOperation func(context.Context, AtomicExecutor, AtomicInput) (AtomicRecord, error)
+
+type AtomicAddConfig struct {
+	Operation AtomicAddOperation `json:"-"`
+}

--- a/atomic_input.go
+++ b/atomic_input.go
@@ -1,0 +1,107 @@
+package module
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/darkrain/request-generator/actions"
+	"github.com/darkrain/request-generator/fields"
+)
+
+func atomicInputFromFields(moduleFields []fields.ModuleField, input map[string]interface{}) (actions.AtomicInput, error) {
+	result := actions.AtomicInput{Fields: make([]actions.AtomicField, 0, len(input))}
+	for _, field := range moduleFields {
+		name := field.Name()
+		if !field.Translatable {
+			name = field.ColumnName()
+		}
+		value, ok := input[name]
+		if !ok {
+			continue
+		}
+		atomicValue, err := atomicValueFromField(field, value)
+		if err != nil {
+			return actions.AtomicInput{}, fmt.Errorf("atomic input field %q: %w", name, err)
+		}
+		result.Fields = append(result.Fields, actions.AtomicField{Name: name, Value: atomicValue})
+	}
+	return result, nil
+}
+
+func atomicValueFromField(field fields.ModuleField, value interface{}) (actions.AtomicValue, error) {
+	if value == nil {
+		return actions.AtomicValue{}, nil
+	}
+	switch field.Type {
+	case fields.ModuleFieldTypeString:
+		value, ok := value.(string)
+		if !ok {
+			return actions.AtomicValue{}, fmt.Errorf("expected string")
+		}
+		return actions.AtomicString(value), nil
+	case fields.ModuleFieldTypeInt:
+		switch value := value.(type) {
+		case int:
+			return actions.AtomicInt(int64(value)), nil
+		case int64:
+			return actions.AtomicInt(value), nil
+		case float64:
+			if math.Trunc(value) != value {
+				return actions.AtomicValue{}, fmt.Errorf("expected integer")
+			}
+			return actions.AtomicInt(int64(value)), nil
+		default:
+			return actions.AtomicValue{}, fmt.Errorf("expected integer")
+		}
+	case fields.ModuleFieldTypeFloat:
+		value, ok := value.(float64)
+		if !ok {
+			return actions.AtomicValue{}, fmt.Errorf("expected number")
+		}
+		return actions.AtomicFloat(value), nil
+	case fields.ModuleFieldTypeArray:
+		switch value := value.(type) {
+		case []string:
+			return actions.AtomicValue{Strings: value}, nil
+		case []int64:
+			return actions.AtomicValue{Ints: value}, nil
+		case []interface{}:
+			strings := make([]string, 0, len(value))
+			ints := make([]int64, 0, len(value))
+			allStrings := true
+			allInts := true
+			for _, item := range value {
+				stringValue, isString := item.(string)
+				if !isString {
+					allStrings = false
+				} else {
+					strings = append(strings, stringValue)
+				}
+				floatValue, isFloat := item.(float64)
+				if !isFloat || math.Trunc(floatValue) != floatValue {
+					allInts = false
+				} else {
+					ints = append(ints, int64(floatValue))
+				}
+			}
+			if allStrings {
+				return actions.AtomicValue{Strings: strings}, nil
+			}
+			if allInts {
+				return actions.AtomicValue{Ints: ints}, nil
+			}
+			return actions.AtomicValue{}, fmt.Errorf("expected an array of strings or integers")
+		default:
+			return actions.AtomicValue{}, fmt.Errorf("expected array")
+		}
+	case fields.ModuleFieldTypeObject:
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return actions.AtomicValue{}, err
+		}
+		return actions.AtomicValue{JSON: encoded}, nil
+	default:
+		return actions.AtomicValue{}, fmt.Errorf("unsupported type %q", field.Type)
+	}
+}

--- a/db/atomic_executor.go
+++ b/db/atomic_executor.go
@@ -35,6 +35,9 @@ func (executor atomicExecutor) Insert(ctx context.Context, insert actions.Atomic
 		if field.Column == nil {
 			return actions.AtomicRecord{}, fmt.Errorf("atomic insert field %d has no column", index)
 		}
+		if err := field.Value.Validate(); err != nil {
+			return actions.AtomicRecord{}, fmt.Errorf("atomic insert field %q: %w", field.Column.Name(), err)
+		}
 		keys = append(keys, fmt.Sprintf(`"%s"`, field.Column.Name()))
 		placeholders = append(placeholders, fmt.Sprintf("$%d", index+1))
 		values = append(values, atomicDBValue(field.Value))

--- a/db/atomic_executor.go
+++ b/db/atomic_executor.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/darkrain/request-generator/actions"
+	"github.com/lib/pq"
+)
+
+type atomicExecutor struct {
+	tx *sql.Tx
+}
+
+// NewAtomicExecutor adapts a generator-owned SQL transaction to the public
+// atomic action contract without exposing the transaction to modules.
+func NewAtomicExecutor(tx *sql.Tx) actions.AtomicExecutor {
+	return atomicExecutor{tx: tx}
+}
+
+func (executor atomicExecutor) Insert(ctx context.Context, insert actions.AtomicInsert) (actions.AtomicRecord, error) {
+	if insert.Table == nil || insert.PrimaryKey == nil {
+		return actions.AtomicRecord{}, fmt.Errorf("atomic insert requires table and primary key")
+	}
+	if len(insert.Fields) == 0 {
+		return actions.AtomicRecord{}, fmt.Errorf("atomic insert requires fields")
+	}
+
+	keys := make([]string, 0, len(insert.Fields))
+	placeholders := make([]string, 0, len(insert.Fields))
+	values := make([]interface{}, 0, len(insert.Fields))
+	for index, field := range insert.Fields {
+		if field.Column == nil {
+			return actions.AtomicRecord{}, fmt.Errorf("atomic insert field %d has no column", index)
+		}
+		keys = append(keys, fmt.Sprintf(`"%s"`, field.Column.Name()))
+		placeholders = append(placeholders, fmt.Sprintf("$%d", index+1))
+		values = append(values, atomicDBValue(field.Value))
+	}
+
+	tableName := fmt.Sprintf(`"%s"`, insert.Table.TableName())
+	if schema := insert.Table.SchemaName(); schema != "" {
+		tableName = fmt.Sprintf(`%s."%s"`, schema, insert.Table.TableName())
+	}
+	query := fmt.Sprintf(`INSERT INTO %s (%s) VALUES (%s) RETURNING "%s"`, tableName, strings.Join(keys, ","), strings.Join(placeholders, ","), insert.PrimaryKey.Name())
+
+	var value int64
+	if err := executor.tx.QueryRowContext(ctx, query, values...).Scan(&value); err != nil {
+		return actions.AtomicRecord{}, err
+	}
+	return actions.AtomicRecord{Value: value, PrimaryKey: insert.PrimaryKey.Name()}, nil
+}
+
+func atomicDBValue(value actions.AtomicValue) interface{} {
+	if value.Strings != nil {
+		return pq.Array(value.Strings)
+	}
+	if value.Ints != nil {
+		return pq.Array(value.Ints)
+	}
+	if value.JSON != nil {
+		return string(value.JSON)
+	}
+	return value.Interface()
+}

--- a/db/postgres_db.go
+++ b/db/postgres_db.go
@@ -164,8 +164,9 @@ func buildTranslationSubquery(tc *TranslationContext, tableRef string, pkName st
 	return pg.Raw(subquery)
 }
 
-// insertTranslations inserts translation rows within a transaction.
-func insertTranslations(tx *sql.Tx, tc *TranslationContext, entityID int64, moduleFields []fields.ModuleField, input map[string]interface{}) error {
+// InsertTranslations inserts translation rows within an existing transaction.
+// It is used by both standard and atomic add paths; modules never receive tx.
+func InsertTranslations(tx *sql.Tx, tc *TranslationContext, entityID int64, moduleFields []fields.ModuleField, input map[string]interface{}) error {
 	for _, field := range moduleFields {
 		if !field.Translatable {
 			continue
@@ -917,7 +918,7 @@ func (db *DB) Add(log *log.Entry, table pg.Table, primaryKey pg.Column, moduleFi
 
 	// Insert translations
 	if tc != nil {
-		if err = insertTranslations(tx, tc, output.Value, moduleFields, input); err != nil {
+		if err = InsertTranslations(tx, tc, output.Value, moduleFields, input); err != nil {
 			log.Errorln("ADD TRANSLATIONS ERR: ", err)
 			return nil, err
 		}

--- a/generator.go
+++ b/generator.go
@@ -115,6 +115,9 @@ func (generator *Generator) Run() {
 	generator.initRealtime()
 
 	for _, module := range generator.Modules {
+		if err := validateAtomicAddActions(module); err != nil {
+			panic(fmt.Sprintf("invalid atomic add config in module %s: %v", module.Name, err))
+		}
 		if err := module.Render.Validate(); err != nil {
 			if module.RenderFunc != nil {
 				panic(fmt.Sprintf("invalid base renderer config in module %s: %v", module.Name, err))
@@ -318,6 +321,32 @@ func (generator *Generator) Run() {
 			c.Data(http.StatusOK, "application/json; charset=utf-8", specJSON)
 		})
 	}
+}
+
+func validateAtomicAddActions(module *BaseModule) error {
+	for _, moduleAction := range module.Actions {
+		action, ok := moduleAction.(actions.AddModuleAction)
+		if !ok {
+			continue
+		}
+		switch action.Mode {
+		case "", actions.AddModeStandard:
+			continue
+		case actions.AddModeAtomic:
+			if action.Atomic == nil || action.Atomic.Operation == nil {
+				return fmt.Errorf("atomic add action requires an operation")
+			}
+			if action.BeforeAction != nil || action.AfterAction != nil {
+				return fmt.Errorf("atomic add action cannot define before or after hooks")
+			}
+			if len(module.RoleBeforeHook) > 0 || len(module.RoleAfterHook) > 0 {
+				return fmt.Errorf("atomic add action cannot be used by a module with role hooks")
+			}
+		default:
+			return fmt.Errorf("unsupported add mode %q", action.Mode)
+		}
+	}
+	return nil
 }
 
 func validateModuleFieldMedia(module *BaseModule) error {
@@ -714,33 +743,35 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 		lang := generator.getLang(c)
 		generator.setTranslationContext(c, lang)
 
-		if hook := actions.ResolveRoleHook(module.RoleBeforeHook, role); hook != nil {
-			if err := hook(c); err != nil {
-				response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
+		if action.Mode != actions.AddModeAtomic {
+			if hook := actions.ResolveRoleHook(module.RoleBeforeHook, role); hook != nil {
+				if err := hook(c); err != nil {
+					response.ErrorResponse(l, c, http.StatusBadRequest, err.Error(), nil)
+					return
+				}
+			}
+			defer func() {
+				if hook := actions.ResolveRoleAfterHook(module.RoleAfterHook, role); hook != nil {
+					hook(c)
+				}
+			}()
+
+			err := action.BeforeRequest(c)
+			if err != nil {
+				if !c.Writer.Written() {
+					response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{
+						err.Error(),
+					})
+				}
+				return
+			}
+			if c.Writer.Written() {
 				return
 			}
 		}
-		defer func() {
-			if hook := actions.ResolveRoleAfterHook(module.RoleAfterHook, role); hook != nil {
-				hook(c)
-			}
-		}()
-
-		err := action.BeforeRequest(c)
-		if err != nil {
-			if !c.Writer.Written() {
-				response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{
-					err.Error(),
-				})
-			}
-			return
-		}
-		if c.Writer.Written() {
-			return
-		}
 
 		var input map[string]interface{}
-		err = utils.ParseJson(c.Request, &input)
+		err := utils.ParseJson(c.Request, &input)
 		if err != nil {
 			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{
 				"Parse Input Error",
@@ -804,6 +835,46 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
 			return
 		}
+		if action.Mode == actions.AddModeAtomic {
+			atomicInput, err := atomicInputFromFields(realFields, mapInput)
+			if err != nil {
+				response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
+				return
+			}
+			rawDB := generator.db(module).RawDB()
+			if rawDB == nil {
+				response.ErrorResponse(l, c, http.StatusInternalServerError, GeneratorErrorAdd, []string{"atomic add requires a SQL database"})
+				return
+			}
+			tx, err := rawDB.BeginTx(ctx, nil)
+			if err != nil {
+				response.ErrorResponse(l, c, http.StatusInternalServerError, GeneratorErrorAdd, []string{err.Error()})
+				return
+			}
+			committed := false
+			defer func() {
+				if !committed {
+					_ = tx.Rollback()
+				}
+			}()
+			output, err := action.Atomic.Operation(ctx, db.NewAtomicExecutor(tx), atomicInput)
+			if err != nil {
+				response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
+				return
+			}
+			if output.PrimaryKey == "" {
+				output.PrimaryKey = module.PrimaryKey.Name()
+			}
+			if err := tx.Commit(); err != nil {
+				response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
+				return
+			}
+			committed = true
+			response.Response(l, c, output)
+			generator.publishRealtime(c, module, actions.ModuleActionNameAdd, output)
+			return
+		}
+
 		output, err := generator.db(module).Add(l, module.Table, module.PrimaryKey, realFields, mapInput, tc)
 		if err != nil {
 			response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{

--- a/generator.go
+++ b/generator.go
@@ -865,6 +865,16 @@ func (generator *Generator) actionAdd(module *BaseModule, action actions.AddModu
 			if output.PrimaryKey == "" {
 				output.PrimaryKey = module.PrimaryKey.Name()
 			}
+			if err := output.Validate(); err != nil {
+				response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
+				return
+			}
+			if tc != nil {
+				if err := db.InsertTranslations(tx, tc, output.Value, realFields, mapInput); err != nil {
+					response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
+					return
+				}
+			}
 			if err := tx.Commit(); err != nil {
 				response.ErrorResponse(l, c, http.StatusBadRequest, GeneratorErrorAdd, []string{err.Error()})
 				return

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -30,6 +32,7 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=

--- a/tests/integration/atomic_add_test.go
+++ b/tests/integration/atomic_add_test.go
@@ -237,6 +237,29 @@ func TestAtomicAdd_RollsBackOnPrimaryDuplicateAndRelatedFailure(t *testing.T) {
 	}
 }
 
+func TestAtomicAdd_RollsBackInvalidResultBeforeCommit(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	engine := setupAtomicAddRouter(t, sqlDB, func(context.Context, actions.AtomicExecutor, actions.AtomicInput) (actions.AtomicRecord, error) {
+		return actions.AtomicRecord{
+			Value:      41,
+			PrimaryKey: "id",
+			Fields: []actions.AtomicField{{
+				Name:  "broken",
+				Value: actions.AtomicValue{JSON: []byte("{")},
+			}},
+		}, nil
+	})
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	w := executeJSONRequest(engine, http.MethodPut, "/admin/atomic-items", map[string]interface{}{"title": "hello"})
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	require.NotEqual(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestAtomicAdd_RejectsHooksAtConfigurationTime(t *testing.T) {
 	for _, testCase := range []struct {
 		name       string

--- a/tests/integration/atomic_add_test.go
+++ b/tests/integration/atomic_add_test.go
@@ -3,9 +3,11 @@ package integration
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -102,12 +104,91 @@ func TestAtomicAdd_CommitsTypedRecordAndInterpolatesRoute(t *testing.T) {
 
 	w := executeJSONRequest(engine, http.MethodPut, "/admin/atomic-items", map[string]interface{}{"title": "hello"})
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
-	require.JSONEq(t, `{"value":41,"primary_key":"id","fields":[{"name":"nick","value":{"string":"atomic-item"}}]}`, w.Body.String())
+	require.JSONEq(t, `{"value":41,"primary_key":"id","nick":"atomic-item"}`, w.Body.String())
 	require.NoError(t, mock.ExpectationsWereMet())
 
-	route, err := (actions.AtomicRecord{Fields: []actions.AtomicField{{Name: "nick", Value: actions.AtomicString("atomic-item")}}}).InterpolateRoute("/profiles/{nick}")
-	require.NoError(t, err)
+	var record map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &record))
+	route := strings.ReplaceAll("/profiles/{nick}", "{nick}", record["nick"].(string))
 	require.Equal(t, "/profiles/atomic-item", route)
+}
+
+func TestAtomicAdd_PersistsTranslationsInsideTransaction(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	id := pg.IntegerColumn("id")
+	title := pg.StringColumn("title")
+	itemID := pg.IntegerColumn("item_id")
+	name := pg.StringColumn("name")
+	items := pg.NewTable("public", "atomic_items", "", id, title, name)
+	related := pg.NewTable("public", "atomic_related", "", id, itemID)
+	atomicModule := &module.BaseModule{
+		Name: "atomic-items", Path: "/admin", Table: items, PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: title, Title: "Title", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeText},
+			{Column: name, FieldName: "name", Title: "Name", Type: fields.ModuleFieldTypeObject, FormType: fields.ModuleFieldFormTypeText, Translatable: true},
+		},
+		Actions: []actions.ModuleAction{actions.AddModuleAction{
+			Mode: actions.AddModeAtomic, Atomic: &actions.AtomicAddConfig{Operation: atomicCreateOperation(items, related, id, title, itemID)}, Columns: []pg.Column{title, name}, Permission: []actions.Role{actions.RoleAll}, Auth: true,
+		}},
+	}
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(func(*module.BaseModule) dbpkg.DBExecutor { return dbpkg.NewDB(sqlDB) }, *group, []*module.BaseModule{atomicModule}, func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+		return func(c *gin.Context) { c.Next() }
+	}, createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}))
+	generator.Run()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO public").WithArgs("hello").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(41))
+	mock.ExpectQuery("INSERT INTO public").WithArgs(int64(41)).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(77))
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO translations (entity, entity_id, field, lang, value) VALUES ($1, $2, $3, $4, $5)`)).WithArgs("atomic_items", int64(41), "name", "en", "Hello").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	w := executeJSONRequest(engine, http.MethodPut, "/admin/atomic-items", map[string]interface{}{"title": "hello", "name": map[string]interface{}{"en": "Hello"}})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAtomicAdd_RollsBackWhenTranslationInsertFails(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	id := pg.IntegerColumn("id")
+	title := pg.StringColumn("title")
+	itemID := pg.IntegerColumn("item_id")
+	name := pg.StringColumn("name")
+	items := pg.NewTable("public", "atomic_items", "", id, title, name)
+	related := pg.NewTable("public", "atomic_related", "", id, itemID)
+	atomicModule := &module.BaseModule{
+		Name: "atomic-items", Path: "/admin", Table: items, PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: title, Title: "Title", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeText},
+			{Column: name, FieldName: "name", Title: "Name", Type: fields.ModuleFieldTypeObject, FormType: fields.ModuleFieldFormTypeText, Translatable: true},
+		},
+		Actions: []actions.ModuleAction{actions.AddModuleAction{
+			Mode: actions.AddModeAtomic, Atomic: &actions.AtomicAddConfig{Operation: atomicCreateOperation(items, related, id, title, itemID)}, Columns: []pg.Column{title, name}, Permission: []actions.Role{actions.RoleAll}, Auth: true,
+		}},
+	}
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(func(*module.BaseModule) dbpkg.DBExecutor { return dbpkg.NewDB(sqlDB) }, *group, []*module.BaseModule{atomicModule}, func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+		return func(c *gin.Context) { c.Next() }
+	}, createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}))
+	generator.Run()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO public").WithArgs("hello").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(41))
+	mock.ExpectQuery("INSERT INTO public").WithArgs(int64(41)).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(77))
+	mock.ExpectExec("INSERT INTO translations").WithArgs("atomic_items", int64(41), "name", "en", "Hello").WillReturnError(errors.New("translation insert failed"))
+	mock.ExpectRollback()
+
+	w := executeJSONRequest(engine, http.MethodPut, "/admin/atomic-items", map[string]interface{}{"title": "hello", "name": map[string]interface{}{"en": "Hello"}})
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestAtomicAdd_RollsBackOnPrimaryDuplicateAndRelatedFailure(t *testing.T) {

--- a/tests/integration/atomic_add_test.go
+++ b/tests/integration/atomic_add_test.go
@@ -1,0 +1,216 @@
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	module "github.com/darkrain/request-generator"
+	"github.com/darkrain/request-generator/actions"
+	dbpkg "github.com/darkrain/request-generator/db"
+	"github.com/darkrain/request-generator/fields"
+	"github.com/darkrain/request-generator/icontext"
+	"github.com/gin-gonic/gin"
+	pg "github.com/go-jet/jet/v2/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func setupAtomicAddRouter(t *testing.T, sqlDB *sql.DB, operation actions.AtomicAddOperation) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	id := pg.IntegerColumn("id")
+	title := pg.StringColumn("title")
+	items := pg.NewTable("public", "atomic_items", "", id, title)
+
+	atomicModule := &module.BaseModule{
+		Name:       "atomic-items",
+		Path:       "/admin",
+		Table:      items,
+		PrimaryKey: id,
+		Fields: []fields.ModuleField{
+			{Column: id, Title: "ID", Type: fields.ModuleFieldTypeInt, FormType: fields.ModuleFieldFormTypeNumber},
+			{Column: title, Title: "Title", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeText},
+		},
+		Actions: []actions.ModuleAction{actions.AddModuleAction{
+			Mode:       actions.AddModeAtomic,
+			Atomic:     &actions.AtomicAddConfig{Operation: operation},
+			Columns:    []pg.Column{title},
+			Permission: []actions.Role{actions.RoleAll},
+			Auth:       true,
+		}},
+	}
+
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(
+		func(_ *module.BaseModule) dbpkg.DBExecutor { return dbpkg.NewDB(sqlDB) },
+		*group,
+		[]*module.BaseModule{atomicModule},
+		func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+			return func(c *gin.Context) { c.Next() }
+		},
+		createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}),
+	)
+	generator.Run()
+	return engine
+}
+
+func atomicCreateOperation(items, related pg.Table, primaryKey, title, relatedItemID pg.Column) actions.AtomicAddOperation {
+	return func(ctx context.Context, executor actions.AtomicExecutor, input actions.AtomicInput) (actions.AtomicRecord, error) {
+		titleValue, err := input.RequireString("title")
+		if err != nil {
+			return actions.AtomicRecord{}, err
+		}
+		item, err := executor.Insert(ctx, actions.AtomicInsert{
+			Table: items, PrimaryKey: primaryKey,
+			Fields: []actions.AtomicInsertField{{Column: title, Value: actions.AtomicString(titleValue)}},
+		})
+		if err != nil {
+			return actions.AtomicRecord{}, err
+		}
+		_, err = executor.Insert(ctx, actions.AtomicInsert{
+			Table: related, PrimaryKey: primaryKey,
+			Fields: []actions.AtomicInsertField{{Column: relatedItemID, Value: actions.AtomicInt(item.Value)}},
+		})
+		if err != nil {
+			return actions.AtomicRecord{}, err
+		}
+		return actions.AtomicRecord{Value: item.Value, PrimaryKey: "id", Fields: []actions.AtomicField{{Name: "nick", Value: actions.AtomicString("atomic-item")}}}, nil
+	}
+}
+
+func TestAtomicAdd_CommitsTypedRecordAndInterpolatesRoute(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	id := pg.IntegerColumn("id")
+	title := pg.StringColumn("title")
+	itemID := pg.IntegerColumn("item_id")
+	items := pg.NewTable("public", "atomic_items", "", id, title)
+	related := pg.NewTable("public", "atomic_related", "", id, itemID)
+	engine := setupAtomicAddRouter(t, sqlDB, atomicCreateOperation(items, related, id, title, itemID))
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO public."atomic_items" ("title") VALUES ($1) RETURNING "id"`)).WithArgs("hello").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(41))
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO public."atomic_related" ("item_id") VALUES ($1) RETURNING "id"`)).WithArgs(int64(41)).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(77))
+	mock.ExpectCommit()
+
+	w := executeJSONRequest(engine, http.MethodPut, "/admin/atomic-items", map[string]interface{}{"title": "hello"})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.JSONEq(t, `{"value":41,"primary_key":"id","fields":[{"name":"nick","value":{"string":"atomic-item"}}]}`, w.Body.String())
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	route, err := (actions.AtomicRecord{Fields: []actions.AtomicField{{Name: "nick", Value: actions.AtomicString("atomic-item")}}}).InterpolateRoute("/profiles/{nick}")
+	require.NoError(t, err)
+	require.Equal(t, "/profiles/atomic-item", route)
+}
+
+func TestAtomicAdd_RollsBackOnPrimaryDuplicateAndRelatedFailure(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		setup func(sqlmock.Sqlmock)
+	}{
+		{
+			name: "duplicate primary",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("INSERT INTO public").WithArgs("duplicate").WillReturnError(errors.New("duplicate key"))
+				mock.ExpectRollback()
+			},
+		},
+		{
+			name: "related insert failure",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("INSERT INTO public").WithArgs("related-fail").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+				mock.ExpectQuery("INSERT INTO public").WithArgs(int64(42)).WillReturnError(errors.New("related insert failed"))
+				mock.ExpectRollback()
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			sqlDB, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = sqlDB.Close() })
+			id := pg.IntegerColumn("id")
+			title := pg.StringColumn("title")
+			itemID := pg.IntegerColumn("item_id")
+			items := pg.NewTable("public", "atomic_items", "", id, title)
+			related := pg.NewTable("public", "atomic_related", "", id, itemID)
+			engine := setupAtomicAddRouter(t, sqlDB, atomicCreateOperation(items, related, id, title, itemID))
+			testCase.setup(mock)
+
+			titleValue := "duplicate"
+			if testCase.name == "related insert failure" {
+				titleValue = "related-fail"
+			}
+			w := executeJSONRequest(engine, http.MethodPut, "/admin/atomic-items", map[string]interface{}{"title": titleValue})
+			require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestAtomicAdd_RejectsHooksAtConfigurationTime(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		before     func(*gin.Context) error
+		after      func(*gin.Context)
+		roleBefore []actions.RoleHook
+		roleAfter  []actions.RoleAfterHook
+	}{
+		{name: "action before hook", before: func(*gin.Context) error { return nil }},
+		{name: "action after hook", after: func(*gin.Context) {}},
+		{name: "module before hook", roleBefore: []actions.RoleHook{{Role: actions.RoleAll, Hook: func(*gin.Context) error { return nil }}}},
+		{name: "module after hook", roleAfter: []actions.RoleAfterHook{{Role: actions.RoleAll, Hook: func(*gin.Context) {}}}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			id := pg.IntegerColumn("id")
+			title := pg.StringColumn("title")
+			table := pg.NewTable("public", "atomic_items", "", id, title)
+			badModule := &module.BaseModule{
+				Name: "atomic-items", Path: "/admin", Table: table, PrimaryKey: id,
+				RoleBeforeHook: testCase.roleBefore, RoleAfterHook: testCase.roleAfter,
+				Actions: []actions.ModuleAction{actions.AddModuleAction{Mode: actions.AddModeAtomic, BeforeAction: testCase.before, AfterAction: testCase.after, Atomic: &actions.AtomicAddConfig{Operation: func(context.Context, actions.AtomicExecutor, actions.AtomicInput) (actions.AtomicRecord, error) {
+					return actions.AtomicRecord{}, nil
+				}}}},
+			}
+			engine := gin.New()
+			group := engine.Group("")
+			generator := module.NewGenerator(func(*module.BaseModule) dbpkg.DBExecutor { return nil }, *group, []*module.BaseModule{badModule}, nil, nil)
+			require.Panics(t, generator.Run)
+		})
+	}
+}
+
+func TestStandardAdd_RemainsUnchanged(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	id := pg.IntegerColumn("id")
+	title := pg.StringColumn("title")
+	table := pg.NewTable("public", "standard_items", "", id, title)
+	standard := &module.BaseModule{
+		Name: "standard-items", Path: "/admin", Table: table, PrimaryKey: id,
+		Fields:  []fields.ModuleField{{Column: title, Title: "Title", Type: fields.ModuleFieldTypeString, FormType: fields.ModuleFieldFormTypeText}},
+		Actions: []actions.ModuleAction{actions.AddModuleAction{Columns: []pg.Column{title}, Permission: []actions.Role{actions.RoleAll}, Auth: true}},
+	}
+	engine := gin.New()
+	group := engine.Group("")
+	generator := module.NewGenerator(func(*module.BaseModule) dbpkg.DBExecutor { return dbpkg.NewDB(sqlDB) }, *group, []*module.BaseModule{standard}, func(_ actions.ModuleAction, _ []actions.Role) gin.HandlerFunc {
+		return func(c *gin.Context) { c.Next() }
+	}, createMockAuthMiddleware(&icontext.UserInfo{ID: 1, Role: "admin"}))
+	generator.Run()
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO public."standard_items" ("title") VALUES ($1) RETURNING "id"`)).WithArgs("ordinary").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(9))
+	mock.ExpectCommit()
+	w := executeJSONRequest(engine, http.MethodPut, "/admin/standard-items", map[string]interface{}{"title": "ordinary"})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.JSONEq(t, `{"value":9,"primary_key":"id"}`, w.Body.String())
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
Closes #75

## Что меняется
- Добавлен `AddModeAtomic` с отдельной typed operation, `AtomicInput`, `AtomicRecord` и минимальным `AtomicExecutor`.
- Generator выполняет существующую нормализацию и validation, сам открывает transaction, вызывает operation и сам делает commit/rollback.
- Atomic mode запрещает `BeforeAction`, `AfterAction` и module role hooks на старте generator.
- SQL transaction скрыта в PostgreSQL adapter; module не получает `*sql.Tx`, `pgx.Tx` и не строит ручной HTTP response.
- `AtomicRecord` является add response и единственным источником значений для `AfterSuccess.Route` interpolation.

## Проверки
- Успешное создание двух связанных записей коммитит одну transaction и возвращает typed record.
- Duplicate первой вставки и ошибка второй вставки делают rollback.
- Hooks в atomic режиме отклоняются как configuration error.
- Обычный add regression остаётся прежним.
- `go test ./...`