### PR TITLE
feat: add typed atomic select

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,6 +1330,8 @@ type TranslationContext struct {
 
 Generator сам выполняет нормализацию и validation input, открывает transaction, вызывает операцию и делает commit или rollback. Atomic operation не получает `*sql.Tx` или типы драйвера: ей доступен только `actions.AtomicExecutor`. Нельзя добавлять `BeforeAction`, `AfterAction`, `RoleBeforeHook` или `RoleAfterHook` в модуль с atomic add: generator завершит запуск configuration error.
 
+Если перед вставками нужен контекст из БД, operation вызывает `executor.SelectOne`. Запрос описывается таблицей, типизированными select-полями и Jet `Where`; он выполняется в той же transaction. Нельзя читать этот контекст через отдельный `*sql.DB` до atomic operation.
+
 ```go
 actions.AddModuleAction{
     Mode: actions.AddModeAtomic,

--- a/actions/atomic_add.go
+++ b/actions/atomic_add.go
@@ -142,6 +142,33 @@ type AtomicInsertField struct {
 	Value  AtomicValue `json:"value"`
 }
 
+// AtomicValueKind declares the SQL result shape requested by AtomicSelect.
+// Keeping it explicit avoids leaking driver scan values into domain operations.
+type AtomicValueKind string
+
+const (
+	AtomicValueKindString  AtomicValueKind = "string"
+	AtomicValueKindInt     AtomicValueKind = "int"
+	AtomicValueKindFloat   AtomicValueKind = "float"
+	AtomicValueKindBool    AtomicValueKind = "bool"
+	AtomicValueKindStrings AtomicValueKind = "strings"
+	AtomicValueKindInts    AtomicValueKind = "ints"
+)
+
+type AtomicSelectField struct {
+	Name   string          `json:"name"`
+	Column pg.Column       `json:"-"`
+	Kind   AtomicValueKind `json:"kind"`
+}
+
+// AtomicSelect describes a typed read executed inside the same transaction as
+// the following atomic writes.
+type AtomicSelect struct {
+	Table  pg.Table            `json:"-"`
+	Fields []AtomicSelectField `json:"-"`
+	Where  pg.BoolExpression   `json:"-"`
+}
+
 // AtomicRecord is both the atomic add response and the source for route
 // interpolation. Fields are serialized at the top level of the response, so a
 // renderer can resolve routes such as /profiles/{nick} from the HTTP result.
@@ -210,6 +237,7 @@ func (record AtomicRecord) String(name string) (string, bool) {
 // creation logic, not a driver transaction or connection.
 type AtomicExecutor interface {
 	Insert(context.Context, AtomicInsert) (AtomicRecord, error)
+	SelectOne(context.Context, AtomicSelect) (AtomicRecord, error)
 }
 
 type AtomicAddOperation func(context.Context, AtomicExecutor, AtomicInput) (AtomicRecord, error)

--- a/db/atomic_executor.go
+++ b/db/atomic_executor.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/darkrain/request-generator/actions"
+	pg "github.com/go-jet/jet/v2/postgres"
 	"github.com/lib/pq"
 )
 
@@ -54,6 +55,90 @@ func (executor atomicExecutor) Insert(ctx context.Context, insert actions.Atomic
 		return actions.AtomicRecord{}, err
 	}
 	return actions.AtomicRecord{Value: value, PrimaryKey: insert.PrimaryKey.Name()}, nil
+}
+
+func (executor atomicExecutor) SelectOne(ctx context.Context, selectRequest actions.AtomicSelect) (actions.AtomicRecord, error) {
+	if selectRequest.Table == nil || len(selectRequest.Fields) == 0 {
+		return actions.AtomicRecord{}, fmt.Errorf("atomic select requires table and fields")
+	}
+	projections := make([]pg.Projection, 0, len(selectRequest.Fields))
+	scans := make([]interface{}, 0, len(selectRequest.Fields))
+	values := make([]func() (actions.AtomicValue, error), 0, len(selectRequest.Fields))
+	for _, field := range selectRequest.Fields {
+		if field.Name == "" || field.Column == nil {
+			return actions.AtomicRecord{}, fmt.Errorf("atomic select field requires name and column")
+		}
+		scan, value, err := atomicSelectScan(field.Kind)
+		if err != nil {
+			return actions.AtomicRecord{}, fmt.Errorf("atomic select field %q: %w", field.Name, err)
+		}
+		projections = append(projections, field.Column)
+		scans = append(scans, scan)
+		values = append(values, value)
+	}
+	query := pg.SELECT(projections[0], projections[1:]...).FROM(selectRequest.Table)
+	if selectRequest.Where != nil {
+		query = query.WHERE(selectRequest.Where)
+	}
+	query = query.LIMIT(1)
+	statement, args := query.Sql()
+	if err := executor.tx.QueryRowContext(ctx, statement, args...).Scan(scans...); err != nil {
+		return actions.AtomicRecord{}, err
+	}
+	record := actions.AtomicRecord{Fields: make([]actions.AtomicField, 0, len(selectRequest.Fields))}
+	for index, field := range selectRequest.Fields {
+		value, err := values[index]()
+		if err != nil {
+			return actions.AtomicRecord{}, fmt.Errorf("atomic select field %q: %w", field.Name, err)
+		}
+		record.Fields = append(record.Fields, actions.AtomicField{Name: field.Name, Value: value})
+	}
+	return record, nil
+}
+
+func atomicSelectScan(kind actions.AtomicValueKind) (interface{}, func() (actions.AtomicValue, error), error) {
+	switch kind {
+	case actions.AtomicValueKindString:
+		value := &sql.NullString{}
+		return value, func() (actions.AtomicValue, error) {
+			if !value.Valid {
+				return actions.AtomicValue{}, fmt.Errorf("value is null")
+			}
+			return actions.AtomicString(value.String), nil
+		}, nil
+	case actions.AtomicValueKindInt:
+		value := &sql.NullInt64{}
+		return value, func() (actions.AtomicValue, error) {
+			if !value.Valid {
+				return actions.AtomicValue{}, fmt.Errorf("value is null")
+			}
+			return actions.AtomicInt(value.Int64), nil
+		}, nil
+	case actions.AtomicValueKindFloat:
+		value := &sql.NullFloat64{}
+		return value, func() (actions.AtomicValue, error) {
+			if !value.Valid {
+				return actions.AtomicValue{}, fmt.Errorf("value is null")
+			}
+			return actions.AtomicFloat(value.Float64), nil
+		}, nil
+	case actions.AtomicValueKindBool:
+		value := &sql.NullBool{}
+		return value, func() (actions.AtomicValue, error) {
+			if !value.Valid {
+				return actions.AtomicValue{}, fmt.Errorf("value is null")
+			}
+			return actions.AtomicBool(value.Bool), nil
+		}, nil
+	case actions.AtomicValueKindInts:
+		value := &pq.Int64Array{}
+		return value, func() (actions.AtomicValue, error) { return actions.AtomicValue{Ints: []int64(*value)}, nil }, nil
+	case actions.AtomicValueKindStrings:
+		value := &pq.StringArray{}
+		return value, func() (actions.AtomicValue, error) { return actions.AtomicValue{Strings: []string(*value)}, nil }, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported kind %q", kind)
+	}
 }
 
 func atomicDBValue(value actions.AtomicValue) interface{} {

--- a/db/atomic_executor.go
+++ b/db/atomic_executor.go
@@ -58,8 +58,8 @@ func (executor atomicExecutor) Insert(ctx context.Context, insert actions.Atomic
 }
 
 func (executor atomicExecutor) SelectOne(ctx context.Context, selectRequest actions.AtomicSelect) (actions.AtomicRecord, error) {
-	if selectRequest.Table == nil || len(selectRequest.Fields) == 0 {
-		return actions.AtomicRecord{}, fmt.Errorf("atomic select requires table and fields")
+	if selectRequest.Table == nil || len(selectRequest.Fields) == 0 || selectRequest.Where == nil {
+		return actions.AtomicRecord{}, fmt.Errorf("atomic select requires table, fields, and where")
 	}
 	projections := make([]pg.Projection, 0, len(selectRequest.Fields))
 	scans := make([]interface{}, 0, len(selectRequest.Fields))
@@ -76,11 +76,7 @@ func (executor atomicExecutor) SelectOne(ctx context.Context, selectRequest acti
 		scans = append(scans, scan)
 		values = append(values, value)
 	}
-	query := pg.SELECT(projections[0], projections[1:]...).FROM(selectRequest.Table)
-	if selectRequest.Where != nil {
-		query = query.WHERE(selectRequest.Where)
-	}
-	query = query.LIMIT(1)
+	query := pg.SELECT(projections[0], projections[1:]...).FROM(selectRequest.Table).WHERE(selectRequest.Where).LIMIT(1)
 	statement, args := query.Sql()
 	if err := executor.tx.QueryRowContext(ctx, statement, args...).Scan(scans...); err != nil {
 		return actions.AtomicRecord{}, err

--- a/db/atomic_executor_test.go
+++ b/db/atomic_executor_test.go
@@ -43,3 +43,24 @@ func TestAtomicExecutorSelectOneReturnsTypedValues(t *testing.T) {
 	require.NoError(t, tx.Rollback())
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestAtomicExecutorSelectOneRequiresWhere(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	id := pg.IntegerColumn("id")
+	table := pg.NewTable("public", "profiles", "", id)
+
+	mock.ExpectBegin()
+	tx, err := sqlDB.Begin()
+	require.NoError(t, err)
+	mock.ExpectRollback()
+
+	_, err = NewAtomicExecutor(tx).SelectOne(context.Background(), actions.AtomicSelect{
+		Table:  table,
+		Fields: []actions.AtomicSelectField{{Name: "id", Column: id, Kind: actions.AtomicValueKindInt}},
+	})
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/db/atomic_executor_test.go
+++ b/db/atomic_executor_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/darkrain/request-generator/actions"
+	pg "github.com/go-jet/jet/v2/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicExecutorSelectOneReturnsTypedValues(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	id := pg.IntegerColumn("id")
+	userID := pg.IntegerColumn("user_id")
+	locationIDs := pg.StringColumn("location_ids")
+	profiles := pg.NewTable("public", "profiles", "", id, userID, locationIDs)
+
+	mock.ExpectBegin()
+	tx, err := sqlDB.Begin()
+	require.NoError(t, err)
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "location_ids"}).AddRow(17, "{101,102}"))
+	mock.ExpectRollback()
+
+	record, err := NewAtomicExecutor(tx).SelectOne(context.Background(), actions.AtomicSelect{
+		Table: profiles,
+		Fields: []actions.AtomicSelectField{
+			{Name: "agency_id", Column: id, Kind: actions.AtomicValueKindInt},
+			{Name: "location_ids", Column: locationIDs, Kind: actions.AtomicValueKindInts},
+		},
+		Where: userID.EQ(pg.Int(7)),
+	})
+	require.NoError(t, err)
+	agency, ok := record.Field("agency_id")
+	require.True(t, ok)
+	require.Equal(t, int64(17), *agency.Int)
+	locations, ok := record.Field("location_ids")
+	require.True(t, ok)
+	require.Equal(t, []int64{101, 102}, locations.Ints)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/tests/integration/atomic_add_test.go
+++ b/tests/integration/atomic_add_test.go
@@ -260,6 +260,72 @@ func TestAtomicAdd_RollsBackInvalidResultBeforeCommit(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestAtomicAdd_SelectOneAndInsertsShareTransaction(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		selectErr error
+		status    int
+	}{
+		{name: "success", status: http.StatusOK},
+		{name: "select failure", selectErr: errors.New("agency context not found"), status: http.StatusBadRequest},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			sqlDB, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = sqlDB.Close() })
+			id := pg.IntegerColumn("id")
+			title := pg.StringColumn("title")
+			ownerID := pg.IntegerColumn("owner_id")
+			items := pg.NewTable("public", "atomic_items", "", id, title)
+			related := pg.NewTable("public", "atomic_related", "", id, ownerID)
+			owners := pg.NewTable("public", "atomic_owners", "", id, ownerID)
+			operation := func(ctx context.Context, executor actions.AtomicExecutor, input actions.AtomicInput) (actions.AtomicRecord, error) {
+				owner, err := executor.SelectOne(ctx, actions.AtomicSelect{
+					Table:  owners,
+					Fields: []actions.AtomicSelectField{{Name: "owner_id", Column: ownerID, Kind: actions.AtomicValueKindInt}},
+					Where:  ownerID.EQ(pg.Int(1)),
+				})
+				if err != nil {
+					return actions.AtomicRecord{}, err
+				}
+				ownerValue, ok := owner.Field("owner_id")
+				if !ok || ownerValue.Int == nil {
+					return actions.AtomicRecord{}, errors.New("owner id missing")
+				}
+				titleValue, err := input.RequireString("title")
+				if err != nil {
+					return actions.AtomicRecord{}, err
+				}
+				item, err := executor.Insert(ctx, actions.AtomicInsert{Table: items, PrimaryKey: id, Fields: []actions.AtomicInsertField{{Column: title, Value: actions.AtomicString(titleValue)}}})
+				if err != nil {
+					return actions.AtomicRecord{}, err
+				}
+				_, err = executor.Insert(ctx, actions.AtomicInsert{Table: related, PrimaryKey: id, Fields: []actions.AtomicInsertField{{Column: ownerID, Value: actions.AtomicInt(*ownerValue.Int)}}})
+				if err != nil {
+					return actions.AtomicRecord{}, err
+				}
+				return actions.AtomicRecord{Value: item.Value, PrimaryKey: "id"}, nil
+			}
+			engine := setupAtomicAddRouter(t, sqlDB, operation)
+			mock.ExpectBegin()
+			selectExpectation := mock.ExpectQuery("SELECT")
+			if testCase.selectErr != nil {
+				selectExpectation.WillReturnError(testCase.selectErr)
+				mock.ExpectRollback()
+			} else {
+				selectExpectation.WillReturnRows(sqlmock.NewRows([]string{"owner_id"}).AddRow(9))
+				mock.ExpectQuery("INSERT INTO public").WithArgs("hello").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(41))
+				mock.ExpectQuery("INSERT INTO public").WithArgs(int64(9)).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(77))
+				mock.ExpectCommit()
+			}
+
+			w := executeJSONRequest(engine, http.MethodPut, "/admin/atomic-items", map[string]interface{}{"title": "hello"})
+			require.Equal(t, testCase.status, w.Code, w.Body.String())
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 func TestAtomicAdd_RejectsHooksAtConfigurationTime(t *testing.T) {
 	for _, testCase := range []struct {
 		name       string


### PR DESCRIPTION
Adds a minimal typed read primitive for atomic domain operations.

- `AtomicExecutor.SelectOne` executes a typed Jet select inside the generator-owned transaction.
- Results are returned as `AtomicRecord` / `AtomicValue`, without exposing `*sql.Tx` or driver scan values.
- Covers integer and array result values with SQL mock test.
- Documents that atomic context must not be read through a separate raw DB connection.

`go test ./...` passes.