### PR TITLE
feat(renderer): typed display tiles and collection groups

### DIFF
--- a/docs/universal-renderer-contract.md
+++ b/docs/universal-renderer-contract.md
@@ -1211,7 +1211,26 @@ Generator behavior:
             "id": "facts",
             "type": "data_list",
             "fields": ["created_at", "updated_at"],
-            "display_type": "key_value_grid"
+            "display_type": "key_value_grid",
+            "items": [
+              {"field": "created_at", "label": "Created", "label_fallback": "Created"},
+              {"field": "updated_at", "label": "Updated", "label_fallback": "Updated"}
+            ]
+          },
+          {
+            "id": "offers",
+            "type": "accordion_groups",
+            "collection_groups": {
+              "source_field": "offers",
+              "groups": [
+                {
+                  "id": "available",
+                  "label": "Available",
+                  "label_fallback": "Available",
+                  "item_condition": {"path": "status", "equals": "available"}
+                }
+              ]
+            }
           }
         ]
       }
@@ -1230,6 +1249,10 @@ Generator behavior:
 ```
 
 `record_page.sections[].components` и `record_page.sections[].stack` являются canonical metadata для display renderer.
+
+Для `data_list` поле `items` задает типизированные ссылки на поля и их короткие локализованные подписи. Если `items` отсутствует, renderer использует `fields`, сохраняя совместимость с существующим описанием. `display_type` принимает `key_value_grid` или `tile_grid`; `tile_grid` предназначен для универсальных пар key/value.
+
+`accordion_groups` использует `collection_groups`: `source_field` указывает поле-коллекцию записи, а каждая группа задает уникальный `id`, локализуемую подпись и `item_condition`. Условие вычисляется относительно каждого элемента этой коллекции, а не относительно корневой записи.
 
 ## Renderer Registry
 

--- a/renderer/clone.go
+++ b/renderer/clone.go
@@ -491,6 +491,8 @@ func cloneDisplayComponents(values []DisplayComponent) []DisplayComponent {
 	for i, v := range values {
 		out[i] = v
 		out[i].Fields = cloneSlice(v.Fields)
+		out[i].Items = cloneSlice(v.Items)
+		out[i].CollectionGroups = cloneDisplayCollectionGroups(v.CollectionGroups)
 		out[i].Block = cloneBlock(v.Block)
 		if v.Visible != nil {
 			visible := *v.Visible
@@ -512,6 +514,19 @@ func cloneDisplayComponents(values []DisplayComponent) []DisplayComponent {
 		}
 	}
 	return out
+}
+
+func cloneDisplayCollectionGroups(value *DisplayCollectionGroups) *DisplayCollectionGroups {
+	if value == nil {
+		return nil
+	}
+	cp := *value
+	cp.Groups = make([]DisplayCollectionGroup, len(value.Groups))
+	for index, group := range value.Groups {
+		cp.Groups[index] = group
+		cp.Groups[index].ItemCondition = cloneCondition(group.ItemCondition)
+	}
+	return &cp
 }
 
 func cloneActions(values []Action) []Action {

--- a/renderer/display_component_test.go
+++ b/renderer/display_component_test.go
@@ -119,6 +119,10 @@ func TestDisplayComponentValidation(t *testing.T) {
 			name:      "group condition with path but no predicate",
 			component: DisplayComponent{Type: DisplayAccordionGroups, CollectionGroups: &DisplayCollectionGroups{SourceField: "offers", Groups: []DisplayCollectionGroup{{ID: "available", ItemCondition: &Condition{Path: "status"}}}}},
 		},
+		{
+			name:      "group condition with unsupported not value",
+			component: DisplayComponent{Type: DisplayAccordionGroups, CollectionGroups: &DisplayCollectionGroups{SourceField: "offers", Groups: []DisplayCollectionGroup{{ID: "available", ItemCondition: &Condition{Not: "invalid"}}}}},
+		},
 	}
 
 	for _, test := range tests {

--- a/renderer/display_component_test.go
+++ b/renderer/display_component_test.go
@@ -115,6 +115,10 @@ func TestDisplayComponentValidation(t *testing.T) {
 			name:      "empty group condition",
 			component: DisplayComponent{Type: DisplayAccordionGroups, CollectionGroups: &DisplayCollectionGroups{SourceField: "offers", Groups: []DisplayCollectionGroup{{ID: "available", ItemCondition: &Condition{}}}}},
 		},
+		{
+			name:      "group condition with path but no predicate",
+			component: DisplayComponent{Type: DisplayAccordionGroups, CollectionGroups: &DisplayCollectionGroups{SourceField: "offers", Groups: []DisplayCollectionGroup{{ID: "available", ItemCondition: &Condition{Path: "status"}}}}},
+		},
 	}
 
 	for _, test := range tests {

--- a/renderer/display_component_test.go
+++ b/renderer/display_component_test.go
@@ -1,0 +1,167 @@
+package renderer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisplayComponentJSONAndLocalization(t *testing.T) {
+	source := displayComponentsUniversal()
+
+	encoded, err := json.Marshal(source.Record.Sections[0].Components)
+	require.NoError(t, err)
+	require.JSONEq(t, `[
+		{
+			"id":"rates",
+			"type":"data_list",
+			"display_type":"tile_grid",
+			"items":[
+				{"field":"incall","label":"display.incall","label_fallback":"Incall"},
+				{"field":"outcall","label":"display.outcall","label_fallback":"Outcall"}
+			]
+		},
+		{
+			"id":"offers",
+			"type":"accordion_groups",
+			"collection_groups":{
+				"source_field":"offers",
+				"groups":[{
+					"id":"available",
+					"label":"group.available",
+					"label_fallback":"Available",
+					"item_condition":{"path":"status","equals":"available"}
+				}]
+			}
+		}
+	]`, string(encoded))
+
+	localized := Localize(source, func(value, key string) string {
+		translations := map[string]string{
+			"display.incall":  "Incall price",
+			"group.available": "Available offers",
+		}
+		if text, ok := translations[value]; ok {
+			return text
+		}
+		return value
+	})
+
+	require.Equal(t, "Incall price", localized.Record.Sections[0].Components[0].Items[0].Label)
+	require.Equal(t, "Outcall", localized.Record.Sections[0].Components[0].Items[1].Label)
+	require.Empty(t, localized.Record.Sections[0].Components[0].Items[0].LabelFallback)
+	require.Equal(t, "Available offers", localized.Record.Sections[0].Components[1].CollectionGroups.Groups[0].Label)
+	require.Empty(t, localized.Record.Sections[0].Components[1].CollectionGroups.Groups[0].LabelFallback)
+	require.Equal(t, "display.incall", source.Record.Sections[0].Components[0].Items[0].Label)
+	require.Equal(t, "group.available", source.Record.Sections[0].Components[1].CollectionGroups.Groups[0].Label)
+}
+
+func TestDisplayComponentValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		component DisplayComponent
+		valid     bool
+	}{
+		{
+			name:      "valid typed tile grid",
+			component: DisplayComponent{Type: DisplayDataList, DisplayType: ComponentDisplayTileGrid, Items: []DisplayFieldRef{{Field: "incall"}}},
+			valid:     true,
+		},
+		{
+			name: "valid accordion groups",
+			component: DisplayComponent{Type: DisplayAccordionGroups, CollectionGroups: &DisplayCollectionGroups{
+				SourceField: "offers",
+				Groups:      []DisplayCollectionGroup{{ID: "available", ItemCondition: &Condition{Path: "status", Equals: "available"}}},
+			}},
+			valid: true,
+		},
+		{
+			name:      "unsupported display type",
+			component: DisplayComponent{Type: DisplayDataList, DisplayType: ComponentDisplayType("cards")},
+		},
+		{
+			name:      "items on another component",
+			component: DisplayComponent{Type: DisplayMediaGallery, Items: []DisplayFieldRef{{Field: "photos"}}},
+		},
+		{
+			name:      "empty item field",
+			component: DisplayComponent{Type: DisplayDataList, Items: []DisplayFieldRef{{}}},
+		},
+		{
+			name:      "duplicate item field",
+			component: DisplayComponent{Type: DisplayDataList, Items: []DisplayFieldRef{{Field: "incall"}, {Field: "incall"}}},
+		},
+		{
+			name:      "accordion misses groups",
+			component: DisplayComponent{Type: DisplayAccordionGroups},
+		},
+		{
+			name:      "empty group source",
+			component: DisplayComponent{Type: DisplayAccordionGroups, CollectionGroups: &DisplayCollectionGroups{Groups: []DisplayCollectionGroup{{ID: "available", ItemCondition: &Condition{Path: "status"}}}}},
+		},
+		{
+			name: "duplicate group identifier",
+			component: DisplayComponent{Type: DisplayAccordionGroups, CollectionGroups: &DisplayCollectionGroups{
+				SourceField: "offers",
+				Groups: []DisplayCollectionGroup{
+					{ID: "available", ItemCondition: &Condition{Path: "status"}},
+					{ID: "available", ItemCondition: &Condition{Path: "status"}},
+				},
+			}},
+		},
+		{
+			name:      "empty group condition",
+			component: DisplayComponent{Type: DisplayAccordionGroups, CollectionGroups: &DisplayCollectionGroups{SourceField: "offers", Groups: []DisplayCollectionGroup{{ID: "available", ItemCondition: &Condition{}}}}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (Universal{Record: &RecordPage{Sections: []RecordSection{{ID: "details", Components: []DisplayComponent{test.component}}}}}).Validate()
+			assert.Equal(t, test.valid, err == nil, err)
+		})
+	}
+}
+
+func TestDisplayComponentClone(t *testing.T) {
+	original := displayComponentsUniversal()
+	cloned := original.Clone()
+
+	cloned.Record.Sections[0].Components[0].Items[0].Label = "changed"
+	cloned.Record.Sections[0].Components[1].CollectionGroups.Groups[0].ItemCondition.Path = "changed"
+
+	assert.Equal(t, "display.incall", original.Record.Sections[0].Components[0].Items[0].Label)
+	assert.Equal(t, "status", original.Record.Sections[0].Components[1].CollectionGroups.Groups[0].ItemCondition.Path)
+}
+
+func displayComponentsUniversal() Universal {
+	return Universal{Record: &RecordPage{Sections: []RecordSection{{
+		ID: "details",
+		Components: []DisplayComponent{
+			{
+				ID:          "rates",
+				Type:        DisplayDataList,
+				DisplayType: ComponentDisplayTileGrid,
+				Items: []DisplayFieldRef{
+					{Field: "incall", Label: "display.incall", LabelFallback: "Incall"},
+					{Field: "outcall", Label: "display.outcall", LabelFallback: "Outcall"},
+				},
+			},
+			{
+				ID:   "offers",
+				Type: DisplayAccordionGroups,
+				CollectionGroups: &DisplayCollectionGroups{
+					SourceField: "offers",
+					Groups: []DisplayCollectionGroup{{
+						ID:            "available",
+						Label:         "group.available",
+						LabelFallback: "Available",
+						ItemCondition: &Condition{Path: "status", Equals: "available"},
+					}},
+				},
+			},
+		},
+	}}}}
+}

--- a/renderer/localize.go
+++ b/renderer/localize.go
@@ -271,8 +271,28 @@ func (localizer textLocalizer) localizeRecordPage(page *RecordPage) {
 		for j := range section.Components {
 			component := &section.Components[j]
 			localizer.localizeTextFields(&component.ValueLabel, &component.ValueFallback, &component.MatrixLabel, &component.Title, &component.TitleFallback, &component.Subtitle, &component.SubtitleFallback)
+			for index := range component.Items {
+				item := &component.Items[index]
+				item.Label = localizer.localizeWithFallback(item.Label, item.LabelFallback)
+				item.LabelFallback = ""
+			}
+			if component.CollectionGroups != nil {
+				for index := range component.CollectionGroups.Groups {
+					group := &component.CollectionGroups.Groups[index]
+					group.Label = localizer.localizeWithFallback(group.Label, group.LabelFallback)
+					group.LabelFallback = ""
+				}
+			}
 		}
 	}
+}
+
+func (localizer textLocalizer) localizeWithFallback(value string, fallback string) string {
+	localized := localizer.localizeRendererText(value, "")
+	if localized == value && fallback != "" {
+		return fallback
+	}
+	return localized
 }
 
 func (localizer textLocalizer) localizeResourceGridPage(page *ResourceGridPage) {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -142,6 +142,9 @@ func (r Universal) Validate() error {
 		if err := validateActions("record page", r.Record.Actions); err != nil {
 			return err
 		}
+		if err := validateRecordComponents(r.Record); err != nil {
+			return err
+		}
 	}
 	if r.ResourceGrid != nil {
 		if err := validateAction("resource grid create", r.ResourceGrid.Create); err != nil {
@@ -163,6 +166,80 @@ func (r Universal) Validate() error {
 		}
 	}
 	return nil
+}
+
+func validateRecordComponents(page *RecordPage) error {
+	for _, section := range page.Sections {
+		for _, component := range section.Components {
+			if err := component.Validate(); err != nil {
+				return fmt.Errorf("renderer.Universal: record section %q component %q: %w", section.ID, component.ID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (component DisplayComponent) Validate() error {
+	if component.DisplayType != "" {
+		if component.Type != DisplayDataList {
+			return fmt.Errorf("display type requires component type %q", DisplayDataList)
+		}
+		switch component.DisplayType {
+		case ComponentDisplayKeyValueGrid, ComponentDisplayTileGrid:
+		default:
+			return fmt.Errorf("unsupported display type %q", component.DisplayType)
+		}
+	}
+	if len(component.Items) > 0 {
+		if component.Type != DisplayDataList {
+			return fmt.Errorf("items require component type %q", DisplayDataList)
+		}
+		seen := make(map[string]struct{}, len(component.Items))
+		for _, item := range component.Items {
+			if item.Field == "" {
+				return fmt.Errorf("item field is required")
+			}
+			if _, exists := seen[item.Field]; exists {
+				return fmt.Errorf("item field %q is duplicated", item.Field)
+			}
+			seen[item.Field] = struct{}{}
+		}
+	}
+	if component.CollectionGroups != nil {
+		if component.Type != DisplayAccordionGroups {
+			return fmt.Errorf("collection groups require component type %q", DisplayAccordionGroups)
+		}
+		if component.CollectionGroups.SourceField == "" {
+			return fmt.Errorf("collection groups source field is required")
+		}
+		if len(component.CollectionGroups.Groups) == 0 {
+			return fmt.Errorf("collection groups are required")
+		}
+		seen := make(map[string]struct{}, len(component.CollectionGroups.Groups))
+		for _, group := range component.CollectionGroups.Groups {
+			if group.ID == "" {
+				return fmt.Errorf("collection group id is required")
+			}
+			if _, exists := seen[group.ID]; exists {
+				return fmt.Errorf("collection group id %q is duplicated", group.ID)
+			}
+			seen[group.ID] = struct{}{}
+			if !hasCondition(group.ItemCondition) {
+				return fmt.Errorf("collection group %q item condition is required", group.ID)
+			}
+		}
+	}
+	if component.Type == DisplayAccordionGroups && component.CollectionGroups == nil {
+		return fmt.Errorf("accordion groups require collection groups")
+	}
+	return nil
+}
+
+func hasCondition(condition *Condition) bool {
+	if condition == nil {
+		return false
+	}
+	return condition.Path != "" || len(condition.All) > 0 || len(condition.Any) > 0 || condition.Not != nil
 }
 
 func validateListPage(scope string, page *ListPage) error {
@@ -1124,6 +1201,8 @@ type DisplayComponent struct {
 	Columns             int                      `json:"columns,omitempty"`
 	ReadonlyColumns     int                      `json:"readonly_columns,omitempty"`
 	DisplayType         ComponentDisplayType     `json:"display_type,omitempty"`
+	Items               []DisplayFieldRef        `json:"items,omitempty"`
+	CollectionGroups    *DisplayCollectionGroups `json:"collection_groups,omitempty"`
 	SeparatorVariant    ToneToken                `json:"separator_variant,omitempty"`
 	SeparatorAppearance SeparatorAppearance      `json:"separator_appearance,omitempty"`
 	MatrixColumns       []map[string]interface{} `json:"matrix_columns,omitempty"`
@@ -1139,6 +1218,24 @@ type DisplayComponent struct {
 	TitleLevel          int                      `json:"title_level,omitempty"`
 	TitleTone           ToneToken                `json:"title_tone,omitempty"`
 	BodyClass           string                   `json:"body_class,omitempty"`
+}
+
+type DisplayFieldRef struct {
+	Field         string `json:"field"`
+	Label         string `json:"label,omitempty"`
+	LabelFallback string `json:"label_fallback,omitempty"`
+}
+
+type DisplayCollectionGroup struct {
+	ID            string     `json:"id"`
+	Label         string     `json:"label,omitempty"`
+	LabelFallback string     `json:"label_fallback,omitempty"`
+	ItemCondition *Condition `json:"item_condition,omitempty"`
+}
+
+type DisplayCollectionGroups struct {
+	SourceField string                   `json:"source_field"`
+	Groups      []DisplayCollectionGroup `json:"groups"`
 }
 
 type RecordPage struct {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -239,7 +239,45 @@ func hasCondition(condition *Condition) bool {
 	if condition == nil {
 		return false
 	}
-	return condition.Path != "" || len(condition.All) > 0 || len(condition.Any) > 0 || condition.Not != nil
+	hasDirectPredicate := condition.Equals != nil ||
+		condition.NotEquals != nil ||
+		len(condition.In) > 0 ||
+		len(condition.NotIn) > 0 ||
+		condition.Empty != nil ||
+		condition.NotEmpty != nil ||
+		condition.Truthy != nil ||
+		condition.Falsy != nil
+	if hasDirectPredicate && condition.Path == "" {
+		return false
+	}
+
+	hasPredicate := hasDirectPredicate
+	for index := range condition.All {
+		if !hasCondition(&condition.All[index]) {
+			return false
+		}
+		hasPredicate = true
+	}
+	for index := range condition.Any {
+		if !hasCondition(&condition.Any[index]) {
+			return false
+		}
+		hasPredicate = true
+	}
+	if condition.Not != nil {
+		switch value := condition.Not.(type) {
+		case Condition:
+			if !hasCondition(&value) {
+				return false
+			}
+		case *Condition:
+			if !hasCondition(value) {
+				return false
+			}
+		}
+		hasPredicate = true
+	}
+	return hasPredicate
 }
 
 func validateListPage(scope string, page *ListPage) error {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -274,6 +274,8 @@ func hasCondition(condition *Condition) bool {
 			if !hasCondition(value) {
 				return false
 			}
+		default:
+			return false
 		}
 		hasPredicate = true
 	}

--- a/renderer/tokens.go
+++ b/renderer/tokens.go
@@ -321,6 +321,7 @@ type ComponentDisplayType string
 
 const (
 	ComponentDisplayKeyValueGrid ComponentDisplayType = "key_value_grid"
+	ComponentDisplayTileGrid     ComponentDisplayType = "tile_grid"
 )
 
 type ComponentRatio string


### PR DESCRIPTION
## Что изменено
- добавлены типизированные `DisplayFieldRef` для `data_list` и универсальный `tile_grid`;
- добавлены `DisplayCollectionGroups`/`DisplayCollectionGroup` для `accordion_groups`;
- добавлены валидация, серверная локализация с fallback и глубокое клонирование новой metadata;
- контракт UniversalRenderer дополнен JSON-примерами и описанием поведения;
- добавлены unit-тесты сериализации, локализации, валидации и clone isolation.

`fields` остается источником отображаемых полей, когда `items` не задан.

Closes #78

## Проверка
- `go test ./...`
- `go vet ./...`